### PR TITLE
v0.3.0: sustainable dedup-aware ingestion + topic clusters + clean-vault workflow

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -7,6 +7,7 @@
     "logs": "~/knowledge-base/logs",
     "obsidian_graph": "~/knowledge-base/.obsidian/graph.json"
   },
+  "clusters_file": "~/knowledge-base/.research_hub/clusters.yaml",
   "zotero": {
     "library_id": "YOUR_ZOTERO_USER_ID",
     "library_type": "user",

--- a/docs/clean_vault.md
+++ b/docs/clean_vault.md
@@ -1,0 +1,181 @@
+# Clean Vault at Scale
+
+A practical playbook for keeping an Obsidian vault usable when it holds 1,000+ research papers. Written for Research Hub v0.3.0 but the ideas apply to any large research vault.
+
+---
+
+## The core principle
+
+**`raw/` is storage. `hub/` is the map. You navigate via the map, never the storage.**
+
+Obsidian's graph view and file explorer stop being useful around ~500 notes. Instead of fighting it, treat `raw/<cluster>/*.md` as an inert data layer that you query via dataview blocks inside `hub/clusters/<slug>.md` pages. You open a hub page, filter by reading status, click into one or two papers, done. You never scroll `raw/` looking for something.
+
+---
+
+## Five settings that matter
+
+### 1. Hide `raw/` and other storage dirs from the graph view
+
+Edit `.obsidian/graph.json` (or use the graph view settings panel). Add hidden filters:
+
+```
+-path:raw/ -path:hub/clusters/archive/
+```
+
+The graph view then only renders `hub/` hub pages and concept/theory pages. Instead of a supernova of 1,063 dots you see 30–60 meaningful nodes — cluster hubs linked to theory pages linked to a handful of seed papers. Each node is clickable to dig deeper.
+
+### 2. Excluded files in the quick-switcher
+
+Obsidian Settings → Files & Links → Excluded files → add `raw/`.
+
+You can still `[[wikilink]]` into raw notes and search them with `Ctrl+Shift+F`, but they stop cluttering the quick-switcher (`Ctrl+O`) and the left-hand file tree gets scoped to hub pages and theories.
+
+### 3. Obsidian's `userIgnoreFilters` in `.obsidian/app.json`
+
+Research Hub v0.3.0 auto-populates this key during install with sensible defaults. Verify it includes:
+
+```json
+{
+  "userIgnoreFilters": [
+    "pytest-cache-files-",
+    "__pycache__/",
+    ".research_hub/",
+    "pdfs/"
+  ]
+}
+```
+
+This stops the indexer from descending into non-vault directories that share the vault root.
+
+### 4. Set a default folder for new notes
+
+Files & Links → Default location for new notes → `inbox/` (create this folder if it does not exist).
+
+Any note you create by hand goes to `inbox/`, not to the root of `raw/`. The pipeline still writes to `raw/<cluster>/`. A weekly triage pulls `inbox/` notes into the right cluster.
+
+### 5. Turn off "Detect all file extensions"
+
+Files & Links → Detect all file extensions → off. Then Obsidian only indexes `.md` and ignores stray `.json`, `.py`, `.log`, `.tmp` files that sometimes end up next to your notes.
+
+---
+
+## The reading status workflow
+
+Every note written by Research Hub v0.3.0 gets `status: unread` in its YAML frontmatter. The progression is:
+
+```
+unread      just ingested, not looked at
+skimming    read the abstract + first figure
+deep-read   read cover to cover, took notes
+cited       actively referenced in your current paper
+archived    confirmed not relevant — kept for history, hidden from default views
+```
+
+You advance status by hand (or via a simple Obsidian template). Hub pages filter on status so you only see what matters right now.
+
+### A ready-to-paste cluster hub page template
+
+```markdown
+---
+type: cluster-hub
+cluster: llm-behav-env-abm
+---
+
+# LLM Agents × Behavioral Science × Environmental Interaction
+
+Short description of what this cluster is for and the research question it serves.
+
+## Reading Queue (unread, top by citations)
+
+```dataview
+TABLE title, authors, year, citation-count
+FROM "raw/llm-behav-env-abm"
+WHERE status = "unread"
+SORT citation-count DESC
+LIMIT 10
+```
+
+## Deep-read (actively thinking about)
+
+```dataview
+TABLE title, authors, year
+FROM "raw/llm-behav-env-abm"
+WHERE status = "deep-read" OR status = "cited"
+SORT year DESC
+```
+
+## Everything (including archived, by year)
+
+```dataview
+TABLE status, year, citation-count
+FROM "raw/llm-behav-env-abm"
+SORT year DESC, citation-count DESC
+```
+```
+
+Open this file. See 10 unread papers. Read 2. Change their status to `skimming` or `deep-read`. Next week, 2 more. The queue shrinks visibly.
+
+---
+
+## Cluster sizing guideline
+
+A cluster should hold roughly **30–80 papers**. Above ~100 the cluster itself becomes unusable and should be split. Below ~15 you probably are over-fragmenting — merge into a parent cluster.
+
+If a cluster grows past 80, run:
+
+```bash
+research-hub clusters split <slug>
+```
+
+This scans the cluster's notes by tag and suggests 2–3 sub-clusters. You approve the split; the pipeline moves files and updates wikilinks.
+
+(`research-hub clusters split` is planned for v0.4 — for v0.3.0 do it by hand: create the new cluster, move files, run `research-hub index` to rebuild the dedup cache.)
+
+---
+
+## Weekly review ritual (20 minutes)
+
+1. Open `hub/index.md` — scan cluster sizes. Any over 80? Flag for split.
+2. For each active cluster, open its hub page. Look at the Reading Queue block.
+3. Pick 3–5 unread papers. Skim or deep-read. Update their `status:` field.
+4. For papers you archived this week, move them out of the graph view (they are automatically hidden since status = archived is filtered).
+5. Close Obsidian. Done.
+
+Running this ritual weekly prevents the backlog from becoming the 1,063-note mess that v0.3.0 had to clean up.
+
+---
+
+## What NOT to do
+
+- **Do not** flat-dump all papers into `raw/`. Always use a cluster sub-folder. An unclustered paper is an invisible paper.
+- **Do not** navigate via the left-hand file tree in `raw/`. Use hub pages and dataview queries.
+- **Do not** let `status` stay `unread` forever. A paper you will never read should be `archived`, not `unread`.
+- **Do not** trust the graph view as a research map until you hide `raw/`. It is a pretty picture, not a thinking tool, when all 1,000 papers are visible.
+- **Do not** manually add papers to hub pages. Let `build_hub.py` (run by `research-hub ingest` or a cron) regenerate them from frontmatter.
+
+---
+
+## Migrating an existing messy vault
+
+If you already have a large flat `raw/` with hundreds of notes, the v0.3.0 migration is:
+
+1. **Audit**: run `python scripts/audit_vault.py` (from the research-hub-audit workspace) to produce a report of YAML completeness and tag distribution.
+2. **Propose clusters**: run `research-hub clusters propose --from-raw` to get a suggested list of clusters based on tag co-occurrence. Review and edit.
+3. **Assign**: `research-hub clusters auto-assign --use-existing-yaml` moves each note into the best-matching cluster sub-folder and updates its frontmatter.
+4. **Rebuild**: `research-hub index` then `research-hub build` regenerates the dedup index and hub pages.
+5. **Verify**: open `hub/index.md` and spot-check 2–3 clusters.
+
+Steps 2 and 3 are planned for v0.3.0 follow-up. For v0.3.0 base the migration is manual: create clusters via `research-hub clusters new`, move files by hand, run `research-hub index`.
+
+---
+
+## Summary
+
+- Read notes from `hub/`, not `raw/`.
+- Every note has `status:` — use it to filter.
+- Cluster size 30–80; split when it grows.
+- Run a 20-minute weekly review.
+- Hide `raw/` from the graph view.
+- Never add notes by hand to hub pages; let the pipeline regenerate.
+
+These six rules keep a 5,000-paper vault usable. The v0.3.0 pipeline handles the mechanics; the discipline is yours.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "research-hub"
-version = "0.2.0"
+version = "0.3.0"
 description = "Zotero -> Obsidian -> NotebookLM research pipeline"
 authors = [{name = "WenyuChiou"}]
 requires-python = ">=3.10"
 dependencies = [
     "pyzotero>=1.5",
+    "pyyaml>=6",
     "requests>=2.28",
 ]
 

--- a/skills/knowledge-base/SKILL.md
+++ b/skills/knowledge-base/SKILL.md
@@ -124,6 +124,10 @@ Write `.md` to `<vault-root>/raw/{sub-category}/{slugified-title}.md` (where `<v
 
 Use template from `references/paper-template.md`. Auto-generate: Summary (2-3 sentences), Key Findings (3-5 bullets), Methodology, Relevance. Follow conventions in `references/obsidian-conventions.md`.
 
+**Language rule — strict English default.** All auto-generated sections (Summary, Key Findings, Methodology, Relevance, any Obsidian section headers) MUST be written in English, regardless of the user's trigger-phrase language. The original paper's title, abstract, and Zotero annotation excerpts stay in their source language (do not translate). This rule applies to v0.3.0+ and overrides the global Language Policy for content inside Obsidian notes. Only deviate if the user explicitly says "在筆記裡用中文" or similar.
+
+**Default reading status.** New notes get `status: unread` in YAML frontmatter. The reading workflow progresses `unread → skimming → deep-read → cited → archived`. Hub pages filter by status to keep the vault scannable at scale.
+
 ### 4c: Update Hub Page
 
 Append entry to `hub/methods/{parent}/{sub-category}.md`:

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
 
+from research_hub.clusters import ClusterRegistry
+from research_hub.config import get_config
+from research_hub.dedup import DedupIndex, build_from_obsidian, build_from_zotero
 from research_hub.pipeline import run_pipeline
+from research_hub.search import SemanticScholarClient, iter_new_results
 
 
 def _verify() -> int:
@@ -17,14 +22,88 @@ def _verify() -> int:
     return completed.returncode
 
 
+def _rebuild_index() -> int:
+    cfg = get_config()
+    index = DedupIndex()
+    for hit in build_from_obsidian(cfg.raw):
+        index.add(hit)
+    if cfg.zotero_library_id:
+        from research_hub.zotero.client import get_client
+
+        zot = get_client()
+        for hit in build_from_zotero(zot, cfg.zotero_library_id):
+            index.add(hit)
+    index.save(cfg.research_hub_dir / "dedup_index.json")
+    return 0
+
+
+def _clusters_list() -> int:
+    cfg = get_config()
+    registry = ClusterRegistry(cfg.clusters_file)
+    for cluster in registry.list():
+        print(f"{cluster.slug}\t{cluster.name}")
+    return 0
+
+
+def _clusters_show(slug: str) -> int:
+    cfg = get_config()
+    registry = ClusterRegistry(cfg.clusters_file)
+    cluster = registry.get(slug)
+    if cluster is None:
+        raise ValueError(f"Cluster not found: {slug}")
+    print(json.dumps(cluster.__dict__, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _clusters_new(query: str, name: str | None, slug: str | None) -> int:
+    cfg = get_config()
+    registry = ClusterRegistry(cfg.clusters_file)
+    cluster = registry.create(query=query, name=name, slug=slug)
+    print(cluster.slug)
+    return 0
+
+
+def _search(query: str, limit: int) -> int:
+    cfg = get_config()
+    index = DedupIndex.load(cfg.research_hub_dir / "dedup_index.json")
+    client = SemanticScholarClient()
+    results = iter_new_results(client, query, index.doi_to_hits.keys(), limit=limit)
+    for result in results:
+        print(f"{result.title}\t{result.doi}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="research-hub")
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command")
 
     run_parser = subparsers.add_parser("run", help="Run the research pipeline")
     run_parser.add_argument("--topic", default=None, help="Pipeline topic context")
     run_parser.add_argument("--max-papers", type=int, default=None, help="Maximum papers to process")
     run_parser.add_argument("--dry-run", action="store_true", help="Validate config and inputs only")
+    run_parser.add_argument("--cluster", default=None, help="Cluster slug for ingestion")
+    run_parser.add_argument("--query", default=None, help="Query text")
+
+    ingest_parser = subparsers.add_parser("ingest", help="Run ingestion")
+    ingest_parser.add_argument("--cluster", default=None, help="Cluster slug for ingestion")
+    ingest_parser.add_argument("--query", default=None, help="Query text")
+    ingest_parser.add_argument("--dry-run", action="store_true", help="Validate config and inputs only")
+
+    subparsers.add_parser("index", help="Rebuild dedup_index.json from Zotero and Obsidian")
+
+    clusters_parser = subparsers.add_parser("clusters", help="Manage topic clusters")
+    clusters_subparsers = clusters_parser.add_subparsers(dest="clusters_command", required=True)
+    clusters_subparsers.add_parser("list", help="List clusters")
+    show_parser = clusters_subparsers.add_parser("show", help="Show cluster details")
+    show_parser.add_argument("slug")
+    new_parser = clusters_subparsers.add_parser("new", help="Create a new cluster")
+    new_parser.add_argument("--query", required=True)
+    new_parser.add_argument("--name", default=None)
+    new_parser.add_argument("--slug", default=None)
+
+    search_parser = subparsers.add_parser("search", help="Search Semantic Scholar")
+    search_parser.add_argument("query")
+    search_parser.add_argument("--limit", type=int, default=20)
 
     subparsers.add_parser("verify", help="Run repository verification checks")
     return parser
@@ -34,8 +113,25 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    if args.command == "run":
-        return run_pipeline(dry_run=args.dry_run)
+    if args.command in (None, "run"):
+        return run_pipeline(
+            dry_run=getattr(args, "dry_run", False),
+            cluster_slug=getattr(args, "cluster", None),
+            query=getattr(args, "query", None),
+        )
+    if args.command == "ingest":
+        return run_pipeline(dry_run=args.dry_run, cluster_slug=args.cluster, query=args.query)
+    if args.command == "index":
+        return _rebuild_index()
+    if args.command == "clusters":
+        if args.clusters_command == "list":
+            return _clusters_list()
+        if args.clusters_command == "show":
+            return _clusters_show(args.slug)
+        if args.clusters_command == "new":
+            return _clusters_new(args.query, args.name, args.slug)
+    if args.command == "search":
+        return _search(args.query, args.limit)
     if args.command == "verify":
         return _verify()
 

--- a/src/research_hub/clusters.py
+++ b/src/research_hub/clusters.py
@@ -1,0 +1,148 @@
+"""Topic cluster registry for Research Hub."""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Cluster:
+    """Stable named container for a line of inquiry."""
+
+    slug: str
+    name: str
+    seed_keywords: list[str] = field(default_factory=list)
+    zotero_collection_key: str | None = None
+    obsidian_subfolder: str = ""
+    notebooklm_notebook: str = ""
+    created_at: str = ""
+    first_query: str = ""
+    description: str = ""
+
+
+def slugify(text: str) -> str:
+    """Turn free text into a cluster slug."""
+    normalized = unicodedata.normalize("NFKD", text or "").encode("ascii", "ignore").decode()
+    normalized = re.sub(r"[^a-z0-9]+", "-", normalized.lower()).strip("-")
+    stopwords = {
+        "a",
+        "an",
+        "the",
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "with",
+        "and",
+        "or",
+        "by",
+        "from",
+        "as",
+        "this",
+        "that",
+        "is",
+        "are",
+        "between",
+        "their",
+        "these",
+        "those",
+    }
+    parts = [part for part in normalized.split("-") if part and part not in stopwords]
+    slug = "-".join(parts[:6])
+    return slug or "unnamed-cluster"
+
+
+class ClusterRegistry:
+    """Load and save cluster definitions."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.clusters: dict[str, Cluster] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            import yaml
+
+            data = yaml.safe_load(self.path.read_text(encoding="utf-8")) or {}
+        except ImportError:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        for slug, cluster_dict in (data.get("clusters") or {}).items():
+            clean = {key: value for key, value in cluster_dict.items() if key != "slug"}
+            self.clusters[slug] = Cluster(slug=slug, **clean)
+
+    def save(self) -> None:
+        """Persist cluster definitions."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "clusters": {
+                cluster.slug: {
+                    key: value for key, value in asdict(cluster).items() if key != "slug"
+                }
+                for cluster in self.clusters.values()
+            }
+        }
+        try:
+            import yaml
+
+            self.path.write_text(
+                yaml.safe_dump(payload, allow_unicode=True, sort_keys=False),
+                encoding="utf-8",
+            )
+        except ImportError:
+            self.path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def get(self, slug: str) -> Cluster | None:
+        """Get a cluster by slug."""
+        return self.clusters.get(slug)
+
+    def list(self) -> list[Cluster]:
+        """List all clusters."""
+        return list(self.clusters.values())
+
+    def create(
+        self,
+        query: str,
+        name: str | None = None,
+        slug: str | None = None,
+        seed_keywords: list[str] | None = None,
+        **kwargs,
+    ) -> Cluster:
+        """Create a cluster from a query or return the existing one."""
+        final_slug = slug or slugify(query)
+        if final_slug in self.clusters:
+            return self.clusters[final_slug]
+        from datetime import datetime, timezone
+
+        cluster = Cluster(
+            slug=final_slug,
+            name=name or query[:80],
+            seed_keywords=seed_keywords or [part for part in slugify(query).split("-") if len(part) > 2],
+            first_query=query,
+            created_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            obsidian_subfolder=final_slug,
+            **kwargs,
+        )
+        self.clusters[final_slug] = cluster
+        self.save()
+        return cluster
+
+    def match_by_query(self, query: str, min_overlap: int = 2) -> Cluster | None:
+        """Match the best existing cluster by keyword overlap."""
+        query_words = set(slugify(query).split("-"))
+        best_overlap = 0
+        best_cluster: Cluster | None = None
+        for cluster in self.clusters.values():
+            overlap = len(query_words & set(cluster.seed_keywords))
+            if overlap > best_overlap and overlap >= min_overlap:
+                best_overlap = overlap
+                best_cluster = cluster
+        return best_cluster

--- a/src/research_hub/config.py
+++ b/src/research_hub/config.py
@@ -31,6 +31,7 @@ class HubConfig:
         config_projects: str | None = None
         config_logs: str | None = None
         config_graph: str | None = None
+        config_clusters_file: str | None = None
         config_zotero_library_id: str | None = None
         config_zotero_library_type: str | None = None
         config_zotero_default_collection: str | None = None
@@ -47,6 +48,7 @@ class HubConfig:
             config_projects = knowledge_base.get("projects")
             config_logs = knowledge_base.get("logs")
             config_graph = knowledge_base.get("obsidian_graph")
+            config_clusters_file = data.get("clusters_file")
             zotero = data.get("zotero", {})
             config_zotero_library_id = zotero.get("library_id")
             config_zotero_library_type = zotero.get("library_type")
@@ -79,6 +81,12 @@ class HubConfig:
             if graph_path
             else self.root / ".obsidian" / "graph.json"
         )
+        self.research_hub_dir = self.root / ".research_hub"
+        self.clusters_file = (
+            Path(config_clusters_file).expanduser()
+            if config_clusters_file
+            else self.research_hub_dir / "clusters.yaml"
+        )
         self.zotero_library_id = zotero_library_id
         self.zotero_library_type = config_zotero_library_type or os.environ.get(
             "ZOTERO_LIBRARY_TYPE", "user"
@@ -89,6 +97,10 @@ class HubConfig:
         ) else {}
 
         self.logs.mkdir(parents=True, exist_ok=True)
+        try:
+            self.research_hub_dir.mkdir(parents=True, exist_ok=True)
+        except PermissionError:
+            pass
 
 
 _config: HubConfig | None = None

--- a/src/research_hub/dedup.py
+++ b/src/research_hub/dedup.py
@@ -1,0 +1,186 @@
+"""Deduplication index for Research Hub.
+
+Checks DOI and normalized-title matches across BOTH Zotero and the Obsidian vault.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def normalize_doi(doi: str | None) -> str:
+    """Lowercase, strip whitespace, remove common DOI prefixes."""
+    if not doi:
+        return ""
+    normalized = doi.strip().lower()
+    for prefix in ("https://doi.org/", "http://doi.org/", "doi:"):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix):]
+    return normalized.strip()
+
+
+def normalize_title(title: str | None) -> str:
+    """Lowercase, strip accents and punctuation, collapse whitespace."""
+    if not title:
+        return ""
+    normalized = unicodedata.normalize("NFKD", title).encode("ascii", "ignore").decode()
+    normalized = re.sub(r"[^a-z0-9]+", " ", normalized.lower()).strip()
+    return re.sub(r"\s+", " ", normalized)
+
+
+@dataclass
+class DedupHit:
+    """A single deduplication hit from Zotero or Obsidian."""
+
+    source: str
+    doi: str = ""
+    title: str = ""
+    zotero_key: str | None = None
+    obsidian_path: str | None = None
+
+
+@dataclass
+class DedupIndex:
+    """Index of already-ingested papers across Zotero and Obsidian."""
+
+    doi_to_hits: dict[str, list[DedupHit]] = field(default_factory=dict)
+    title_to_hits: dict[str, list[DedupHit]] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Path) -> "DedupIndex":
+        """Load a persisted index from disk, or return an empty one."""
+        if not path.exists():
+            return cls()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        index = cls()
+        for doi, hits in data.get("doi_to_hits", {}).items():
+            index.doi_to_hits[doi] = [DedupHit(**hit) for hit in hits]
+        for title, hits in data.get("title_to_hits", {}).items():
+            index.title_to_hits[title] = [DedupHit(**hit) for hit in hits]
+        return index
+
+    def save(self, path: Path) -> None:
+        """Persist the index to disk."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "doi_to_hits": {
+                doi: [hit.__dict__ for hit in hits] for doi, hits in self.doi_to_hits.items()
+            },
+            "title_to_hits": {
+                title: [hit.__dict__ for hit in hits]
+                for title, hits in self.title_to_hits.items()
+            },
+        }
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def add(self, hit: DedupHit) -> None:
+        """Add a hit to DOI and title lookups if not already present."""
+        normalized_doi = normalize_doi(hit.doi)
+        normalized_title = normalize_title(hit.title)
+        if normalized_doi:
+            self._append_unique(self.doi_to_hits.setdefault(normalized_doi, []), hit)
+        if normalized_title and len(normalized_title) > 15:
+            self._append_unique(self.title_to_hits.setdefault(normalized_title, []), hit)
+
+    def lookup(self, doi: str = "", title: str = "") -> list[DedupHit]:
+        """Return matching hits by DOI first, then title."""
+        matches: list[DedupHit] = []
+        normalized_doi = normalize_doi(doi)
+        if normalized_doi and normalized_doi in self.doi_to_hits:
+            matches.extend(self.doi_to_hits[normalized_doi])
+        if not matches:
+            normalized_title = normalize_title(title)
+            if normalized_title and normalized_title in self.title_to_hits:
+                matches.extend(self.title_to_hits[normalized_title])
+        return matches
+
+    def check(self, paper: dict) -> tuple[bool, list[DedupHit]]:
+        """Check whether a paper dict has already been ingested."""
+        hits = self.lookup(doi=paper.get("doi", ""), title=paper.get("title", ""))
+        return bool(hits), hits
+
+    @staticmethod
+    def _append_unique(hits: list[DedupHit], new_hit: DedupHit) -> None:
+        marker = (
+            new_hit.source,
+            normalize_doi(new_hit.doi),
+            normalize_title(new_hit.title),
+            new_hit.zotero_key,
+            new_hit.obsidian_path,
+        )
+        for existing in hits:
+            existing_marker = (
+                existing.source,
+                normalize_doi(existing.doi),
+                normalize_title(existing.title),
+                existing.zotero_key,
+                existing.obsidian_path,
+            )
+            if existing_marker == marker:
+                return
+        hits.append(new_hit)
+
+
+def build_from_zotero(zot, library_id: str) -> list[DedupHit]:
+    """Scan the Zotero library and return dedup hits."""
+    del library_id
+    hits: list[DedupHit] = []
+    start = 0
+    while True:
+        batch = zot.items(start=start, limit=100, itemType="-attachment || note")
+        if not batch:
+            break
+        for item in batch:
+            data = item.get("data", {})
+            if data.get("itemType") in ("attachment", "note"):
+                continue
+            hits.append(
+                DedupHit(
+                    source="zotero",
+                    doi=data.get("DOI", ""),
+                    title=data.get("title", ""),
+                    zotero_key=item.get("key"),
+                )
+            )
+        if len(batch) < 100:
+            break
+        start += 100
+    return hits
+
+
+def build_from_obsidian(vault_raw_dir: Path) -> list[DedupHit]:
+    """Scan Obsidian raw notes and return dedup hits."""
+    hits: list[DedupHit] = []
+    if not vault_raw_dir.exists():
+        return hits
+    for md_path in vault_raw_dir.rglob("*.md"):
+        try:
+            text = md_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if not text.startswith("---"):
+            continue
+        end = text.find("\n---", 3)
+        if end < 0:
+            continue
+        frontmatter = text[3:end]
+        title_match = re.search(r'^title:\s*"([^"]+)"', frontmatter, re.MULTILINE)
+        doi_match = re.search(r'^doi:\s*"([^"]*)"', frontmatter, re.MULTILINE)
+        key_match = re.search(r'^zotero-key:\s*"?([^"\n]+)"?', frontmatter, re.MULTILINE)
+        zotero_key = key_match.group(1) if key_match else None
+        if zotero_key == "null":
+            zotero_key = None
+        hits.append(
+            DedupHit(
+                source="obsidian",
+                doi=doi_match.group(1) if doi_match else "",
+                title=title_match.group(1) if title_match else "",
+                zotero_key=zotero_key,
+                obsidian_path=str(md_path),
+            )
+        )
+    return hits

--- a/src/research_hub/manifest.py
+++ b/src/research_hub/manifest.py
@@ -1,0 +1,80 @@
+"""Append-only ingestion manifest for Research Hub."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class ManifestEntry:
+    """Single ingestion log line."""
+
+    timestamp: str
+    cluster: str
+    query: str
+    action: str
+    doi: str = ""
+    title: str = ""
+    zotero_key: str = ""
+    obsidian_path: str = ""
+    error: str = ""
+
+
+class Manifest:
+    """Append-only JSONL manifest."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def append(self, entry: ManifestEntry) -> None:
+        """Append an entry to the manifest."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(entry), ensure_ascii=False) + "\n")
+
+    def read_all(self) -> list[ManifestEntry]:
+        """Read all valid manifest entries."""
+        if not self.path.exists():
+            return []
+        entries: list[ManifestEntry] = []
+        with self.path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                payload = line.strip()
+                if not payload:
+                    continue
+                try:
+                    entries.append(ManifestEntry(**json.loads(payload)))
+                except Exception:
+                    continue
+        return entries
+
+    def get_ingested_keys(self, cluster: str) -> set[str]:
+        """Return newly ingested Zotero keys for a cluster."""
+        return {
+            entry.zotero_key
+            for entry in self.read_all()
+            if entry.cluster == cluster and entry.zotero_key and entry.action == "new"
+        }
+
+    def count_by_action(self, cluster: str | None = None) -> dict[str, int]:
+        """Return action counts, optionally scoped to a cluster."""
+        counts: dict[str, int] = {}
+        for entry in self.read_all():
+            if cluster and entry.cluster != cluster:
+                continue
+            counts[entry.action] = counts.get(entry.action, 0) + 1
+        return counts
+
+
+def new_entry(cluster: str, query: str, action: str, **kwargs) -> ManifestEntry:
+    """Create a manifest entry with the current UTC timestamp."""
+    return ManifestEntry(
+        timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        cluster=cluster,
+        query=query,
+        action=action,
+        **kwargs,
+    )

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -1,12 +1,18 @@
 import argparse
 import json
 import os
+import re
 import time
 import traceback
 from pathlib import Path
 
+from research_hub.clusters import ClusterRegistry
 from research_hub.config import get_config
+from research_hub.dedup import DedupHit, DedupIndex, build_from_obsidian, build_from_zotero
+from research_hub.manifest import Manifest, new_entry
+from research_hub.vault.link_updater import update_cluster_links
 from research_hub.zotero.client import add_note, check_duplicate, get_client
+from research_hub.zotero.fetch import make_raw_md
 
 
 def _write_error_log(logs_dir: Path, errors: list[dict]) -> Path:
@@ -30,7 +36,101 @@ def _resolve_log_path(preferred_logs_dir: Path) -> Path:
         return fallback_logs_dir / "pipeline_log.txt"
 
 
-def run_pipeline(dry_run: bool = False) -> int:
+def append_cluster_query_to_existing(note_path: Path, query: str) -> bool:
+    """Append query to cluster_queries in a note frontmatter, idempotently."""
+    if not note_path.exists():
+        return False
+    text = note_path.read_text(encoding="utf-8", errors="ignore")
+    if not text.startswith("---"):
+        return False
+    end = text.find("\n---", 3)
+    if end < 0:
+        return False
+    frontmatter = text[3:end]
+    pattern = re.compile(r"^cluster_queries:\s*\[(.*?)\]$", re.MULTILINE)
+    match = pattern.search(frontmatter)
+    if not match:
+        return False
+    current = [
+        value.strip().strip('"').strip("'")
+        for value in match.group(1).split(",")
+        if value.strip()
+    ]
+    if query in current:
+        return False
+    updated = current + [query]
+    replacement = "cluster_queries: [" + ", ".join(f'"{value}"' for value in updated) + "]"
+    updated_frontmatter = pattern.sub(replacement, frontmatter, count=1)
+    note_path.write_text(text[:3] + updated_frontmatter + text[end:], encoding="utf-8")
+    return True
+
+
+def _query_for_paper(paper: dict, query: str | None = None) -> str:
+    return query or paper.get("query") or paper.get("search_query") or paper["title"]
+
+
+def _folder_for_paper(cfg, paper: dict, cluster_slug: str | None) -> Path:
+    if cluster_slug:
+        return cfg.raw / cluster_slug
+    return cfg.root / "raw" / paper["sub_category"]
+
+
+def _load_or_build_dedup(cfg, zot=None, *, dry_run: bool) -> DedupIndex:
+    dedup_path = cfg.research_hub_dir / "dedup_index.json"
+    dedup = DedupIndex.load(dedup_path)
+    if dedup.doi_to_hits or dedup.title_to_hits:
+        return dedup
+    for hit in build_from_obsidian(cfg.raw):
+        dedup.add(hit)
+    if not dry_run and zot is not None and cfg.zotero_library_id and hasattr(zot, "items"):
+        for hit in build_from_zotero(zot, cfg.zotero_library_id):
+            dedup.add(hit)
+    return dedup
+
+
+def _render_obsidian_note(
+    pp: dict,
+    collection_name: str,
+    cluster_slug: str | None,
+    query: str | None,
+) -> str:
+    item_data = {
+        "key": pp.get("zotero_key", ""),
+        "title": pp["title"],
+        "authors": [pp["authors_str"]] if pp.get("authors_str") else [],
+        "year": pp["year"],
+        "journal": pp["journal"],
+        "doi": pp["doi"],
+        "abstract": pp["abstract"],
+        "tags": pp["tags"],
+    }
+    content = make_raw_md(
+        item_data,
+        [collection_name],
+        [],
+        topic_cluster=cluster_slug or "",
+        cluster_queries=[_query_for_paper(pp, query)] if cluster_slug else [],
+    )
+    content += (
+        "\n## Summary\n\n"
+        + pp["summary"]
+        + "\n\n## Key Findings\n\n"
+        + "".join("- " + finding + "\n" for finding in pp["key_findings"])
+        + "\n## Methodology\n\n"
+        + pp["methodology"]
+        + "\n\n## Relevance\n\n"
+        + pp["relevance"]
+        + "\n"
+    )
+    return content
+
+
+def run_pipeline(
+    dry_run: bool = False,
+    *,
+    cluster_slug: str | None = None,
+    query: str | None = None,
+) -> int:
     cfg = get_config()
     kb = str(cfg.root)
     collection_key = cfg.zotero_default_collection
@@ -48,7 +148,11 @@ def run_pipeline(dry_run: bool = False) -> int:
         if collection_key is not None
         else "<unconfigured>"
     )
-    frontmatter_collections = json.dumps([collection_name])
+    clusters = ClusterRegistry(cfg.clusters_file)
+    if cluster_slug is not None and clusters.get(cluster_slug) is None:
+        raise ValueError("Cluster not found - use 'research-hub clusters new' first")
+    manifest = Manifest(cfg.research_hub_dir / "manifest.jsonl")
+    dedup_path = cfg.research_hub_dir / "dedup_index.json"
 
     with log_path.open("w", encoding="utf-8") as log:
         def p(message: str) -> None:
@@ -68,20 +172,88 @@ def run_pipeline(dry_run: bool = False) -> int:
             papers = json.load(file_obj)
         p(f"Loaded {len(papers)} papers")
 
+        dedup = _load_or_build_dedup(cfg, dry_run=dry_run)
+
         if dry_run:
+            if cluster_slug:
+                for paper in papers:
+                    manifest.append(
+                        new_entry(
+                            cluster=cluster_slug,
+                            query=_query_for_paper(paper, query),
+                            action="new",
+                            doi=paper.get("doi", ""),
+                            title=paper.get("title", ""),
+                        )
+                    )
             p(f"DRY RUN: would process {len(papers)} papers. Config OK. Exiting.")
             return 0
 
         zot = get_client()
+        dedup = _load_or_build_dedup(cfg, zot, dry_run=False)
         p("Zotero client ready")
+
         zr = []
         obr = []
         dr = []
         errors = []
+        papers_for_notes = []
 
         for i, pp in enumerate(papers):
             p(f"\n--- Paper {i+1}: {pp['title'][:60]}...")
+            query_text = _query_for_paper(pp, query)
             try:
+                is_duplicate, dedup_hits = dedup.check({"doi": pp["doi"], "title": pp["title"]})
+                if is_duplicate:
+                    obsidian_hit = next((hit for hit in dedup_hits if hit.source == "obsidian"), None)
+                    zotero_hit = next((hit for hit in dedup_hits if hit.source == "zotero"), None)
+                    if obsidian_hit and obsidian_hit.obsidian_path:
+                        append_cluster_query_to_existing(Path(obsidian_hit.obsidian_path), query_text)
+                        manifest.append(
+                            new_entry(
+                                cluster=cluster_slug or "",
+                                query=query_text,
+                                action="dup-obsidian",
+                                doi=pp["doi"],
+                                title=pp["title"],
+                                zotero_key=obsidian_hit.zotero_key or "",
+                                obsidian_path=obsidian_hit.obsidian_path,
+                            )
+                        )
+                        p("  SKIPPED dup in Obsidian")
+                        zr.append(
+                            {
+                                "title": pp["title"],
+                                "status": "SKIPPED_DUPLICATE",
+                                "key": obsidian_hit.zotero_key or "",
+                            }
+                        )
+                        continue
+                    if zotero_hit:
+                        cluster = clusters.get(cluster_slug) if cluster_slug else None
+                        if cluster and cluster.zotero_collection_key:
+                            move = getattr(zot, "move_to_collection", None)
+                            if callable(move) and zotero_hit.zotero_key:
+                                move(zotero_hit.zotero_key, cluster.zotero_collection_key)
+                        manifest.append(
+                            new_entry(
+                                cluster=cluster_slug or "",
+                                query=query_text,
+                                action="dup-zotero",
+                                doi=pp["doi"],
+                                title=pp["title"],
+                                zotero_key=zotero_hit.zotero_key or "",
+                            )
+                        )
+                        p("  SKIPPED dup in Zotero")
+                        zr.append(
+                            {
+                                "title": pp["title"],
+                                "status": "SKIPPED_DUPLICATE",
+                                "key": zotero_hit.zotero_key or "",
+                            }
+                        )
+                        continue
                 dup = check_duplicate(zot, pp["title"], pp["doi"])
             except Exception:
                 dup = False
@@ -89,6 +261,7 @@ def run_pipeline(dry_run: bool = False) -> int:
                 p("  SKIPPED dup")
                 zr.append({"title": pp["title"], "status": "SKIPPED_DUPLICATE", "key": ""})
                 continue
+
             t = zot.item_template("journalArticle")
             t["title"] = pp["title"]
             t["creators"] = pp["authors"]
@@ -114,6 +287,7 @@ def run_pipeline(dry_run: bool = False) -> int:
                     nh += "<h2>Relevance</h2><p>" + pp["relevance"] + "</p>"
                     ok = add_note(zot, key, nh)
                     p(f"  Note: {'OK' if ok else 'FAIL'}")
+                    papers_for_notes.append(pp)
                 else:
                     p(f"  RESP: {resp}")
                     zr.append({"title": pp["title"], "status": "FAILED", "key": ""})
@@ -131,61 +305,55 @@ def run_pipeline(dry_run: bool = False) -> int:
             time.sleep(1)
 
         p("\n=== OBSIDIAN NOTES ===")
-        for pp in papers:
-            sc = pp["sub_category"]
-            folder = os.path.join(kb, "raw", sc)
-            os.makedirs(folder, exist_ok=True)
-            fp = os.path.join(folder, pp["slug"] + ".md")
-            zk = pp.get("zotero_key", "")
-            rel = [x["slug"] for x in papers if x["slug"] != pp["slug"]]
-            wl = ["[[LLM-Agents]]", "[[Agent-Based-Modeling]]"]
-            if "behavioral" in (pp["title"] + " ".join(pp["tags"])).lower():
-                wl.append("[[Bounded-Rationality]]")
-            if "policy" in pp["title"].lower():
-                wl.append("[[Climate-Adaptation]]")
-            if "urban" in pp["title"].lower():
-                wl.append("[[Disaster-Preparedness]]")
-            md = "---\n"
-            md += 'title: "' + pp["title"] + '"\n'
-            md += 'authors: "' + pp["authors_str"] + '"\n'
-            md += "year: " + pp["year"] + "\n"
-            md += 'journal: "' + pp["journal"] + '"\n'
-            md += 'doi: "' + pp["doi"] + '"\n'
-            md += 'zotero-key: "' + zk + '"\n'
-            md += "collections: " + frontmatter_collections + "\n"
-            md += "tags: " + json.dumps(pp["tags"]) + "\n"
-            md += 'category: "' + pp["category"] + '"\n'
-            md += 'method-type: "' + pp["method_type"] + '"\n'
-            md += 'sub-category: "' + sc + '"\n'
-            md += 'status: "unread"\nthesis-chapter: ""\nresearch-questions: []\n'
-            md += "citation-count: " + str(pp["citations"]) + "\n"
-            md += "related-papers: " + json.dumps(rel) + "\n"
-            md += (
-                "---\n\n# "
-                + pp["title"]
-                + "\n\n## Summary\n\n"
-                + pp["summary"]
-                + "\n\n## Key Findings\n\n"
-            )
-            for finding in pp["key_findings"]:
-                md += "- " + finding + "\n"
-            md += (
-                "\n## Methodology\n\n"
-                + pp["methodology"]
-                + "\n\n## Relevance\n\n"
-                + pp["relevance"]
-                + "\n\n## Wiki Links\n\n"
-            )
-            for wiki_link in wl:
-                md += "- " + wiki_link + "\n"
+        for pp in papers_for_notes:
+            folder = _folder_for_paper(cfg, pp, cluster_slug)
+            folder.mkdir(parents=True, exist_ok=True)
+            file_path = folder / f"{pp['slug']}.md"
+            zotero_key = pp.get("zotero_key", "")
             try:
-                with open(fp, "w", encoding="utf-8") as fh:
-                    fh.write(md)
-                p(f"  OK: {fp}")
-                obr.append({"file": fp, "status": "CREATED"})
+                file_path.write_text(
+                    _render_obsidian_note(pp, collection_name, cluster_slug, query),
+                    encoding="utf-8",
+                )
+                p(f"  OK: {file_path}")
+                obr.append({"file": str(file_path), "status": "CREATED"})
+                dedup.add(
+                    DedupHit(
+                        source="obsidian",
+                        doi=pp["doi"],
+                        title=pp["title"],
+                        zotero_key=zotero_key or None,
+                        obsidian_path=str(file_path),
+                    )
+                )
+                if cluster_slug:
+                    update_cluster_links(file_path, cfg.raw, cluster_slug)
+                manifest.append(
+                    new_entry(
+                        cluster=cluster_slug or "",
+                        query=_query_for_paper(pp, query),
+                        action="new",
+                        doi=pp["doi"],
+                        title=pp["title"],
+                        zotero_key=zotero_key,
+                        obsidian_path=str(file_path),
+                    )
+                )
             except Exception as exc:
-                p(f"  ERR: {fp} {exc}")
-                obr.append({"file": fp, "status": "ERROR"})
+                p(f"  ERR: {file_path} {exc}")
+                obr.append({"file": str(file_path), "status": "ERROR"})
+                manifest.append(
+                    new_entry(
+                        cluster=cluster_slug or "",
+                        query=_query_for_paper(pp, query),
+                        action="error",
+                        doi=pp.get("doi", ""),
+                        title=pp.get("title", ""),
+                        zotero_key=zotero_key,
+                        obsidian_path=str(file_path),
+                        error=str(exc),
+                    )
+                )
                 errors.append(
                     {
                         "paper": pp["title"],
@@ -226,16 +394,17 @@ def run_pipeline(dry_run: bool = False) -> int:
             "doi_results": dr,
             "papers": [
                 {
-                    "title": x["title"],
-                    "slug": x["slug"],
-                    "zotero_key": x.get("zotero_key", ""),
-                    "sub_category": x["sub_category"],
+                    "title": paper["title"],
+                    "slug": paper["slug"],
+                    "zotero_key": paper.get("zotero_key", ""),
+                    "sub_category": paper["sub_category"],
                 }
-                for x in papers
+                for paper in papers
             ],
         }
         with out_path.open("w", encoding="utf-8") as file_obj:
             json.dump(out, file_obj, indent=2, ensure_ascii=False)
+        dedup.save(dedup_path)
         if errors:
             errors_log = _write_error_log(cfg.logs, errors)
             p(f"Errors logged: {errors_log}")
@@ -247,9 +416,11 @@ def run_pipeline(dry_run: bool = False) -> int:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dry-run", action="store_true", help="Validate config and input, no writes")
+    parser.add_argument("--cluster", default=None, help="Cluster slug for ingestion")
+    parser.add_argument("--query", default=None, help="Query text for cluster_queries")
     args = parser.parse_args(argv)
     try:
-        return run_pipeline(dry_run=args.dry_run)
+        return run_pipeline(dry_run=args.dry_run, cluster_slug=args.cluster, query=args.query)
     except Exception:
         log_path = _resolve_log_path(get_config().logs)
         with log_path.open("a", encoding="utf-8") as log:

--- a/src/research_hub/search.py
+++ b/src/research_hub/search.py
@@ -1,0 +1,125 @@
+"""Experimental headless Semantic Scholar search client for Research Hub."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import requests
+
+
+SEMANTIC_SCHOLAR_BASE = "https://api.semanticscholar.org/graph/v1"
+DEFAULT_FIELDS = (
+    "title,abstract,year,authors,externalIds,venue,citationCount,url,openAccessPdf"
+)
+
+
+@dataclass
+class SearchResult:
+    """Normalized search result."""
+
+    title: str
+    doi: str = ""
+    abstract: str = ""
+    year: int | None = None
+    authors: list[str] = field(default_factory=list)
+    venue: str = ""
+    url: str = ""
+    citation_count: int = 0
+    pdf_url: str = ""
+    source: str = "semantic-scholar"
+
+    @classmethod
+    def from_s2_json(cls, item: dict) -> "SearchResult":
+        """Create a result from Semantic Scholar JSON."""
+        authors = [author.get("name", "") for author in item.get("authors") or [] if author.get("name")]
+        external_ids = item.get("externalIds") or {}
+        pdf = item.get("openAccessPdf") or {}
+        return cls(
+            title=item.get("title") or "",
+            doi=external_ids.get("DOI", "") or "",
+            abstract=item.get("abstract") or "",
+            year=item.get("year"),
+            authors=authors,
+            venue=item.get("venue") or "",
+            url=item.get("url") or "",
+            citation_count=item.get("citationCount", 0) or 0,
+            pdf_url=pdf.get("url", "") or "",
+        )
+
+
+class SemanticScholarClient:
+    """Thin Semantic Scholar REST client with polite throttling."""
+
+    def __init__(self, delay_seconds: float = 3.0, timeout: int = 30) -> None:
+        self.delay = delay_seconds
+        self.timeout = timeout
+        self._last_request: float | None = None
+
+    def _throttle(self) -> None:
+        current_time = time.time()
+        if self._last_request is None:
+            self._last_request = current_time
+            return
+        elapsed = current_time - self._last_request
+        if elapsed < self.delay:
+            sleep_for = self.delay - elapsed
+            time.sleep(sleep_for)
+            current_time += sleep_for
+        self._last_request = current_time
+
+    def search(
+        self,
+        query: str,
+        limit: int = 20,
+        year_from: int | None = None,
+    ) -> list[SearchResult]:
+        """Search papers by query."""
+        self._throttle()
+        params: dict[str, str | int] = {
+            "query": query,
+            "limit": min(limit, 100),
+            "fields": DEFAULT_FIELDS,
+        }
+        if year_from:
+            params["year"] = f"{year_from}-"
+        response = requests.get(
+            f"{SEMANTIC_SCHOLAR_BASE}/paper/search",
+            params=params,
+            timeout=self.timeout,
+        )
+        if response.status_code == 429:
+            time.sleep(self.delay * 2)
+            return []
+        response.raise_for_status()
+        return [SearchResult.from_s2_json(item) for item in response.json().get("data", [])]
+
+    def get_paper(self, identifier: str) -> SearchResult | None:
+        """Fetch a single paper by DOI, arXiv ID, or Semantic Scholar ID."""
+        self._throttle()
+        response = requests.get(
+            f"{SEMANTIC_SCHOLAR_BASE}/paper/{identifier}",
+            params={"fields": DEFAULT_FIELDS},
+            timeout=self.timeout,
+        )
+        if response.status_code != 200:
+            return None
+        return SearchResult.from_s2_json(response.json())
+
+
+def iter_new_results(
+    client: SemanticScholarClient,
+    query: str,
+    already_ingested: Iterable[str],
+    limit: int = 20,
+) -> list[SearchResult]:
+    """Filter search results by normalized DOI."""
+    from research_hub.dedup import normalize_doi
+
+    ingested = {normalize_doi(doi) for doi in already_ingested}
+    return [
+        result
+        for result in client.search(query, limit=limit)
+        if normalize_doi(result.doi) not in ingested
+    ]

--- a/src/research_hub/vault/builder.py
+++ b/src/research_hub/vault/builder.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+from research_hub.clusters import ClusterRegistry
 from research_hub.config import get_config as _get_config
 
 # Merge mapping: normalize duplicate/typo Zotero collection names to canonical wiki names
@@ -163,6 +164,32 @@ papers: {len(matched)}
         with open(hub_path, "w", encoding="utf-8") as fh:
             fh.write(content)
         print(f"  Hub: {topic}.md ({len(matched)} papers)")
+
+    clusters = ClusterRegistry(cfg.clusters_file)
+    if clusters.list():
+        clusters_dir = os.path.join(hub_dir, "clusters")
+        os.makedirs(clusters_dir, exist_ok=True)
+        for cluster in clusters.list():
+            matched = [paper for paper in papers if paper.get("topic_cluster") == cluster.slug]
+            content = f"""---
+type: hub-cluster
+cluster: {cluster.slug}
+papers: {len(matched)}
+---
+
+# {cluster.name}
+
+First query: {cluster.first_query}
+
+## Papers ({len(matched)})
+
+"""
+            for paper in sorted(matched, key=lambda item: item.get("year", "0"), reverse=True):
+                content += f"- [[{paper['filename']}|{paper['title_line'][:80]}]] ({paper.get('year', 'n.d.')})\n"
+            cluster_path = os.path.join(clusters_dir, f"{cluster.slug}.md")
+            with open(cluster_path, "w", encoding="utf-8") as fh:
+                fh.write(content)
+            print(f"  Cluster: {cluster.slug}.md ({len(matched)} papers)")
 
     projects = {
         "ABM-Paper": {

--- a/src/research_hub/vault/link_updater.py
+++ b/src/research_hub/vault/link_updater.py
@@ -1,0 +1,137 @@
+"""Bidirectional wikilink updater for the Obsidian vault."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+RELATED_SECTION_HEADER = "## Related Papers in This Cluster"
+SECTION_PATTERN = re.compile(
+    r"(## Related Papers in This Cluster\n)(.*?)(\n## |\n---\n|\Z)",
+    re.DOTALL,
+)
+
+
+@dataclass
+class NoteMeta:
+    """Minimal note metadata used for related-paper linking."""
+
+    path: Path
+    title: str
+    tags: list[str]
+    topic_cluster: str
+
+    @property
+    def slug(self) -> str:
+        """Obsidian page slug."""
+        return self.path.stem
+
+
+def parse_frontmatter(md_path: Path) -> NoteMeta | None:
+    """Extract title, tags, and cluster from note frontmatter."""
+    try:
+        text = md_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end < 0:
+        return None
+    frontmatter = text[3:end]
+    title_match = re.search(r'^title:\s*"([^"]+)"', frontmatter, re.MULTILINE)
+    tags_match = re.search(r"^tags:\s*\[(.*?)\]", frontmatter, re.MULTILINE | re.DOTALL)
+    cluster_match = re.search(
+        r'^topic_cluster:\s*["\']?([^"\n\']*)["\']?',
+        frontmatter,
+        re.MULTILINE,
+    )
+    tags: list[str] = []
+    if tags_match:
+        tags = [tag.strip().strip('"').strip("'") for tag in tags_match.group(1).split(",") if tag.strip()]
+    return NoteMeta(
+        path=md_path,
+        title=title_match.group(1) if title_match else md_path.stem,
+        tags=tags,
+        topic_cluster=cluster_match.group(1).strip() if cluster_match else "",
+    )
+
+
+def find_related_in_cluster(
+    new_note: NoteMeta,
+    all_notes: list[NoteMeta],
+    min_tag_overlap: int = 1,
+) -> list[NoteMeta]:
+    """Find same-cluster notes ordered by descending tag overlap."""
+    related: list[tuple[int, NoteMeta]] = []
+    new_tag_set = set(new_note.tags)
+    for other in all_notes:
+        if other.path == new_note.path:
+            continue
+        if new_note.topic_cluster:
+            if other.topic_cluster != new_note.topic_cluster:
+                continue
+        overlap = len(new_tag_set & set(other.tags))
+        if overlap >= min_tag_overlap:
+            related.append((overlap, other))
+    related.sort(key=lambda item: (-item[0], item[1].slug))
+    return [item[1] for item in related]
+
+
+def add_wikilinks_to_note(note_path: Path, related_slugs: list[str]) -> bool:
+    """Create or replace the related-papers section idempotently."""
+    if not note_path.exists():
+        return False
+    text = note_path.read_text(encoding="utf-8", errors="ignore")
+    unique_slugs = list(dict.fromkeys(slug for slug in related_slugs if slug))
+    new_section = RELATED_SECTION_HEADER + "\n" + "\n".join(
+        f"- [[{slug}]]" for slug in unique_slugs
+    ) + "\n"
+    if SECTION_PATTERN.search(text):
+        new_text = SECTION_PATTERN.sub(lambda match: new_section + match.group(3), text, count=1)
+    else:
+        new_text = text.rstrip() + "\n\n" + new_section
+    if new_text == text:
+        return False
+    note_path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def update_cluster_links(
+    new_note_path: Path,
+    vault_raw_dir: Path,
+    cluster_slug: str,
+    bidirectional: bool = True,
+) -> dict[str, int]:
+    """Wire a new note into existing notes in the same cluster."""
+    new_meta = parse_frontmatter(new_note_path)
+    if new_meta is None:
+        return {"forward": 0, "backward": 0, "scanned": 0}
+
+    all_notes: list[NoteMeta] = []
+    for md_path in vault_raw_dir.rglob("*.md"):
+        meta = parse_frontmatter(md_path)
+        if meta and meta.topic_cluster == cluster_slug:
+            all_notes.append(meta)
+
+    related = find_related_in_cluster(new_meta, all_notes)
+    forward = 1 if add_wikilinks_to_note(new_note_path, [note.slug for note in related]) else 0
+    backward = 0
+
+    if bidirectional:
+        for other in related:
+            text = other.path.read_text(encoding="utf-8", errors="ignore")
+            match = SECTION_PATTERN.search(text)
+            if match:
+                existing_slugs = re.findall(r"\[\[([^\]]+)\]\]", match.group(2))
+                if new_meta.slug in existing_slugs:
+                    continue
+                new_slugs = existing_slugs + [new_meta.slug]
+            else:
+                new_slugs = [new_meta.slug]
+            if add_wikilinks_to_note(other.path, new_slugs):
+                backward += 1
+
+    return {"forward": forward, "backward": backward, "scanned": len(all_notes)}

--- a/src/research_hub/zotero/fetch.py
+++ b/src/research_hub/zotero/fetch.py
@@ -198,6 +198,7 @@ ingestion_source: "{ingestion_source}"
 topic_cluster: "{topic_cluster}"
 cluster_queries: {cluster_queries_yaml}
 verified: false
+status: unread
 ---
 
 # {title}

--- a/src/research_hub/zotero/fetch.py
+++ b/src/research_hub/zotero/fetch.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from collections import defaultdict
+from datetime import datetime, timezone
 
 import requests
 
@@ -141,7 +142,15 @@ def tags_to_wiki_links(tags):
                 links.add(link)
     return sorted(links)
 
-def make_raw_md(item_data, collections_list, notes):
+def make_raw_md(
+    item_data,
+    collections_list,
+    notes,
+    *,
+    topic_cluster: str = "",
+    cluster_queries: list[str] | None = None,
+    ingestion_source: str = "research-hub-v0.3.0",
+):
     title = item_data['title'].replace('"', "'")
     authors = item_data['authors']
     year = item_data['year']
@@ -154,6 +163,10 @@ def make_raw_md(item_data, collections_list, notes):
     author_str = '; '.join(authors) if authors else 'Unknown'
     tags_yaml = '[' + ', '.join(f'"{t}"' for t in tags) + ']' if tags else '[]'
     collections_yaml = '[' + ', '.join(f'"{c}"' for c in collections_list) + ']'
+    cluster_queries_yaml = '[' + ', '.join(
+        f'"{query}"' for query in (cluster_queries or [])
+    ) + ']'
+    ingested_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     wiki_links = tags_to_wiki_links(tags)
 
@@ -180,6 +193,11 @@ journal: "{journal}"
 zotero-key: {key}
 collections: {collections_yaml}
 tags: {tags_yaml}
+ingested_at: "{ingested_at}"
+ingestion_source: "{ingestion_source}"
+topic_cluster: "{topic_cluster}"
+cluster_queries: {cluster_queries_yaml}
+verified: false
 ---
 
 # {title}

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("yaml")
+
+from research_hub.clusters import ClusterRegistry, slugify
+
+
+def test_slugify_basic():
+    assert slugify("LLM agents in behavioral science") == "llm-agents-behavioral-science"
+
+
+def test_slugify_strips_stopwords():
+    assert slugify("The role of agents in the model") == "role-agents-model"
+
+
+def test_slugify_caps_at_6_words():
+    result = slugify("one two three four five six seven eight")
+
+    assert result == "one-two-three-four-five-six"
+
+
+def test_cluster_registry_empty_file(tmp_path):
+    registry = ClusterRegistry(tmp_path / "clusters.yaml")
+
+    assert registry.list() == []
+
+
+def test_cluster_registry_create_and_save_roundtrip(tmp_path):
+    path = tmp_path / "clusters.yaml"
+    registry = ClusterRegistry(path)
+    created = registry.create(query="behavioral llm agents", name="Behavioral LLM")
+
+    loaded = ClusterRegistry(path)
+
+    assert loaded.get(created.slug) is not None
+    assert loaded.get(created.slug).name == "Behavioral LLM"
+
+
+def test_cluster_registry_create_returns_existing_on_collision(tmp_path):
+    registry = ClusterRegistry(tmp_path / "clusters.yaml")
+    first = registry.create(query="same query", slug="same-slug")
+    second = registry.create(query="different query", slug="same-slug")
+
+    assert first is second
+
+
+def test_cluster_registry_match_by_query_overlap(tmp_path):
+    registry = ClusterRegistry(tmp_path / "clusters.yaml")
+    cluster = registry.create(
+        query="llm agents behavioral science",
+        seed_keywords=["llm", "agents", "behavioral", "science"],
+    )
+
+    match = registry.match_by_query("agents and llm in behavioral economics")
+
+    assert match is not None
+    assert match.slug == cluster.slug
+
+
+def test_cluster_registry_match_by_query_returns_none_on_no_overlap(tmp_path):
+    registry = ClusterRegistry(tmp_path / "clusters.yaml")
+    registry.create(query="llm agents behavioral science")
+
+    assert registry.match_by_query("coastal flooding insurance premiums") is None

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from research_hub.dedup import (
+    DedupHit,
+    DedupIndex,
+    build_from_obsidian,
+    normalize_doi,
+    normalize_title,
+)
+
+
+def test_normalize_doi_strips_prefix_and_case():
+    assert normalize_doi("https://doi.org/10.1234/ABC") == "10.1234/abc"
+    assert normalize_doi("DOI:10.5/XYZ") == "10.5/xyz"
+    assert normalize_doi("  http://doi.org/10.1/Test  ") == "10.1/test"
+
+
+def test_normalize_title_strips_accents_and_punct():
+    assert normalize_title("Flóòd Risk?") == "flood risk"
+
+
+def test_normalize_title_empty_on_none_or_empty():
+    assert normalize_title(None) == ""
+    assert normalize_title("") == ""
+
+
+def test_dedup_index_add_and_lookup_by_doi():
+    index = DedupIndex()
+    hit = DedupHit(source="zotero", doi="10.1000/example", title="Example Paper")
+
+    index.add(hit)
+
+    assert index.lookup(doi="10.1000/example") == [hit]
+
+
+def test_dedup_index_lookup_falls_back_to_title_when_no_doi():
+    index = DedupIndex()
+    hit = DedupHit(source="obsidian", title="A Long Enough Title For Lookup")
+    index.add(hit)
+
+    matches = index.lookup(title="A long enough title for lookup")
+
+    assert matches == [hit]
+
+
+def test_dedup_index_save_and_load_roundtrip(tmp_path):
+    index = DedupIndex()
+    index.add(DedupHit(source="zotero", doi="10.1/x", title="Roundtrip Title"))
+    path = tmp_path / "dedup_index.json"
+
+    index.save(path)
+    loaded = DedupIndex.load(path)
+
+    assert loaded.lookup(doi="10.1/x")[0].title == "Roundtrip Title"
+
+
+def test_dedup_check_returns_hits_for_matching_doi():
+    index = DedupIndex()
+    index.add(DedupHit(source="zotero", doi="10.1/check", title="Check Title"))
+
+    is_duplicate, hits = index.check({"doi": "10.1/check", "title": "Other"})
+
+    assert is_duplicate is True
+    assert hits[0].source == "zotero"
+
+
+def test_dedup_check_returns_empty_for_new_paper():
+    index = DedupIndex()
+
+    is_duplicate, hits = index.check({"doi": "10.9/new", "title": "Brand New Paper"})
+
+    assert is_duplicate is False
+    assert hits == []
+
+
+def test_build_from_obsidian_parses_yaml_frontmatter(tmp_path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "one.md").write_text(
+        '---\n'
+        'title: "Paper One"\n'
+        'doi: "10.1/one"\n'
+        'zotero-key: "KEY1"\n'
+        '---\n',
+        encoding="utf-8",
+    )
+    (raw_dir / "two.md").write_text(
+        '---\n'
+        'title: "Paper Two"\n'
+        'doi: ""\n'
+        'zotero-key: null\n'
+        '---\n',
+        encoding="utf-8",
+    )
+
+    hits = build_from_obsidian(raw_dir)
+
+    assert len(hits) == 2
+    assert hits[0].source == "obsidian"
+    assert hits[1].zotero_key is None

--- a/tests/test_link_updater.py
+++ b/tests/test_link_updater.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from research_hub.vault.link_updater import (
+    NoteMeta,
+    add_wikilinks_to_note,
+    find_related_in_cluster,
+    parse_frontmatter,
+)
+
+
+def test_parse_frontmatter_extracts_title_tags_cluster(tmp_path):
+    note = tmp_path / "paper.md"
+    note.write_text(
+        '---\n'
+        'title: "Paper"\n'
+        'tags: ["llm", "agents"]\n'
+        'topic_cluster: "cluster-a"\n'
+        '---\n',
+        encoding="utf-8",
+    )
+
+    meta = parse_frontmatter(note)
+
+    assert meta is not None
+    assert meta.title == "Paper"
+    assert meta.tags == ["llm", "agents"]
+    assert meta.topic_cluster == "cluster-a"
+
+
+def test_parse_frontmatter_returns_none_for_no_yaml(tmp_path):
+    note = tmp_path / "paper.md"
+    note.write_text("# No YAML", encoding="utf-8")
+
+    assert parse_frontmatter(note) is None
+
+
+def test_find_related_in_cluster_filters_by_cluster():
+    new_note = NoteMeta(Path("new.md"), "New", ["llm"], "cluster-a")
+    notes = [
+        NoteMeta(Path("one.md"), "One", ["llm"], "cluster-a"),
+        NoteMeta(Path("two.md"), "Two", ["llm"], "cluster-b"),
+    ]
+
+    related = find_related_in_cluster(new_note, notes)
+
+    assert [item.slug for item in related] == ["one"]
+
+
+def test_find_related_in_cluster_ranks_by_tag_overlap():
+    new_note = NoteMeta(Path("new.md"), "New", ["llm", "agents"], "cluster-a")
+    notes = [
+        NoteMeta(Path("one.md"), "One", ["llm"], "cluster-a"),
+        NoteMeta(Path("two.md"), "Two", ["llm", "agents"], "cluster-a"),
+    ]
+
+    related = find_related_in_cluster(new_note, notes)
+
+    assert [item.slug for item in related] == ["two", "one"]
+
+
+def test_add_wikilinks_to_note_creates_section(tmp_path):
+    note = tmp_path / "paper.md"
+    note.write_text("---\ntitle: \"Paper\"\n---\n", encoding="utf-8")
+
+    changed = add_wikilinks_to_note(note, ["other-paper"])
+
+    assert changed is True
+    assert "## Related Papers in This Cluster" in note.read_text(encoding="utf-8")
+
+
+def test_add_wikilinks_to_note_idempotent_update(tmp_path):
+    note = tmp_path / "paper.md"
+    note.write_text("---\ntitle: \"Paper\"\n---\n", encoding="utf-8")
+
+    add_wikilinks_to_note(note, ["other-paper"])
+    changed = add_wikilinks_to_note(note, ["other-paper"])
+
+    assert changed is False

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from research_hub.manifest import Manifest, new_entry
+
+
+def test_manifest_append_creates_parent_dir(tmp_path):
+    manifest = Manifest(tmp_path / "nested" / "manifest.jsonl")
+
+    manifest.append(new_entry("cluster-a", "query", "new"))
+
+    assert manifest.path.exists()
+
+
+def test_manifest_read_all_returns_empty_for_missing_file(tmp_path):
+    manifest = Manifest(tmp_path / "missing.jsonl")
+
+    assert manifest.read_all() == []
+
+
+def test_manifest_append_and_read_roundtrip(tmp_path):
+    manifest = Manifest(tmp_path / "manifest.jsonl")
+    entry = new_entry("cluster-a", "query", "new", title="Paper")
+
+    manifest.append(entry)
+    loaded = manifest.read_all()
+
+    assert len(loaded) == 1
+    assert loaded[0].title == "Paper"
+
+
+def test_manifest_get_ingested_keys_filters_by_cluster_and_new(tmp_path):
+    manifest = Manifest(tmp_path / "manifest.jsonl")
+    manifest.append(new_entry("cluster-a", "q1", "new", zotero_key="A"))
+    manifest.append(new_entry("cluster-a", "q2", "dup-zotero", zotero_key="B"))
+    manifest.append(new_entry("cluster-b", "q3", "new", zotero_key="C"))
+
+    assert manifest.get_ingested_keys("cluster-a") == {"A"}
+
+
+def test_manifest_count_by_action(tmp_path):
+    manifest = Manifest(tmp_path / "manifest.jsonl")
+    manifest.append(new_entry("cluster-a", "q1", "new"))
+    manifest.append(new_entry("cluster-a", "q2", "new"))
+    manifest.append(new_entry("cluster-a", "q3", "dup-zotero"))
+
+    assert manifest.count_by_action("cluster-a") == {"new": 2, "dup-zotero": 1}
+
+
+def test_new_entry_includes_timestamp():
+    entry = new_entry("cluster-a", "query", "new")
+
+    assert entry.timestamp.endswith("Z")

--- a/tests/test_pipeline_v03.py
+++ b/tests/test_pipeline_v03.py
@@ -1,0 +1,137 @@
+"""v0.3.0 pipeline integration tests."""
+
+from __future__ import annotations
+
+import json
+
+from tests.test_pipeline import _configure, _paper
+
+
+def _create_cluster(cfg, slug: str) -> None:
+    cfg.clusters_file.write_text(
+        "clusters:\n"
+        f"  {slug}:\n"
+        f"    name: {slug}\n"
+        "    seed_keywords:\n"
+        "      - llm\n"
+        "      - agents\n"
+        f"    obsidian_subfolder: {slug}\n",
+        encoding="utf-8",
+    )
+
+
+def test_run_pipeline_no_cluster_behaves_like_v02(tmp_path, monkeypatch):
+    from research_hub import pipeline
+
+    cfg = _configure(monkeypatch, tmp_path, default_collection="ABCD1234")
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps([_paper("Paper One", "paper-one", "10.1000/one")]),
+        encoding="utf-8",
+    )
+
+    class StubClient:
+        def item_template(self, item_type: str):
+            return {"itemType": item_type}
+
+        def create_items(self, items):
+            return {"successful": {"0": {"key": "KEY1"}}}
+
+    monkeypatch.setattr(pipeline, "get_client", lambda: StubClient())
+    monkeypatch.setattr(pipeline, "check_duplicate", lambda zot, title, doi="": False)
+    monkeypatch.setattr(pipeline, "add_note", lambda zot, key, content: True)
+    monkeypatch.setattr(pipeline.time, "sleep", lambda seconds: None)
+
+    result = pipeline.run_pipeline()
+
+    note = cfg.raw / "survey" / "paper-one.md"
+    assert result == 0
+    assert note.exists()
+    assert 'topic_cluster: ""' in note.read_text(encoding="utf-8")
+
+
+def test_run_pipeline_with_cluster_writes_manifest(tmp_path, monkeypatch):
+    from research_hub import pipeline
+
+    cfg = _configure(monkeypatch, tmp_path, default_collection="ABCD1234")
+    _create_cluster(cfg, "cluster-a")
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps([_paper("Paper One", "paper-one", "10.1000/one")]),
+        encoding="utf-8",
+    )
+
+    result = pipeline.run_pipeline(dry_run=True, cluster_slug="cluster-a")
+
+    manifest_path = cfg.research_hub_dir / "manifest.jsonl"
+    assert result == 0
+    assert manifest_path.exists()
+    assert '"cluster": "cluster-a"' in manifest_path.read_text(encoding="utf-8")
+
+
+def test_run_pipeline_dedup_hit_updates_cluster_queries(tmp_path, monkeypatch):
+    from research_hub import pipeline
+
+    cfg = _configure(monkeypatch, tmp_path, default_collection="ABCD1234")
+    _create_cluster(cfg, "cluster-a")
+    existing_dir = cfg.raw / "cluster-a"
+    existing_dir.mkdir(parents=True, exist_ok=True)
+    existing_note = existing_dir / "paper-one.md"
+    existing_note.write_text(
+        '---\n'
+        'title: "Paper One"\n'
+        'doi: "10.1000/one"\n'
+        'zotero-key: "KEY1"\n'
+        'cluster_queries: ["old query"]\n'
+        'topic_cluster: "cluster-a"\n'
+        'tags: ["flood risk"]\n'
+        '---\n',
+        encoding="utf-8",
+    )
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps([_paper("Paper One", "paper-one", "10.1000/one")]),
+        encoding="utf-8",
+    )
+
+    class StubClient:
+        def item_template(self, item_type: str):
+            return {"itemType": item_type}
+
+        def create_items(self, items):
+            raise AssertionError("Duplicate paper should not be created")
+
+    monkeypatch.setattr(pipeline, "get_client", lambda: StubClient())
+    monkeypatch.setattr(pipeline, "check_duplicate", lambda zot, title, doi="": False)
+    monkeypatch.setattr(pipeline, "add_note", lambda zot, key, content: True)
+    monkeypatch.setattr(pipeline.time, "sleep", lambda seconds: None)
+
+    result = pipeline.run_pipeline(cluster_slug="cluster-a")
+
+    assert result == 0
+    assert '"Paper One"' in existing_note.read_text(encoding="utf-8")
+
+
+def test_run_pipeline_creates_cluster_subfolder_in_raw(tmp_path, monkeypatch):
+    from research_hub import pipeline
+
+    cfg = _configure(monkeypatch, tmp_path, default_collection="ABCD1234")
+    _create_cluster(cfg, "cluster-a")
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps([_paper("Paper One", "paper-one", "10.1000/one")]),
+        encoding="utf-8",
+    )
+
+    class StubClient:
+        def item_template(self, item_type: str):
+            return {"itemType": item_type}
+
+        def create_items(self, items):
+            return {"successful": {"0": {"key": "KEY1"}}}
+
+    monkeypatch.setattr(pipeline, "get_client", lambda: StubClient())
+    monkeypatch.setattr(pipeline, "check_duplicate", lambda zot, title, doi="": False)
+    monkeypatch.setattr(pipeline, "add_note", lambda zot, key, content: True)
+    monkeypatch.setattr(pipeline.time, "sleep", lambda seconds: None)
+
+    result = pipeline.run_pipeline(cluster_slug="cluster-a")
+
+    assert result == 0
+    assert (cfg.raw / "cluster-a" / "paper-one.md").exists()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from research_hub.search import SearchResult, SemanticScholarClient, iter_new_results
+
+
+def test_search_result_from_s2_json():
+    result = SearchResult.from_s2_json(
+        {
+            "title": "Paper",
+            "abstract": "Abstract",
+            "year": 2024,
+            "authors": [{"name": "Jane Doe"}],
+            "externalIds": {"DOI": "10.1/example"},
+            "venue": "Venue",
+            "citationCount": 7,
+            "url": "https://example.com",
+            "openAccessPdf": {"url": "https://example.com/paper.pdf"},
+        }
+    )
+
+    assert result.title == "Paper"
+    assert result.doi == "10.1/example"
+    assert result.authors == ["Jane Doe"]
+
+
+def test_semantic_scholar_client_throttle_delays(monkeypatch):
+    client = SemanticScholarClient(delay_seconds=3.0)
+    timeline = iter([0.0, 1.0, 4.0])
+    sleeps = []
+
+    monkeypatch.setattr("research_hub.search.time.time", lambda: next(timeline))
+    monkeypatch.setattr("research_hub.search.time.sleep", lambda seconds: sleeps.append(seconds))
+
+    client._throttle()
+    client._throttle()
+
+    assert sleeps == [2.0]
+
+
+def test_search_filters_already_ingested_by_doi():
+    class StubClient:
+        def search(self, query: str, limit: int = 20):
+            return [
+                SearchResult(title="Old", doi="10.1/old"),
+                SearchResult(title="New", doi="10.1/new"),
+            ]
+
+    results = iter_new_results(StubClient(), "query", already_ingested=["10.1/old"], limit=2)
+
+    assert [result.title for result in results] == ["New"]
+
+
+def test_get_paper_returns_none_on_404(monkeypatch):
+    class Response:
+        status_code = 404
+
+    monkeypatch.setattr("research_hub.search.requests.get", lambda *args, **kwargs: Response())
+
+    assert SemanticScholarClient().get_paper("missing") is None


### PR DESCRIPTION
## Why

v0.2.1 ships a working Zotero → Obsidian → NotebookLM pipeline, but running the same search next month creates duplicates and loses thematic structure. v0.3.0 fixes that end-to-end by adding:

1. A **dedup index** that catches already-ingested papers across both Zotero AND the Obsidian vault, not just Zotero
2. A **topic cluster** abstraction: one stable named container per line of inquiry, with its own Zotero collection, Obsidian sub-folder, NotebookLM notebook, and seed keyword list
3. An **append-only manifest** log so re-runs know what has been ingested without rescanning the whole library
4. A **bidirectional wikilink updater** that wires every new paper into its cluster's existing members by tag overlap — the knowledge graph grows with the library
5. An **experimental headless search** client (Semantic Scholar REST) for future scheduled re-ingestion without Claude Code in the loop
6. A **reading-status workflow** (`unread → skimming → deep-read → cited → archived`) and a dedicated **Clean Vault at Scale** playbook for keeping a 1000+ note vault usable

## What landed

Four commits:

1. `b7cf2b7` **chore: bump to v0.3.0 and register clusters_file config key**
2. `4b74527` **feat(core): add dedup, clusters, manifest, link_updater, search modules**
3. `2e91137` **feat(pipeline): integrate dedup, clusters, manifest, link_updater**
4. `84e2291` **feat(ux): English-default notes, reading status, clean-vault playbook**

## Scope

**New Python modules** (5 files, ~676 LOC):
- `src/research_hub/dedup.py` (186)
- `src/research_hub/clusters.py` (148)
- `src/research_hub/manifest.py` (80)
- `src/research_hub/vault/link_updater.py` (137)
- `src/research_hub/search.py` (125, experimental)

**Modified** (7 files):
- `src/research_hub/pipeline.py` (+232 / -61) — dedup gate, cluster routing, manifest logging, link_updater call
- `src/research_hub/cli.py` (+99 / -3) — new `index`, `clusters`, `ingest --cluster`, `search` sub-commands
- `src/research_hub/zotero/fetch.py` (+20 / -1) — 6 new YAML fields: `ingested_at`, `ingestion_source`, `topic_cluster`, `cluster_queries`, `verified`, `status`
- `src/research_hub/config.py` (+12) — `research_hub_dir`, `clusters_file` config key
- `src/research_hub/vault/builder.py` (+27) — emit `hub/clusters/<slug>.md` pages
- `skills/knowledge-base/SKILL.md` — strict English rule for auto-generated sections
- `pyproject.toml` — version 0.3.0, add `pyyaml>=6`

**New tests** (6 files, 37 tests):
- `tests/test_dedup.py` (9), `test_clusters.py` (8), `test_manifest.py` (6), `test_link_updater.py` (6), `test_search.py` (4), `test_pipeline_v03.py` (4)

**New docs**:
- `docs/clean_vault.md` — Clean Vault at Scale playbook (~160 lines)

Total suite: **80 tests passing** on Python 3.14 locally (CI will verify 3.10/3.11/3.12).

## New YAML frontmatter fields

Every note written by v0.3.0 gets:

```yaml
ingested_at: "2026-04-11T11:45:00Z"
ingestion_source: "research-hub-v0.3.0"
topic_cluster: "llm-behav-env-abm"
cluster_queries:
  - "LLM agents in behavioral science"
verified: false
status: unread
```

Existing v0.2.1 notes are NOT retroactively mutated. The dedup module reads whichever YAML is present.

## New files inside the vault (not the repo)

```
<vault>/.research_hub/
├── clusters.yaml     # cluster registry
├── manifest.jsonl    # append-only ingestion log
└── dedup_index.json  # precomputed dedup index
```

These live inside the Obsidian vault so the vault is self-contained. `.research_hub/` is already in user `.gitignore` patterns and in Obsidian `userIgnoreFilters`.

## Backward compatibility

- `run_pipeline()` without `cluster_slug` behaves exactly like v0.2.1. All 43 existing tests still pass untouched.
- `make_raw_md()` new parameters are keyword-only with sensible defaults — existing callers still work.
- `check_duplicate()` in `zotero/client.py` is NOT removed — still available for back-compat.
- Config lookup order unchanged. `clusters_file` is optional.

## Experimental: headless search

`src/research_hub/search.py` is a thin Semantic Scholar REST client for future scheduled re-ingestion (cron, GitHub Actions) without a Claude Code session. Marked experimental in v0.3.0. The primary ingestion path still goes through Claude Code + `paper-search-mcp` as before.

## Delegation note

Planned by Claude Opus 4.6. Python modules and tests delegated to Codex CLI (gpt-5.4) via `.claude/codex_brief_v0_3_0.md` (~900 lines); Codex returned a clean 80-test suite on first pass. Claude reviewed the diff, split into four semantic commits, added the UX commit (SKILL.md language rule + `status: unread` + clean_vault.md playbook), and opened this PR. No Gemini delegation this cycle.

## Test plan

- [ ] CI green on Python 3.10, 3.11, 3.12
- [ ] Fresh clone + `pip install -e '.[dev]'` + `pytest -q` → 80 passed
- [ ] `research-hub clusters new --query "LLM agents in behavioral science and environmental interaction" --name "LLM × Behavioral × Env × ABM"` creates a cluster entry in `.research_hub/clusters.yaml`
- [ ] `research-hub ingest --cluster llm-behav-env-abm --dry-run` writes a planned manifest entry without touching Zotero
- [ ] Manually verify `docs/clean_vault.md` renders cleanly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)