### PR TITLE
v0.3.1: support legacy notes + dedup-path link_updater

### DIFF
--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -36,8 +36,18 @@ def _resolve_log_path(preferred_logs_dir: Path) -> Path:
         return fallback_logs_dir / "pipeline_log.txt"
 
 
-def append_cluster_query_to_existing(note_path: Path, query: str) -> bool:
-    """Append query to cluster_queries in a note frontmatter, idempotently."""
+def append_cluster_query_to_existing(
+    note_path: Path,
+    query: str,
+    *,
+    topic_cluster: str = "",
+) -> bool:
+    """Append query to cluster_queries in a note frontmatter, idempotently.
+
+    If the note pre-dates v0.3.0 and lacks the ``cluster_queries`` field,
+    the missing v0.3.0 fields (``cluster_queries``, ``topic_cluster``,
+    ``verified``, ``status``) are inserted before the closing ``---``.
+    """
     if not note_path.exists():
         return False
     text = note_path.read_text(encoding="utf-8", errors="ignore")
@@ -49,18 +59,28 @@ def append_cluster_query_to_existing(note_path: Path, query: str) -> bool:
     frontmatter = text[3:end]
     pattern = re.compile(r"^cluster_queries:\s*\[(.*?)\]$", re.MULTILINE)
     match = pattern.search(frontmatter)
-    if not match:
-        return False
-    current = [
-        value.strip().strip('"').strip("'")
-        for value in match.group(1).split(",")
-        if value.strip()
-    ]
-    if query in current:
-        return False
-    updated = current + [query]
-    replacement = "cluster_queries: [" + ", ".join(f'"{value}"' for value in updated) + "]"
-    updated_frontmatter = pattern.sub(replacement, frontmatter, count=1)
+    if match:
+        current = [
+            value.strip().strip('"').strip("'")
+            for value in match.group(1).split(",")
+            if value.strip()
+        ]
+        if query in current:
+            return False
+        updated = current + [query]
+        replacement = "cluster_queries: [" + ", ".join(f'"{value}"' for value in updated) + "]"
+        updated_frontmatter = pattern.sub(replacement, frontmatter, count=1)
+    else:
+        # Legacy note (pre-v0.3.0): append the new v0.3.0 fields.
+        new_fields_lines = [""]
+        if not re.search(r"^topic_cluster:", frontmatter, re.MULTILINE):
+            new_fields_lines.append(f'topic_cluster: "{topic_cluster}"')
+        new_fields_lines.append(f'cluster_queries: ["{query}"]')
+        if not re.search(r"^verified:", frontmatter, re.MULTILINE):
+            new_fields_lines.append("verified: false")
+        if not re.search(r"^status:", frontmatter, re.MULTILINE):
+            new_fields_lines.append("status: unread")
+        updated_frontmatter = frontmatter.rstrip() + "\n".join(new_fields_lines)
     note_path.write_text(text[:3] + updated_frontmatter + text[end:], encoding="utf-8")
     return True
 
@@ -151,6 +171,10 @@ def run_pipeline(
     clusters = ClusterRegistry(cfg.clusters_file)
     if cluster_slug is not None and clusters.get(cluster_slug) is None:
         raise ValueError("Cluster not found - use 'research-hub clusters new' first")
+    if query is None and cluster_slug is not None:
+        cluster_obj = clusters.get(cluster_slug)
+        if cluster_obj is not None and cluster_obj.first_query:
+            query = cluster_obj.first_query
     manifest = Manifest(cfg.research_hub_dir / "manifest.jsonl")
     dedup_path = cfg.research_hub_dir / "dedup_index.json"
 
@@ -208,7 +232,17 @@ def run_pipeline(
                     obsidian_hit = next((hit for hit in dedup_hits if hit.source == "obsidian"), None)
                     zotero_hit = next((hit for hit in dedup_hits if hit.source == "zotero"), None)
                     if obsidian_hit and obsidian_hit.obsidian_path:
-                        append_cluster_query_to_existing(Path(obsidian_hit.obsidian_path), query_text)
+                        append_cluster_query_to_existing(
+                            Path(obsidian_hit.obsidian_path),
+                            query_text,
+                            topic_cluster=cluster_slug or "",
+                        )
+                        if cluster_slug:
+                            update_cluster_links(
+                                Path(obsidian_hit.obsidian_path),
+                                cfg.raw,
+                                cluster_slug,
+                            )
                         manifest.append(
                             new_entry(
                                 cluster=cluster_slug or "",

--- a/src/research_hub/vault/link_updater.py
+++ b/src/research_hub/vault/link_updater.py
@@ -64,18 +64,29 @@ def find_related_in_cluster(
     all_notes: list[NoteMeta],
     min_tag_overlap: int = 1,
 ) -> list[NoteMeta]:
-    """Find same-cluster notes ordered by descending tag overlap."""
+    """Find same-cluster notes ordered by descending tag overlap.
+
+    When ``new_note`` has a ``topic_cluster`` set, cluster membership
+    alone is sufficient — notes in the same cluster are included even
+    when tag overlap is zero. Tag overlap only affects ranking so the
+    most topically-similar papers appear first. When ``new_note`` has
+    no cluster, fall back to the tag-overlap threshold.
+    """
     related: list[tuple[int, NoteMeta]] = []
     new_tag_set = set(new_note.tags)
+    in_cluster = bool(new_note.topic_cluster)
     for other in all_notes:
         if other.path == new_note.path:
             continue
-        if new_note.topic_cluster:
+        if in_cluster:
             if other.topic_cluster != new_note.topic_cluster:
                 continue
-        overlap = len(new_tag_set & set(other.tags))
-        if overlap >= min_tag_overlap:
+            overlap = len(new_tag_set & set(other.tags))
             related.append((overlap, other))
+        else:
+            overlap = len(new_tag_set & set(other.tags))
+            if overlap >= min_tag_overlap:
+                related.append((overlap, other))
     related.sort(key=lambda item: (-item[0], item[1].slug))
     return [item[1] for item in related]
 


### PR DESCRIPTION
## Why

Three real-world bugs caught by running v0.3.0 live against a 1063-note production vault. All three block the "re-run the same query next month and get dedup + wikilink maintenance" story that v0.3.0 was shipped for.

## Fixes

1. **Legacy note frontmatter patching** — pre-v0.3.0 notes have no ``cluster_queries`` field. ``append_cluster_query_to_existing`` returned False silently and did nothing, so dedup-caught legacy notes stayed as v0.2.1 frontmatter forever. Fix: insert the missing v0.3.0 fields (``topic_cluster``, ``cluster_queries``, ``verified``, ``status``) before the closing ``---``.

2. **Dedup-obsidian path now calls link_updater** — previously the dup-hit branch only updated ``cluster_queries`` and skipped ``update_cluster_links``, meaning re-running the same query never wired cluster members together. Fix: call ``update_cluster_links`` after ``append_cluster_query_to_existing`` on the dedup-obsidian branch.

3. **Cluster membership sufficient for a link** — ``find_related_in_cluster`` required ``min_tag_overlap >= 1``, which returned empty for cluster members with disjoint tag sets. Fix: when the new note has ``topic_cluster`` set, cluster membership alone guarantees a baseline link; tag overlap only affects ordering.

Also: default ``query`` in ``run_pipeline`` now falls back to the cluster's ``first_query`` instead of each paper's title, so ``cluster_queries`` records the search that brought a paper in, not the paper's own title.

## Verification

Real ingestion of 8 papers from Wenyu's production Zotero (already-ingested, test cluster `llm-agents-behavioral-science-environmental-interaction`):
- 8 legacy notes patched with v0.3.0 fields
- 8 bidirectional ``[[...]]`` links created under ``## Related Papers in This Cluster``
- Second run: byte-identical SHA-256 hash — idempotent
- ``pytest -q`` → 80 passed

## Test plan

- [ ] CI green on 3.10/3.11/3.12
- [ ] Fresh clone + ``pip install -e .`` + ``pytest`` → 80 passed
- [ ] Manual smoke: run ``research-hub ingest --cluster <slug>`` on a vault that has pre-v0.3.0 notes; verify YAML fields and Related Papers section appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)