### PR TITLE
v0.3.4: status dashboard + YAML migration + cluster overview

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub"
-version = "0.3.3"
+version = "0.3.4"
 description = "Zotero -> Obsidian -> NotebookLM research pipeline"
 authors = [{name = "WenyuChiou"}]
 requires-python = ">=3.10"

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -123,6 +123,44 @@ def _search(query: str, limit: int) -> int:
     return 0
 
 
+def _status(cluster: str | None = None) -> int:
+    from research_hub.vault.progress import print_status_table
+
+    cfg = get_config()
+    registry = ClusterRegistry(cfg.clusters_file)
+    print_status_table(cfg.raw, registry, one_cluster=cluster)
+    return 0
+
+
+def _migrate_yaml(
+    assign_cluster: str | None = None,
+    folder: str | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> int:
+    from research_hub.vault.migrate import migrate_vault
+
+    cfg = get_config()
+    registry = ClusterRegistry(cfg.clusters_file)
+    if assign_cluster is not None and registry.get(assign_cluster) is None:
+        raise ValueError(f"Cluster not found: {assign_cluster}")
+
+    folder_path = Path(folder) if folder else None
+    report = migrate_vault(
+        cfg.raw,
+        cluster_override=assign_cluster,
+        folder=folder_path,
+        force=force,
+        dry_run=dry_run,
+    )
+    mode = "Would patch" if dry_run else "Patched"
+    print(
+        f"{mode} {report['changed']} notes "
+        f"(scanned {report['scanned']}, skipped {report['skipped']})"
+    )
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="research-hub")
     subparsers = parser.add_subparsers(dest="command")
@@ -154,6 +192,31 @@ def build_parser() -> argparse.ArgumentParser:
     search_parser = subparsers.add_parser("search", help="Search Semantic Scholar")
     search_parser.add_argument("query")
     search_parser.add_argument("--limit", type=int, default=20)
+
+    status_parser = subparsers.add_parser("status", help="Show per-cluster reading progress")
+    status_parser.add_argument("--cluster", default=None, help="Show only this cluster")
+
+    migrate_parser = subparsers.add_parser(
+        "migrate-yaml", help="Patch legacy notes to v0.3.x YAML spec"
+    )
+    migrate_parser.add_argument(
+        "--assign-cluster",
+        default=None,
+        help="Bulk-assign all matched notes to this cluster slug",
+    )
+    migrate_parser.add_argument(
+        "--folder",
+        default=None,
+        help="Restrict to this subfolder under raw/",
+    )
+    migrate_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing topic_cluster values",
+    )
+    migrate_parser.add_argument(
+        "--dry-run", action="store_true", help="Report without writing"
+    )
 
     subparsers.add_parser("verify", help="Run repository verification checks")
 
@@ -202,6 +265,15 @@ def main(argv: list[str] | None = None) -> int:
             return _clusters_new(args.query, args.name, args.slug)
     if args.command == "search":
         return _search(args.query, args.limit)
+    if args.command == "status":
+        return _status(cluster=args.cluster)
+    if args.command == "migrate-yaml":
+        return _migrate_yaml(
+            assign_cluster=args.assign_cluster,
+            folder=args.folder,
+            force=args.force,
+            dry_run=args.dry_run,
+        )
     if args.command == "verify":
         return _verify()
     if args.command == "cleanup":

--- a/src/research_hub/vault/builder.py
+++ b/src/research_hub/vault/builder.py
@@ -3,6 +3,7 @@ import re
 
 from research_hub.clusters import ClusterRegistry
 from research_hub.config import get_config as _get_config
+from research_hub.vault.progress import count_status_by_cluster
 
 # Merge mapping: normalize duplicate/typo Zotero collection names to canonical wiki names
 WIKI_MERGE = {
@@ -35,6 +36,12 @@ def normalize_collections(collections):
             seen.add(canonical.lower())
             normalized.append(canonical)
     return normalized
+
+
+def _ingested_sort_key(value: str) -> tuple[int, str]:
+    """Sort ingest timestamps with blank values last."""
+
+    return (1, value) if value else (0, "")
 
 
 def main() -> int:
@@ -263,6 +270,35 @@ papers: {len(matched)}
             fh.write(content)
         print(f"  Project: {proj_name}.md ({len(matched)} papers)")
 
+    status_counts = count_status_by_cluster(cfg.raw)
+    cluster_rows = []
+    for cluster in clusters.list():
+        matched = [paper for paper in papers if paper.get("topic_cluster") == cluster.slug]
+        last_ingest = "?"
+        ingested_values = [
+            str(paper.get("ingested_at", "")).strip()
+            for paper in matched
+            if str(paper.get("ingested_at", "")).strip()
+        ]
+        if ingested_values:
+            last_ingest = max(ingested_values, key=_ingested_sort_key)[:10]
+        counter = status_counts.get(cluster.slug, {})
+        cluster_rows.append(
+            {
+                "slug": cluster.slug,
+                "name": cluster.name,
+                "total": sum(counter.values()),
+                "unread": counter.get("unread", 0),
+                "skim": counter.get("skim", 0),
+                "deep": counter.get("deep-read", 0),
+                "cited": counter.get("cited", 0),
+                "last_ingest": last_ingest,
+            }
+        )
+
+    cluster_rows.sort(key=lambda row: (-row["unread"], -row["total"], row["slug"]))
+    unassigned_count = sum(status_counts.get("__unassigned__", {}).values())
+
     index_content = f"""---
 type: index
 total_papers: {len(papers)}
@@ -271,6 +307,23 @@ total_papers: {len(papers)}
 # Knowledge Base Index
 
 Total papers: **{len(papers)}**
+
+## Clusters Overview
+
+| Cluster | Total | Unread | Skim | Deep | Cited | Last Ingest |
+|---|---:|---:|---:|---:|---:|---|
+"""
+    for row in cluster_rows:
+        index_content += (
+            f"| [[clusters/{row['slug']}|{row['name']}]] | {row['total']} | "
+            f"{row['unread']} | {row['skim']} | {row['deep']} | {row['cited']} | "
+            f"{row['last_ingest']} |\n"
+        )
+
+    if unassigned_count:
+        index_content += f"\n**Unassigned notes:** {unassigned_count}\n"
+
+    index_content += """
 
 ## Research Projects
 
@@ -285,6 +338,16 @@ Total papers: **{len(papers)}**
         index_content += f"- {topic.replace('-', ' ')}\n"
 
     index_content += """
+## Global Unread Queue (top 20)
+
+```dataview
+TABLE year, authors, topic_cluster, status
+FROM "raw"
+WHERE status = "unread"
+SORT year DESC
+LIMIT 20
+```
+
 ## All Papers by Year
 
 """
@@ -299,10 +362,10 @@ Total papers: **{len(papers)}**
             index_content += f"- {paper['title_line'][:80]} ({paper.get('year', 'n.d.')})\n"
         index_content += "\n"
 
-    index_path = os.path.join(root, "index.md")
+    index_path = os.path.join(hub_dir, "index.md")
     with open(index_path, "w", encoding="utf-8") as fh:
         fh.write(index_content)
-    print("  Index: index.md")
+    print("  Index: hub/index.md")
     print("DONE")
     return 0
 

--- a/src/research_hub/vault/migrate.py
+++ b/src/research_hub/vault/migrate.py
@@ -1,0 +1,181 @@
+"""YAML migration helpers for legacy vault notes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+import re
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---(?=\n|$)", re.DOTALL)
+REQUIRED_FIELDS = (
+    "status",
+    "topic_cluster",
+    "verified",
+    "ingested_at",
+    "ingestion_source",
+)
+
+
+def _frontmatter_map(frontmatter_text: str) -> dict[str, str]:
+    """Parse flat YAML-style frontmatter into a string mapping."""
+
+    match = FRONTMATTER_RE.match(frontmatter_text)
+    if not match:
+        return {}
+    mapping: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        mapping[key.strip()] = value.strip().strip('"').strip("'")
+    return mapping
+
+
+def _yaml_scalar(value: Any) -> str:
+    """Render a small scalar value into the repo's YAML style."""
+
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list):
+        return "[" + ", ".join(f'"{item}"' for item in value) + "]"
+    if value is None:
+        return '""'
+    if isinstance(value, str):
+        lowered = value.lower()
+        if lowered in {"true", "false"} or value == "" or ":" in value or value.endswith(" "):
+            return f'"{value}"'
+        return value
+    return str(value)
+
+
+def _mtime_iso(path: Path) -> str:
+    """Format the file modification time as UTC ISO 8601."""
+
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def needs_migration(frontmatter_text: str) -> list[str]:
+    """Return required v0.3.x fields that are absent from the note."""
+
+    current = _frontmatter_map(frontmatter_text)
+    return [field for field in REQUIRED_FIELDS if field not in current]
+
+
+def patch_frontmatter(frontmatter_text: str, patches: dict[str, Any]) -> str:
+    """Insert or replace frontmatter keys while preserving unchanged order."""
+
+    match = FRONTMATTER_RE.match(frontmatter_text)
+    if not match:
+        patch_lines = [f"{key}: {_yaml_scalar(value)}" for key, value in patches.items()]
+        prefix = "---\n" + "\n".join(patch_lines) + "\n---\n"
+        return prefix + frontmatter_text.lstrip("\n")
+
+    lines = frontmatter_text.splitlines()
+    closing_index = lines.index("---", 1)
+    key_positions: dict[str, int] = {}
+    for index in range(1, closing_index):
+        line = lines[index]
+        if ":" not in line:
+            continue
+        key = line.split(":", 1)[0].strip()
+        key_positions[key] = index
+
+    for key, value in patches.items():
+        rendered = f"{key}: {_yaml_scalar(value)}"
+        if key in key_positions:
+            lines[key_positions[key]] = rendered
+        else:
+            lines.insert(closing_index, rendered)
+            closing_index += 1
+    return "\n".join(lines) + ("\n" if frontmatter_text.endswith("\n") else "")
+
+
+def migrate_note(
+    path: Path,
+    default_status: str = "unread",
+    cluster_override: str | None = None,
+    force: bool = False,
+    write: bool = True,
+) -> dict[str, Any] | None:
+    """Patch one note and return a migration report when a change is needed."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    current = _frontmatter_map(text)
+    missing = needs_migration(text)
+    patches: dict[str, Any] = {}
+    skipped: str | None = None
+
+    existing_cluster = current.get("topic_cluster", "").strip()
+    if cluster_override is not None:
+        if existing_cluster and existing_cluster != cluster_override and not force:
+            skipped = "topic_cluster already set"
+        elif existing_cluster != cluster_override:
+            patches["topic_cluster"] = cluster_override
+
+    if cluster_override is None and "status" not in missing:
+        return None
+
+    if "status" in missing:
+        defaults: dict[str, Any] = {
+            "topic_cluster": cluster_override or "",
+            "cluster_queries": [],
+            "verified": False,
+            "status": default_status,
+            "ingested_at": _mtime_iso(path),
+            "ingestion_source": "pre-v0.3.0-migration",
+        }
+        for key, value in defaults.items():
+            if key not in current and (key != "topic_cluster" or skipped is None):
+                patches.setdefault(key, value)
+
+    if skipped is not None and not patches:
+        return {"path": str(path), "added": [], "skipped": skipped}
+    if not patches:
+        return None
+
+    updated_text = patch_frontmatter(text, patches)
+    if write and updated_text != text:
+        path.write_text(updated_text, encoding="utf-8")
+    return {"path": str(path), "added": list(patches.keys()), "skipped": skipped}
+
+
+def migrate_vault(
+    raw_dir: Path,
+    cluster_override: str | None = None,
+    folder: Path | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Walk the vault, optionally restricting to a folder, and patch notes."""
+
+    target_dir = raw_dir / folder if folder is not None else raw_dir
+    reports: list[dict[str, Any]] = []
+    skipped = 0
+    scanned = 0
+
+    if not target_dir.exists():
+        return {"scanned": 0, "changed": 0, "skipped": 0, "reports": []}
+
+    for path in sorted(target_dir.rglob("*.md")):
+        scanned += 1
+        report = migrate_note(
+            path,
+            cluster_override=cluster_override,
+            force=force,
+            write=not dry_run,
+        )
+        if report is None:
+            continue
+        if report.get("skipped"):
+            skipped += 1
+        reports.append(report)
+
+    changed = sum(1 for report in reports if report["added"])
+    return {"scanned": scanned, "changed": changed, "skipped": skipped, "reports": reports}

--- a/src/research_hub/vault/progress.py
+++ b/src/research_hub/vault/progress.py
@@ -1,0 +1,172 @@
+"""Vault reading-progress reporting helpers."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from pathlib import Path
+import re
+
+from research_hub.clusters import ClusterRegistry
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---(?:\n|$)", re.DOTALL)
+STATUS_COLUMNS = (
+    ("unread", "Unread"),
+    ("skim", "Skim"),
+    ("deep-read", "Deep"),
+    ("cited", "Cited"),
+    ("archived", "Arch"),
+)
+STATUS_ALIASES = {
+    "deep": "deep-read",
+    "deep-read": "deep-read",
+    "archive": "archived",
+    "arch": "archived",
+    "archived": "archived",
+    "skim": "skim",
+    "cited": "cited",
+    "unread": "unread",
+}
+
+
+def _frontmatter_map(text: str) -> dict[str, str]:
+    """Return a flat frontmatter mapping parsed from a markdown note."""
+
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+
+    frontmatter: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        frontmatter[key.strip()] = value.strip().strip('"').strip("'")
+    return frontmatter
+
+
+def _iter_note_rows(raw_dir: Path) -> list[dict[str, str]]:
+    """Read note metadata needed for status reports in a single vault walk."""
+
+    rows: list[dict[str, str]] = []
+    if not raw_dir.exists():
+        return rows
+
+    for path in sorted(raw_dir.rglob("*.md")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        frontmatter = _frontmatter_map(text)
+        status = STATUS_ALIASES.get(frontmatter.get("status", "").strip().lower(), "unread")
+        rows.append(
+            {
+                "cluster": frontmatter.get("topic_cluster", "").strip(),
+                "status": status,
+                "title": frontmatter.get("title", path.stem).strip() or path.stem,
+                "path": str(path),
+                "ingested_at": frontmatter.get("ingested_at", "").strip(),
+            }
+        )
+    return rows
+
+
+def count_status_by_cluster(raw_dir: Path) -> dict[str, Counter]:
+    """Return per-cluster reading-status counts plus ``__unassigned__``."""
+
+    counts: dict[str, Counter] = {}
+    for row in _iter_note_rows(raw_dir):
+        cluster = row["cluster"] or "__unassigned__"
+        counts.setdefault(cluster, Counter())
+        counts[cluster][row["status"]] += 1
+    return counts
+
+
+def _format_table_rows(
+    rows: list[tuple[str, int, int, int, int, int, int]],
+) -> list[str]:
+    """Render the summary rows as a plain-text table."""
+
+    headers = ("Cluster", "Total", "Unread", "Skim", "Deep", "Cited", "Arch")
+    cluster_width = max([len(headers[0]), *[len(row[0]) for row in rows]] or [len(headers[0])])
+    widths = [cluster_width]
+    for index in range(1, len(headers)):
+        widths.append(
+            max(
+                len(headers[index]),
+                *[len(str(row[index])) for row in rows],
+            )
+        )
+
+    def fmt(row: tuple[str, int, int, int, int, int, int] | tuple[str, ...]) -> str:
+        parts = [str(row[0]).ljust(widths[0])]
+        for index in range(1, len(row)):
+            parts.append(str(row[index]).rjust(widths[index]))
+        return "  ".join(parts)
+
+    lines = [fmt(headers), "-" * len(fmt(headers))]
+    for row in rows:
+        lines.append(fmt(row))
+    return lines
+
+
+def print_status_table(
+    raw_dir: Path,
+    clusters_registry: ClusterRegistry,
+    one_cluster: str | None = None,
+) -> None:
+    """Print either the global cluster table or one cluster's paper breakdown."""
+
+    counts = count_status_by_cluster(raw_dir)
+    rows = _iter_note_rows(raw_dir)
+    known_slugs = [cluster.slug for cluster in clusters_registry.list()]
+
+    if one_cluster is not None:
+        cluster = clusters_registry.get(one_cluster)
+        if cluster is None:
+            raise ValueError(f"Cluster not found: {one_cluster}")
+        grouped: dict[str, list[dict[str, str]]] = defaultdict(list)
+        for row in rows:
+            if row["cluster"] == one_cluster:
+                grouped[row["status"]].append(row)
+
+        cluster_counts = counts.get(one_cluster, Counter())
+        total = sum(cluster_counts.values())
+        print(f"{cluster.slug} ({cluster.name})")
+        print(f"Total: {total}")
+        for status, label in STATUS_COLUMNS:
+            items = sorted(grouped.get(status, []), key=lambda item: item["title"].lower())
+            print(f"\n{label} ({len(items)})")
+            if not items:
+                print("- none")
+                continue
+            for item in items:
+                rel_path = Path(item["path"]).relative_to(raw_dir)
+                print(f"- {item['title']} [{rel_path.as_posix()}]")
+        return
+
+    cluster_rows: list[tuple[str, int, int, int, int, int, int]] = []
+    extra_slugs = sorted(
+        slug for slug in counts if slug not in {"__unassigned__", *known_slugs}
+    )
+    for slug in [*known_slugs, *extra_slugs]:
+        counter = counts.get(slug, Counter())
+        total = sum(counter.values())
+        cluster_rows.append(
+            (
+                slug,
+                total,
+                counter.get("unread", 0),
+                counter.get("skim", 0),
+                counter.get("deep-read", 0),
+                counter.get("cited", 0),
+                counter.get("archived", 0),
+            )
+        )
+
+    cluster_rows.sort(key=lambda row: (-row[2], -row[1], row[0]))
+    for line in _format_table_rows(cluster_rows):
+        print(line)
+
+    unassigned = sum(counts.get("__unassigned__", Counter()).values())
+    if unassigned:
+        print(f"Unassigned notes (no topic_cluster): {unassigned}")

--- a/tests/test_cli_status_migrate.py
+++ b/tests/test_cli_status_migrate.py
@@ -1,0 +1,68 @@
+"""Tests for CLI status and migrate-yaml wiring."""
+
+from __future__ import annotations
+
+
+def test_build_parser_accepts_status_flags():
+    from research_hub.cli import build_parser
+
+    args = build_parser().parse_args(["status", "--cluster", "alpha"])
+    assert args.command == "status"
+    assert args.cluster == "alpha"
+
+
+def test_build_parser_accepts_migrate_yaml_flags():
+    from research_hub.cli import build_parser
+
+    args = build_parser().parse_args(
+        ["migrate-yaml", "--assign-cluster", "alpha", "--folder", "survey", "--force", "--dry-run"]
+    )
+    assert args.command == "migrate-yaml"
+    assert args.assign_cluster == "alpha"
+    assert args.folder == "survey"
+    assert args.force is True
+    assert args.dry_run is True
+
+
+def test_main_routes_status_and_migrate(monkeypatch):
+    from research_hub import cli
+
+    calls: list[tuple[str, tuple, dict]] = []
+
+    def fake_status(*, cluster=None):
+        calls.append(("status", tuple(), {"cluster": cluster}))
+        return 0
+
+    def fake_migrate(*, assign_cluster=None, folder=None, force=False, dry_run=False):
+        calls.append(
+            (
+                "migrate-yaml",
+                tuple(),
+                {
+                    "assign_cluster": assign_cluster,
+                    "folder": folder,
+                    "force": force,
+                    "dry_run": dry_run,
+                },
+            )
+        )
+        return 0
+
+    monkeypatch.setattr(cli, "_status", fake_status)
+    monkeypatch.setattr(cli, "_migrate_yaml", fake_migrate)
+
+    assert cli.main(["status", "--cluster", "alpha"]) == 0
+    assert cli.main(["migrate-yaml", "--assign-cluster", "alpha", "--folder", "survey", "--force"]) == 0
+    assert calls == [
+        ("status", tuple(), {"cluster": "alpha"}),
+        (
+            "migrate-yaml",
+            tuple(),
+            {
+                "assign_cluster": "alpha",
+                "folder": "survey",
+                "force": True,
+                "dry_run": False,
+            },
+        ),
+    ]

--- a/tests/test_vault_migrate.py
+++ b/tests/test_vault_migrate.py
@@ -1,0 +1,81 @@
+"""Tests for vault YAML migration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from research_hub.vault.migrate import (
+    migrate_note,
+    migrate_vault,
+    needs_migration,
+    patch_frontmatter,
+)
+
+
+def _write_note(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_needs_migration_detects_missing_status_field():
+    text = "---\ntitle: Test\ntopic_cluster: \"\"\nverified: false\n---\n"
+    assert "status" in needs_migration(text)
+
+
+def test_needs_migration_returns_empty_when_all_present():
+    text = (
+        "---\n"
+        "title: Test\n"
+        "topic_cluster: \"\"\n"
+        "verified: false\n"
+        "status: unread\n"
+        "ingested_at: \"2026-04-11T00:00:00Z\"\n"
+        "ingestion_source: \"research-hub\"\n"
+        "---\n"
+    )
+    assert needs_migration(text) == []
+
+
+def test_patch_frontmatter_inserts_before_closing_dashes():
+    text = "---\ntitle: Test\n---\nBody\n"
+    patched = patch_frontmatter(text, {"status": "unread"})
+    assert "status: unread\n---" in patched
+
+
+def test_patch_frontmatter_preserves_existing_fields():
+    text = "---\ntitle: Test\nyear: 2024\n---\nBody\n"
+    patched = patch_frontmatter(text, {"status": "unread"})
+    assert patched.index("title: Test") < patched.index("year: 2024") < patched.index("status: unread")
+
+
+def test_migrate_note_skips_when_status_already_present(tmp_path: Path):
+    note = tmp_path / "note.md"
+    _write_note(note, "---\ntitle: Test\nstatus: unread\n---\nBody\n")
+
+    assert migrate_note(note) is None
+
+
+def test_migrate_note_bulk_assign_cluster_without_force_skips_existing(tmp_path: Path):
+    note = tmp_path / "note.md"
+    _write_note(
+        note,
+        "---\ntitle: Test\nstatus: unread\ntopic_cluster: existing\n---\nBody\n",
+    )
+
+    report = migrate_note(note, cluster_override="alpha", force=False)
+
+    assert report is not None
+    assert report["skipped"] == "topic_cluster already set"
+    assert 'topic_cluster: existing' in note.read_text(encoding="utf-8")
+
+
+def test_migrate_vault_dry_run_does_not_write(tmp_path: Path):
+    raw_dir = tmp_path / "raw"
+    note = raw_dir / "legacy.md"
+    original = "---\ntitle: Legacy\n---\nBody\n"
+    _write_note(note, original)
+
+    report = migrate_vault(raw_dir, dry_run=True)
+
+    assert report["changed"] == 1
+    assert note.read_text(encoding="utf-8") == original

--- a/tests/test_vault_progress.py
+++ b/tests/test_vault_progress.py
@@ -1,0 +1,118 @@
+"""Tests for vault progress reporting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from research_hub.clusters import ClusterRegistry
+from research_hub.vault.progress import count_status_by_cluster, print_status_table
+
+
+def _write_note(path: Path, frontmatter: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(frontmatter + "\nBody\n", encoding="utf-8")
+
+
+def _write_clusters(path: Path) -> ClusterRegistry:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "clusters:\n"
+        "  alpha:\n"
+        "    name: Alpha Cluster\n"
+        "    first_query: alpha\n"
+        "  beta:\n"
+        "    name: Beta Cluster\n"
+        "    first_query: beta\n",
+        encoding="utf-8",
+    )
+    return ClusterRegistry(path)
+
+
+def test_count_status_by_cluster_empty_vault(tmp_path: Path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    assert count_status_by_cluster(raw_dir) == {}
+
+
+def test_count_status_by_cluster_groups_by_cluster(tmp_path: Path):
+    raw_dir = tmp_path / "raw"
+    _write_note(
+        raw_dir / "a.md",
+        '---\ntitle: "A"\ntopic_cluster: "alpha"\nstatus: unread\n---',
+    )
+    _write_note(
+        raw_dir / "b.md",
+        '---\ntitle: "B"\ntopic_cluster: "alpha"\nstatus: skim\n---',
+    )
+    _write_note(
+        raw_dir / "c.md",
+        '---\ntitle: "C"\ntopic_cluster: "beta"\nstatus: cited\n---',
+    )
+
+    result = count_status_by_cluster(raw_dir)
+
+    assert result["alpha"]["unread"] == 1
+    assert result["alpha"]["skim"] == 1
+    assert result["beta"]["cited"] == 1
+
+
+def test_count_status_by_cluster_counts_unassigned(tmp_path: Path):
+    raw_dir = tmp_path / "raw"
+    _write_note(raw_dir / "legacy.md", '---\ntitle: "Legacy"\nstatus: unread\n---')
+
+    result = count_status_by_cluster(raw_dir)
+
+    assert result["__unassigned__"]["unread"] == 1
+
+
+def test_count_status_by_cluster_defaults_unread(tmp_path: Path):
+    raw_dir = tmp_path / "raw"
+    _write_note(raw_dir / "legacy.md", '---\ntitle: "Legacy"\ntopic_cluster: "alpha"\n---')
+
+    result = count_status_by_cluster(raw_dir)
+
+    assert result["alpha"]["unread"] == 1
+
+
+def test_print_status_table_sorts_by_unread_desc(tmp_path: Path, capsys):
+    raw_dir = tmp_path / "raw"
+    registry = _write_clusters(tmp_path / ".research_hub" / "clusters.yaml")
+    _write_note(
+        raw_dir / "a.md",
+        '---\ntitle: "A"\ntopic_cluster: "alpha"\nstatus: unread\n---',
+    )
+    _write_note(
+        raw_dir / "b.md",
+        '---\ntitle: "B"\ntopic_cluster: "alpha"\nstatus: unread\n---',
+    )
+    _write_note(
+        raw_dir / "c.md",
+        '---\ntitle: "C"\ntopic_cluster: "beta"\nstatus: unread\n---',
+    )
+
+    print_status_table(raw_dir, registry)
+    output = capsys.readouterr().out.strip().splitlines()
+
+    alpha_index = next(index for index, line in enumerate(output) if line.strip().startswith("alpha"))
+    beta_index = next(index for index, line in enumerate(output) if line.strip().startswith("beta"))
+    assert alpha_index < beta_index
+
+
+def test_print_status_table_single_cluster_mode(tmp_path: Path, capsys):
+    raw_dir = tmp_path / "raw"
+    registry = _write_clusters(tmp_path / ".research_hub" / "clusters.yaml")
+    _write_note(
+        raw_dir / "a.md",
+        '---\ntitle: "Alpha Paper"\ntopic_cluster: "alpha"\nstatus: unread\n---',
+    )
+    _write_note(
+        raw_dir / "b.md",
+        '---\ntitle: "Beta Paper"\ntopic_cluster: "beta"\nstatus: skim\n---',
+    )
+
+    print_status_table(raw_dir, registry, one_cluster="alpha")
+    output = capsys.readouterr().out
+
+    assert "Alpha Paper" in output
+    assert "Beta Paper" not in output
+    assert "Unread (1)" in output


### PR DESCRIPTION
Three UX features addressing real pain points from live usage on a 1063-note production vault.

- **research-hub status** — per-cluster reading-progress table, sorted by unread count descending
- **research-hub migrate-yaml** — patches legacy pre-v0.3.0 notes with default v0.3.x fields; supports --assign-cluster --folder for bulk cluster assignment (idempotent, refuses to clobber without --force)
- **hub/index.md cluster overview** — index page now opens with a Clusters Overview table + global Unread Queue dataview block

Tests: 109 → 125. Live-validated: migrated 1042 legacy notes, bulk-assigned 331 papers to a second cluster, status command + dashboard render correctly.