### PR TITLE
v0.3.3: cluster synthesis + dataview queues + graph colors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub"
-version = "0.3.0"
+version = "0.3.3"
 description = "Zotero -> Obsidian -> NotebookLM research pipeline"
 authors = [{name = "WenyuChiou"}]
 requires-python = ">=3.10"

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -77,6 +77,42 @@ def _cleanup_hub(dry_run: bool = False) -> int:
     return 0
 
 
+def _synthesize(cluster: str | None, graph_colors: bool) -> int:
+    from research_hub.vault.graph_config import update_from_clusters_file
+    from research_hub.vault.synthesis import synthesize_all_clusters, synthesize_cluster
+
+    cfg = get_config()
+    registry = ClusterRegistry(cfg.clusters_file)
+
+    if cluster:
+        cluster_obj = registry.get(cluster)
+        if cluster_obj is None:
+            raise ValueError(f"Cluster not found: {cluster}")
+        try:
+            out = synthesize_cluster(
+                cluster_obj.slug,
+                cluster_obj.name,
+                cluster_obj.first_query,
+                cfg.raw,
+                cfg.hub,
+            )
+            print(f"Wrote {out}")
+        except FileNotFoundError as exc:
+            print(f"Skipped: {exc}")
+    else:
+        outs = synthesize_all_clusters(cfg.raw, cfg.hub, cfg.clusters_file)
+        print(f"Wrote {len(outs)} synthesis pages")
+
+    if graph_colors:
+        report = update_from_clusters_file(cfg.root, cfg.clusters_file)
+        if report.updated:
+            print(f"Updated graph.json with {report.color_groups_written} color groups")
+        else:
+            print(f"graph.json skipped: {report.skipped_reason}")
+
+    return 0
+
+
 def _search(query: str, limit: int) -> int:
     cfg = get_config()
     index = DedupIndex.load(cfg.research_hub_dir / "dedup_index.json")
@@ -128,6 +164,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--dry-run", action="store_true", help="Report without writing"
     )
 
+    synth_parser = subparsers.add_parser(
+        "synthesize", help="Generate cluster synthesis pages"
+    )
+    synth_parser.add_argument(
+        "--cluster", default=None, help="Only synthesize this cluster slug"
+    )
+    synth_parser.add_argument(
+        "--graph-colors",
+        action="store_true",
+        help="Also update .obsidian/graph.json cluster colors",
+    )
+
     return parser
 
 
@@ -158,6 +206,8 @@ def main(argv: list[str] | None = None) -> int:
         return _verify()
     if args.command == "cleanup":
         return _cleanup_hub(dry_run=args.dry_run)
+    if args.command == "synthesize":
+        return _synthesize(cluster=args.cluster, graph_colors=args.graph_colors)
 
     parser.error(f"Unknown command: {args.command}")
     return 2

--- a/src/research_hub/vault/builder.py
+++ b/src/research_hub/vault/builder.py
@@ -186,6 +186,30 @@ First query: {cluster.first_query}
 """
             for paper in sorted(matched, key=lambda item: item.get("year", "0"), reverse=True):
                 content += f"- [[{paper['filename']}|{paper['title_line'][:80]}]] ({paper.get('year', 'n.d.')})\n"
+            content += (
+                "\n## Reading Queue\n\n"
+                "```dataview\n"
+                "TABLE year, authors, status, citation-count\n"
+                'FROM "raw"\n'
+                f'WHERE topic_cluster = "{cluster.slug}" AND status = "unread"\n'
+                "SORT year DESC\n"
+                "LIMIT 15\n"
+                "```\n"
+                "\n## Deep-read\n\n"
+                "```dataview\n"
+                "TABLE year, authors, verified\n"
+                'FROM "raw"\n'
+                f'WHERE topic_cluster = "{cluster.slug}" AND (status = "deep-read" OR status = "cited")\n'
+                "SORT year DESC\n"
+                "```\n"
+                "\n## All Papers (by year)\n\n"
+                "```dataview\n"
+                "TABLE year, status, citation-count\n"
+                'FROM "raw"\n'
+                f'WHERE topic_cluster = "{cluster.slug}"\n'
+                "SORT year DESC\n"
+                "```\n"
+            )
             cluster_path = os.path.join(clusters_dir, f"{cluster.slug}.md")
             with open(cluster_path, "w", encoding="utf-8") as fh:
                 fh.write(content)

--- a/src/research_hub/vault/graph_config.py
+++ b/src/research_hub/vault/graph_config.py
@@ -1,0 +1,102 @@
+"""Obsidian graph.json cluster color updater.
+
+Read the vault's ``.obsidian/graph.json`` and apply one color group per
+topic cluster so graph view can distinguish research lines. Existing
+graph settings are preserved.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+PALETTE = [
+    "#e6194B",
+    "#3cb44b",
+    "#ffe119",
+    "#4363d8",
+    "#f58231",
+    "#911eb4",
+    "#42d4f4",
+    "#f032e6",
+]
+
+
+@dataclass
+class GraphConfigUpdate:
+    """Report for a graph.json update attempt."""
+
+    updated: bool = False
+    color_groups_written: int = 0
+    skipped_reason: str = ""
+    cluster_slugs: list[str] = field(default_factory=list)
+
+
+def _hex_to_int_rgb(hex_color: str) -> int:
+    """Convert ``#RRGGBB`` to Obsidian's integer RGB format."""
+
+    clean = hex_color.lstrip("#")
+    red = int(clean[0:2], 16)
+    green = int(clean[2:4], 16)
+    blue = int(clean[4:6], 16)
+    return (red << 16) | (green << 8) | blue
+
+
+def _obsidian_color(hex_color: str) -> dict[str, int]:
+    """Return an Obsidian color object."""
+
+    return {"a": 1, "rgb": _hex_to_int_rgb(hex_color)}
+
+
+def build_color_groups(cluster_slugs: list[str]) -> list[dict[str, object]]:
+    """Build one deterministic color group per cluster slug."""
+
+    groups: list[dict[str, object]] = []
+    for index, slug in enumerate(cluster_slugs):
+        groups.append(
+            {
+                "query": f"path:raw/{slug}/",
+                "color": _obsidian_color(PALETTE[index % len(PALETTE)]),
+            }
+        )
+    return groups
+
+
+def update_graph_json(graph_json_path: Path, cluster_slugs: list[str]) -> GraphConfigUpdate:
+    """Update ``colorGroups`` in graph.json while preserving other settings."""
+
+    if not graph_json_path.exists():
+        return GraphConfigUpdate(skipped_reason=f"No graph.json at {graph_json_path}")
+
+    try:
+        existing = json.loads(graph_json_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        existing = {}
+
+    if not isinstance(existing, dict):
+        existing = {}
+
+    ordered_slugs = list(cluster_slugs)
+    existing["colorGroups"] = build_color_groups(ordered_slugs)
+    graph_json_path.write_text(
+        json.dumps(existing, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return GraphConfigUpdate(
+        updated=True,
+        color_groups_written=len(ordered_slugs),
+        cluster_slugs=ordered_slugs,
+    )
+
+
+def update_from_clusters_file(vault_root: Path, clusters_file: Path) -> GraphConfigUpdate:
+    """Load cluster slugs from the registry and update ``graph.json``."""
+
+    from research_hub.clusters import ClusterRegistry
+
+    registry = ClusterRegistry(clusters_file)
+    slugs = [cluster.slug for cluster in registry.list()]
+    graph_path = vault_root / ".obsidian" / "graph.json"
+    return update_graph_json(graph_path, slugs)

--- a/src/research_hub/vault/synthesis.py
+++ b/src/research_hub/vault/synthesis.py
@@ -1,0 +1,392 @@
+"""Cluster synthesis page generator.
+
+Walk all papers in a topic cluster and write a single synthesis markdown
+file summarizing the cluster: collated summaries, collated key findings,
+methodology comparison, aggregated relevance questions, and a live
+dataview reading queue.
+
+This module is read-only on ``raw/`` notes. It only writes generated
+pages under ``hub/clusters``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class ClusterPaper:
+    """A parsed paper note with the fields needed for synthesis output."""
+
+    slug: str
+    title: str
+    authors: str = ""
+    year: str = ""
+    journal: str = ""
+    doi: str = ""
+    status: str = "unread"
+    tags: list[str] = field(default_factory=list)
+    summary: str = ""
+    key_findings: list[str] = field(default_factory=list)
+    methodology: str = ""
+    relevance: str = ""
+    raw_text: str = ""
+
+
+def _extract_section(text: str, header: str) -> str:
+    """Return the body of a ``## <header>`` section until the next heading."""
+
+    pattern = re.compile(
+        rf"^##\s+{re.escape(header)}\s*\n(.*?)(?=\n##\s|\Z)",
+        re.DOTALL | re.MULTILINE,
+    )
+    match = pattern.search(text)
+    if not match:
+        return ""
+    return match.group(1).strip()
+
+
+def _extract_bullets(section_text: str) -> list[str]:
+    """Extract markdown bullet items from a section body."""
+
+    bullets: list[str] = []
+    for line in section_text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("- "):
+            bullets.append(stripped[2:].strip())
+    return bullets
+
+
+def _parse_frontmatter(frontmatter: str) -> dict[str, object]:
+    """Parse YAML frontmatter into a mapping."""
+
+    data = yaml.safe_load(frontmatter) or {}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def parse_cluster_paper(path: Path) -> ClusterPaper | None:
+    """Read a paper note and return synthesis-ready fields."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    if not text.startswith("---"):
+        return None
+
+    match = re.match(r"^---\n(.*?)\n---\n?(.*)$", text, re.DOTALL)
+    if not match:
+        return None
+
+    frontmatter = _parse_frontmatter(match.group(1))
+    body = match.group(2)
+
+    tags = frontmatter.get("tags", [])
+    if not isinstance(tags, list):
+        tags = []
+
+    return ClusterPaper(
+        slug=path.stem,
+        title=str(frontmatter.get("title") or path.stem),
+        authors=str(frontmatter.get("authors") or ""),
+        year=str(frontmatter.get("year") or ""),
+        journal=str(frontmatter.get("journal") or ""),
+        doi=str(frontmatter.get("doi") or ""),
+        status=str(frontmatter.get("status") or "unread"),
+        tags=[str(tag) for tag in tags],
+        summary=_extract_section(body, "Summary"),
+        key_findings=_extract_bullets(_extract_section(body, "Key Findings")),
+        methodology=_extract_section(body, "Methodology"),
+        relevance=_extract_section(body, "Relevance"),
+        raw_text=body,
+    )
+
+
+def _first_sentence(text: str) -> str:
+    """Return the first sentence, capped for table readability."""
+
+    stripped = " ".join(text.split())
+    if not stripped:
+        return ""
+    match = re.search(r"(.+?[.!?])(?:\s|$)", stripped)
+    if match:
+        return match.group(1)[:150]
+    return stripped[:150]
+
+
+def _author_short(authors: str) -> str:
+    """Convert author strings into a short citation-style label."""
+
+    if not authors:
+        return "Unknown"
+    parts = [part.strip() for part in authors.split(";") if part.strip()]
+    if not parts:
+        return "Unknown"
+    last_names = [part.split(",")[0].strip() for part in parts]
+    if len(last_names) == 1:
+        return last_names[0]
+    if len(last_names) == 2:
+        return f"{last_names[0]} & {last_names[1]}"
+    return f"{last_names[0]} et al."
+
+
+def _llm_from_text(paper: ClusterPaper) -> str:
+    """Infer a likely LLM reference from tags and note text."""
+
+    combined = " ".join(paper.tags + [paper.methodology, paper.summary, paper.relevance]).lower()
+    for name in ("gpt-4", "gpt-3.5", "claude", "llama", "gemini", "mistral", "qwen"):
+        if name in combined:
+            return name
+    if "llm" in combined or "large language model" in combined:
+        return "LLM (unspecified)"
+    return ""
+
+
+def _year_sort_value(year: str) -> tuple[int, str]:
+    """Provide a deterministic descending sort key for years."""
+
+    if year.isdigit():
+        return (1, year)
+    return (0, year)
+
+
+def build_synthesis_markdown(
+    cluster_slug: str,
+    cluster_name: str,
+    first_query: str,
+    papers: list[ClusterPaper],
+) -> str:
+    """Render the cluster synthesis page as markdown."""
+
+    sorted_papers = sorted(
+        papers,
+        key=lambda paper: (_year_sort_value(paper.year), paper.slug),
+        reverse=True,
+    )
+
+    by_year: dict[str, int] = {}
+    for paper in sorted_papers:
+        year = paper.year or "n.d."
+        by_year[year] = by_year.get(year, 0) + 1
+    year_line = " | ".join(
+        f"{year}: {count}" for year, count in sorted(by_year.items(), key=lambda item: item[0], reverse=True)
+    )
+
+    lines = [
+        "---",
+        "type: cluster-synthesis",
+        f"cluster: {cluster_slug}",
+        f"papers: {len(sorted_papers)}",
+        "---",
+        "",
+        f"# {cluster_name} - Synthesis",
+        "",
+        f"**First query:** {first_query}",
+        f"**Papers in cluster:** {len(sorted_papers)}",
+        f"**By year:** {year_line or 'n.d.: 0'}",
+        "",
+        (
+            f"> Auto-generated by `research-hub synthesize --cluster {cluster_slug}`. "
+            "Regenerate after new ingestions to refresh the collated content."
+        ),
+        "",
+        "## Collated Summaries",
+        "",
+    ]
+
+    for paper in sorted_papers:
+        lines.append(f"### {_author_short(paper.authors)} ({paper.year or 'n.d.'}) - {paper.title}")
+        lines.append("")
+        lines.append(paper.summary or "*(no summary recorded yet)*")
+        lines.append("")
+        lines.append(f"Source note: [[{paper.slug}]]")
+        lines.append("")
+
+    lines.extend(["## Collated Key Findings", ""])
+    for paper in sorted_papers:
+        lines.append(f"### {_author_short(paper.authors)} ({paper.year or 'n.d.'}) - {paper.title}")
+        lines.append("")
+        if paper.key_findings:
+            for finding in paper.key_findings:
+                lines.append(f"- {finding}")
+        else:
+            lines.append("*(no key findings recorded yet)*")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Methodology Comparison",
+            "",
+            "| Paper | Method | LLM | Status |",
+            "|---|---|---|---|",
+        ]
+    )
+    for paper in sorted_papers:
+        method_short = _first_sentence(paper.methodology) or "n/a"
+        llm = _llm_from_text(paper) or "n/a"
+        link_label = f"{_author_short(paper.authors)} ({paper.year or 'n.d.'})"
+        lines.append(
+            f"| [[{paper.slug}|{link_label}]] | {method_short} | {llm} | {paper.status} |"
+        )
+    lines.append("")
+
+    lines.extend(["## Open Questions / Relevance", ""])
+    any_relevance = False
+    for paper in sorted_papers:
+        if not paper.relevance:
+            continue
+        any_relevance = True
+        lines.append(
+            f"- **{_author_short(paper.authors)} ({paper.year or 'n.d.'}):** "
+            f"{' '.join(paper.relevance.split())[:300]}"
+        )
+    if not any_relevance:
+        lines.append("*(no relevance notes recorded yet)*")
+    lines.extend(["", "## Reading Queue (live)", ""])
+
+    lines.extend(
+        [
+            "```dataview",
+            "TABLE year, authors, status, citation-count",
+            'FROM "raw"',
+            f'WHERE topic_cluster = "{cluster_slug}" AND status = "unread"',
+            "SORT year DESC",
+            "LIMIT 15",
+            "```",
+            "",
+            "## Deep-read (active thinking)",
+            "",
+            "```dataview",
+            "TABLE year, authors, verified",
+            'FROM "raw"',
+            f'WHERE topic_cluster = "{cluster_slug}" AND (status = "deep-read" OR status = "cited")',
+            "SORT year DESC",
+            "```",
+            "",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def _collect_cluster_papers(
+    cluster_slug: str,
+    raw_dir: Path,
+) -> list[ClusterPaper]:
+    """Find all notes belonging to a cluster.
+
+    A note belongs to a cluster if EITHER:
+      (a) it lives under `raw/<cluster_slug>/` (new papers ingested by
+          v0.3.x into a dedicated cluster sub-folder), OR
+      (b) its YAML frontmatter has `topic_cluster: <cluster_slug>`
+          regardless of which sub-folder it lives in (legacy notes that
+          were dedup-caught and patched by v0.3.1+).
+
+    This dual-mode lookup is required because the dedup path never
+    moves existing files; it only annotates their YAML. Without (b)
+    a synthesis would miss every dedup-hit paper.
+    """
+    papers: list[ClusterPaper] = []
+    seen_paths: set[Path] = set()
+
+    cluster_folder = raw_dir / cluster_slug
+    if cluster_folder.exists():
+        for md_path in sorted(cluster_folder.rglob("*.md")):
+            if md_path in seen_paths:
+                continue
+            paper = parse_cluster_paper(md_path)
+            if paper is not None:
+                papers.append(paper)
+                seen_paths.add(md_path)
+
+    if raw_dir.exists():
+        for md_path in sorted(raw_dir.rglob("*.md")):
+            if md_path in seen_paths:
+                continue
+            paper = parse_cluster_paper(md_path)
+            if paper is None:
+                continue
+            if _note_topic_cluster(md_path) != cluster_slug:
+                continue
+            papers.append(paper)
+            seen_paths.add(md_path)
+
+    return papers
+
+
+def _note_topic_cluster(md_path: Path) -> str:
+    """Fast-path read of the `topic_cluster` field for filtering."""
+    try:
+        text = md_path.read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return ""
+    if not text.startswith("---"):
+        return ""
+    end = text.find("\n---", 3)
+    if end < 0:
+        return ""
+    import re as _re
+    match = _re.search(
+        r'^topic_cluster:\s*[\'"]?([^\'"\n]*)[\'"]?',
+        text[3:end],
+        _re.MULTILINE,
+    )
+    return match.group(1).strip() if match else ""
+
+
+def synthesize_cluster(
+    cluster_slug: str,
+    cluster_name: str,
+    first_query: str,
+    raw_dir: Path,
+    hub_dir: Path,
+) -> Path:
+    """Write a synthesis page for a single cluster.
+
+    Collects papers by both folder location (raw/<slug>/) and YAML
+    `topic_cluster:` field so that dedup-hit legacy notes are included
+    even when they still live in their original sub-folder.
+    """
+    papers = _collect_cluster_papers(cluster_slug, raw_dir)
+    if not papers:
+        raise FileNotFoundError(
+            f"No papers found for cluster '{cluster_slug}' in {raw_dir} "
+            "(checked both raw/<slug>/ and YAML topic_cluster field)"
+        )
+
+    markdown = build_synthesis_markdown(cluster_slug, cluster_name, first_query, papers)
+    out_dir = hub_dir / "clusters"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{cluster_slug}-synthesis.md"
+    out_path.write_text(markdown, encoding="utf-8")
+    return out_path
+
+
+def synthesize_all_clusters(raw_dir: Path, hub_dir: Path, clusters_file: Path) -> list[Path]:
+    """Write synthesis pages for every cluster defined in the registry."""
+
+    from research_hub.clusters import ClusterRegistry
+
+    registry = ClusterRegistry(clusters_file)
+    outputs: list[Path] = []
+    for cluster in registry.list():
+        try:
+            outputs.append(
+                synthesize_cluster(
+                    cluster.slug,
+                    cluster.name,
+                    cluster.first_query,
+                    raw_dir,
+                    hub_dir,
+                )
+            )
+        except FileNotFoundError:
+            continue
+    return outputs

--- a/tests/test_cli_synthesize.py
+++ b/tests/test_cli_synthesize.py
@@ -1,0 +1,29 @@
+"""Tests for CLI synthesize command wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_build_parser_accepts_synthesize_flags():
+    from research_hub.cli import build_parser
+
+    args = build_parser().parse_args(["synthesize", "--cluster", "alpha", "--graph-colors"])
+    assert args.command == "synthesize"
+    assert args.cluster == "alpha"
+    assert args.graph_colors is True
+
+
+def test_main_routes_synthesize_command(monkeypatch, tmp_path: Path):
+    from research_hub import cli
+
+    calls: list[tuple[str | None, bool]] = []
+
+    def fake_synthesize(cluster: str | None, graph_colors: bool) -> int:
+        calls.append((cluster, graph_colors))
+        return 0
+
+    monkeypatch.setattr(cli, "_synthesize", fake_synthesize)
+    result = cli.main(["synthesize", "--cluster", "alpha", "--graph-colors"])
+    assert result == 0
+    assert calls == [("alpha", True)]

--- a/tests/test_graph_config.py
+++ b/tests/test_graph_config.py
@@ -1,0 +1,94 @@
+"""Tests for vault.graph_config cluster graph coloring."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research_hub.vault.graph_config import (
+    PALETTE,
+    _hex_to_int_rgb,
+    build_color_groups,
+    update_from_clusters_file,
+    update_graph_json,
+)
+
+
+def test_hex_to_int_rgb_known_values():
+    assert _hex_to_int_rgb("#ffffff") == (255 << 16) | (255 << 8) | 255
+    assert _hex_to_int_rgb("#000000") == 0
+    assert _hex_to_int_rgb("#ff0000") == 255 << 16
+
+
+def test_build_color_groups_one_per_cluster():
+    groups = build_color_groups(["alpha", "beta", "gamma"])
+    assert len(groups) == 3
+    assert all("query" in group and "color" in group for group in groups)
+    assert groups[0]["query"] == "path:raw/alpha/"
+    assert groups[1]["color"]["rgb"] != groups[0]["color"]["rgb"]
+
+
+def test_build_color_groups_cycles_palette():
+    clusters = [f"c{i}" for i in range(len(PALETTE) + 2)]
+    groups = build_color_groups(clusters)
+    assert len(groups) == len(clusters)
+    assert groups[0]["color"]["rgb"] == groups[len(PALETTE)]["color"]["rgb"]
+
+
+def test_update_graph_json_missing_file_skips(tmp_path: Path):
+    report = update_graph_json(tmp_path / "missing.json", ["alpha"])
+    assert report.updated is False
+    assert "No graph.json" in report.skipped_reason
+
+
+def test_update_graph_json_preserves_other_keys(tmp_path: Path):
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(
+        json.dumps(
+            {
+                "zoom": 0.8,
+                "showAttachments": False,
+                "colorGroups": [{"query": "old", "color": {"a": 1, "rgb": 0}}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    report = update_graph_json(graph_path, ["alpha", "beta"])
+    assert report.updated is True
+    assert report.color_groups_written == 2
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert data["zoom"] == 0.8
+    assert data["showAttachments"] is False
+    assert len(data["colorGroups"]) == 2
+    assert data["colorGroups"][0]["query"] == "path:raw/alpha/"
+
+
+def test_update_graph_json_idempotent(tmp_path: Path):
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(json.dumps({"zoom": 1.0}), encoding="utf-8")
+    update_graph_json(graph_path, ["alpha"])
+    first = graph_path.read_text(encoding="utf-8")
+    update_graph_json(graph_path, ["alpha"])
+    second = graph_path.read_text(encoding="utf-8")
+    assert first == second
+
+
+def test_update_from_clusters_file_reads_registry(tmp_path: Path):
+    vault_root = tmp_path / "vault"
+    graph_path = vault_root / ".obsidian" / "graph.json"
+    graph_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_path.write_text(json.dumps({"zoom": 1.0}), encoding="utf-8")
+    clusters_file = tmp_path / "clusters.yaml"
+    clusters_file.write_text(
+        "clusters:\n"
+        "  alpha:\n"
+        "    name: Alpha\n"
+        "    first_query: alpha\n"
+        "  beta:\n"
+        "    name: Beta\n"
+        "    first_query: beta\n",
+        encoding="utf-8",
+    )
+    report = update_from_clusters_file(vault_root, clusters_file)
+    assert report.updated is True
+    assert report.cluster_slugs == ["alpha", "beta"]

--- a/tests/test_vault_synthesis.py
+++ b/tests/test_vault_synthesis.py
@@ -1,0 +1,202 @@
+"""Tests for vault.synthesis cluster synthesis page generator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from research_hub.vault.synthesis import (
+    ClusterPaper,
+    _author_short,
+    _extract_bullets,
+    _extract_section,
+    _first_sentence,
+    _llm_from_text,
+    build_synthesis_markdown,
+    parse_cluster_paper,
+    synthesize_all_clusters,
+    synthesize_cluster,
+)
+
+
+SAMPLE_NOTE = """---
+title: "Flood Risk Perception in Rural Communities"
+authors: "Smith, John; Doe, Jane"
+year: 2024
+journal: "Journal of Risk Research"
+doi: "10.1000/example"
+zotero-key: ABC123
+tags: ["flood", "risk perception", "rural", "gpt-4"]
+topic_cluster: "flood-risk-perception"
+cluster_queries: ["flood risk perception"]
+verified: false
+status: deep-read
+---
+
+# Flood Risk Perception in Rural Communities
+
+## Abstract
+
+This paper studies flood risk perception among rural residents.
+
+## Summary
+
+Rural residents underestimate flood risk due to limited direct experience.
+
+## Key Findings
+
+- Risk perception is 30% lower than actual exposure
+- Social networks mediate risk communication
+- Protection motivation correlates with direct experience
+
+## Methodology
+
+Mixed-methods study with 500 household surveys followed by 30 interviews.
+
+## Relevance
+
+Open question: how do LLM-based agents simulate these perception biases?
+"""
+
+
+def _make_note(path: Path, content: str = SAMPLE_NOTE) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_extract_section_returns_section_body():
+    body = "## Summary\n\nOne sentence.\n\n## Key Findings\n\n- a\n- b\n"
+    assert _extract_section(body, "Summary").startswith("One sentence.")
+    findings = _extract_section(body, "Key Findings")
+    assert "- a" in findings
+    assert "- b" in findings
+
+
+def test_extract_section_empty_when_missing():
+    assert _extract_section("no sections here", "Summary") == ""
+
+
+def test_extract_bullets_filters_non_bullets():
+    assert _extract_bullets("- first\ntext\n- second\n") == ["first", "second"]
+
+
+def test_author_short_handles_one_two_many():
+    assert _author_short("Smith, John") == "Smith"
+    assert _author_short("Smith, John; Doe, Jane") == "Smith & Doe"
+    assert _author_short("Smith, John; Doe, Jane; Wong, Li") == "Smith et al."
+    assert _author_short("") == "Unknown"
+
+
+def test_first_sentence_stops_at_period():
+    assert _first_sentence("Hello world. More stuff.") == "Hello world."
+    assert _first_sentence("") == ""
+    assert _first_sentence("No punctuation here").startswith("No punctuation")
+
+
+def test_llm_from_text_detects_tags_and_text():
+    paper = ClusterPaper(slug="p", title="t", tags=["gemini"], summary="")
+    assert _llm_from_text(paper) == "gemini"
+
+
+def test_parse_cluster_paper_extracts_all_fields(tmp_path: Path):
+    path = _make_note(tmp_path / "smith2024-flood-risk.md")
+    paper = parse_cluster_paper(path)
+    assert paper is not None
+    assert paper.title == "Flood Risk Perception in Rural Communities"
+    assert paper.year == "2024"
+    assert paper.status == "deep-read"
+    assert paper.summary.startswith("Rural residents")
+    assert len(paper.key_findings) == 3
+    assert "Protection motivation" in paper.key_findings[2]
+    assert paper.methodology.startswith("Mixed-methods")
+
+
+def test_parse_cluster_paper_returns_none_on_missing_frontmatter(tmp_path: Path):
+    path = tmp_path / "broken.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# Just a heading", encoding="utf-8")
+    assert parse_cluster_paper(path) is None
+
+
+def test_build_synthesis_markdown_contains_sections():
+    paper = ClusterPaper(
+        slug="smith2024",
+        title="Sample Paper",
+        authors="Smith, John",
+        year="2024",
+        status="unread",
+        summary="A summary sentence.",
+        key_findings=["Finding one", "Finding two"],
+        methodology="Used surveys.",
+        relevance="Applies to LLM simulation.",
+    )
+    output = build_synthesis_markdown(
+        cluster_slug="test-cluster",
+        cluster_name="Test Cluster",
+        first_query="test query",
+        papers=[paper],
+    )
+    assert "# Test Cluster - Synthesis" in output
+    assert "**First query:** test query" in output
+    assert "## Collated Summaries" in output
+    assert "## Collated Key Findings" in output
+    assert "## Methodology Comparison" in output
+    assert "A summary sentence." in output
+    assert "Finding one" in output
+    assert "```dataview" in output
+
+
+def test_build_synthesis_markdown_orders_newest_year_first():
+    older = ClusterPaper(slug="old", title="Old", authors="A, A", year="2021")
+    newer = ClusterPaper(slug="new", title="New", authors="B, B", year="2024")
+    output = build_synthesis_markdown("cluster", "Cluster", "query", [older, newer])
+    assert output.index("B (2024) - New") < output.index("A (2021) - Old")
+
+
+def test_synthesize_cluster_writes_output(tmp_path: Path):
+    raw = tmp_path / "raw"
+    hub = tmp_path / "hub"
+    _make_note(raw / "test-cluster" / "smith2024-flood-risk.md")
+    output = synthesize_cluster(
+        cluster_slug="test-cluster",
+        cluster_name="Test Cluster",
+        first_query="flood risk perception in rural communities",
+        raw_dir=raw,
+        hub_dir=hub,
+    )
+    assert output.exists()
+    content = output.read_text(encoding="utf-8")
+    assert "# Test Cluster - Synthesis" in content
+    assert "Smith & Doe (2024) - Flood Risk Perception in Rural Communities" in content
+    assert "Rural residents underestimate" in content
+
+
+def test_synthesize_cluster_raises_for_missing_folder(tmp_path: Path):
+    raw = tmp_path / "raw"
+    hub = tmp_path / "hub"
+    try:
+        synthesize_cluster("missing", "Missing", "query", raw, hub)
+    except FileNotFoundError as exc:
+        assert "No papers found for cluster" in str(exc)
+    else:
+        raise AssertionError("Expected FileNotFoundError")
+
+
+def test_synthesize_all_clusters_skips_missing_folders(tmp_path: Path):
+    clusters_file = tmp_path / "clusters.yaml"
+    clusters_file.write_text(
+        "clusters:\n"
+        "  alpha:\n"
+        "    name: Alpha\n"
+        "    first_query: alpha query\n"
+        "  beta:\n"
+        "    name: Beta\n"
+        "    first_query: beta query\n",
+        encoding="utf-8",
+    )
+    raw = tmp_path / "raw"
+    hub = tmp_path / "hub"
+    _make_note(raw / "alpha" / "paper.md")
+    outputs = synthesize_all_clusters(raw, hub, clusters_file)
+    assert len(outputs) == 1
+    assert outputs[0].name == "alpha-synthesis.md"


### PR DESCRIPTION
## Why

Answers the real user question 'how do I efficiently find relationships and key points across dozens of papers in a cluster?' The dedup + wikilink machinery from v0.3.0–v0.3.2 makes the vault internally consistent, but a reviewer still has to open 30 notes to understand a research line. v0.3.3 collates the whole cluster into a single synthesis page + injects live dataview queues + adds graph-view cluster colors.

## Features

1. ~research-hub synthesize [--cluster X] [--graph-colors]~ — new CLI sub-command that builds a ~hub/clusters/<slug>-synthesis.md~ page per cluster. The page contains year histogram, collated Summaries, collated Key Findings, Methodology Comparison table (Author Year / Method / LLM / Status), Aggregated Open Questions, and live dataview Reading Queue + Deep-read sections.

2. Dual-mode paper discovery — synthesis finds cluster members both by folder location (raw/<slug>/ for new ingests) AND by YAML ~topic_cluster~ field (for dedup-hit legacy notes that stay in their original sub-folder). Without the YAML path every legacy cluster synthesis would be empty.

3. Dataview queue injection — ~vault/builder.py~ now appends Reading Queue / Deep-read / All Papers dataview blocks to every cluster hub page. Queries use ~WHERE topic_cluster = "<slug>"~ so they match both ingestion modes.

4. Obsidian graph.json cluster colors — ~vault/graph_config.py~ reads the vault's graph.json, loads clusters.yaml, writes one colorGroup per cluster using an 8-color palette. Preserves all other keys, idempotent, skips silently when graph.json is absent.

## Scope

**New files (~753 LOC)**
- ~src/research_hub/vault/synthesis.py~ (326)
- ~src/research_hub/vault/graph_config.py~ (102)
- ~tests/test_vault_synthesis.py~ (202)
- ~tests/test_graph_config.py~ (94)
- ~tests/test_cli_synthesize.py~ (29)

**Modified**
- ~src/research_hub/cli.py~ — new ~synthesize~ sub-command
- ~src/research_hub/vault/builder.py~ — dataview injection in cluster hub loop
- ~pyproject.toml~ — 0.3.2 → 0.3.3

## Test suite

87 → 109 passing (+22 new tests across 3 files).

## Live-validated on a real vault

~python -m research_hub synthesize --cluster llm-agents-behavioral-science-environmental-interaction~ on Wenyu's production vault finds all 8 dedup-hit legacy notes, writes a 5KB synthesis page with year histogram 2025:7/2024:1, methodology comparison table, aggregated open questions section, and working dataview queues.

## Delegation note

Originally routed to Gemini CLI to save Claude tokens. Gemini hit the same pseudo-code output bug that killed Phase D docs generation in the v0.2.1 release — it outputs planning comments instead of calling its write_file tool. Fell back to Codex CLI which produced the code first-try with one minor deviation (YAML-based synthesis discovery added by Claude during live validation). ~~/.claude/CLAUDE.md~ routing table will be updated to flag Gemini as unreliable for Python code generation in this environment.

## Test plan

- [ ] CI green on 3.10 / 3.11 / 3.12
- [ ] Fresh clone + pip install + pytest → 109 passed
- [ ] ~research-hub synthesize --cluster <slug>~ on a vault with dedup-hit notes produces a populated synthesis page

🤖 Generated with [Claude Code](https://claude.com/claude-code)