### PR TITLE
fix: remove Codex sandbox workarounds (Phase 1 cleanup)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,1 @@
 [pytest]
-addopts = -p no:cacheprovider

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,33 +1,3 @@
-"""Pytest test-only shims for the sandboxed filesystem."""
+"""Shared pytest fixtures for the Research Hub test suite."""
 
 from __future__ import annotations
-
-import shutil
-import uuid
-from pathlib import Path
-
-import pytest
-from _pytest import pathlib as pytest_pathlib
-from _pytest import tmpdir as pytest_tmpdir
-
-
-def _noop_cleanup(_root):
-    """Skip pytest symlink cleanup; the sandbox denies directory iteration there."""
-
-
-pytest_pathlib.cleanup_dead_symlinks = _noop_cleanup
-pytest_tmpdir.cleanup_dead_symlinks = _noop_cleanup
-
-
-@pytest.fixture
-def tmp_path() -> Path:
-    """Provide a repo-local temp directory instead of pytest's default temp root."""
-
-    base_dir = Path(__file__).resolve().parent.parent / "test_artifacts"
-    base_dir.mkdir(parents=True, exist_ok=True)
-    temp_dir = base_dir / f"tmp_{uuid.uuid4().hex}"
-    temp_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        yield temp_dir
-    finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary

- **Issue 5**: `tests/conftest.py` — removed `_noop_cleanup` monkey-patching of `pytest._pytest.pathlib/tmpdir` internals and the custom `tmp_path` fixture that redirected temp dirs to repo-local `test_artifacts/`. Both were Codex sandbox workarounds that don't belong in the repo. Tests now use pytest's built-in `tmp_path`.
- **Issue 8**: `pytest.ini` — removed `-p no:cacheprovider` from `addopts`. This was a sandbox-only flag (prevents `.pytest_cache/` writes, which the Codex sandbox blocked). Not needed in normal environments.

## Issues audited but already resolved

| # | Issue | Status |
|---|---|---|
| 1 | `.gitignore` | Already exists and comprehensive |
| 2 | `requirements.txt` | Already exists |
| 3 | `README.md` | Already exists |
| 4 | `run_pipeline.py` hardcoded path | Already uses `Path(__file__).parent` (local) |
| 6 | `pytest-cache-files-*` dirs | Already in `.gitignore`, not committed |
| 7 | `config.json.example` in repo root | Already exists |
| 9 | `scripts/verify_setup.py` | Already exists |

## Test plan

- [x] `pytest -q` → **19 passed** (no failures after removing sandbox shims)
- [x] `python run_pipeline.py --dry-run` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)