### PR TITLE
fix: avoid double NLM login + prevent duplicate Zotero collections

### DIFF
--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -198,6 +198,11 @@ def auto_pipeline(
             _ensure_zotero_collection(registry, cluster, slug, report, print_progress)
     else:
         _step_log(report, "cluster", True, 0.0, f"existing: {slug}", print_progress)
+        # NOTE: clusters with a recorded zotero_collection_key are trusted
+        # without round-tripping to Zotero. If the user manually deleted
+        # that collection in the Zotero UI, the next ingest will 404 on
+        # write. Validating-and-rebinding stale keys is a separate concern
+        # (see follow-up: probe-then-rebind on stale keys).
         if not dry_run and not getattr(cluster, "zotero_collection_key", None):
             _ensure_zotero_collection(registry, cluster, slug, report, print_progress)
 
@@ -431,7 +436,7 @@ def _print_next_steps(report: AutoReport, slug: str, *, do_crystals: bool) -> No
 
 
 def _find_existing_collection_key_by_name(web, name: str) -> str | None:
-    """Look up a Zotero collection by exact name, return its key or None.
+    """Look up a Zotero collection by case-insensitive name, return key or None.
 
     v0.68.4: prevent the duplicate-collection accumulation bug. Previously
     `_ensure_zotero_collection` always POSTed a new collection, so any code
@@ -440,7 +445,14 @@ def _find_existing_collection_key_by_name(web, name: str) -> str | None:
     that happens to share a name) would silently create a duplicate. A real
     incident left 283 empty orphan collections in the maintainer's library
     over months of test runs.
+
+    Name match is case-folded (`.casefold()`) on both sides because the
+    Zotero web UI lets users rename to case-only-different forms ("Flood
+    Risk" vs "flood risk"), and a case-sensitive match would still leak
+    duplicates from that path. casefold() is preferred over lower() for
+    Unicode correctness (e.g., German ß).
     """
+    target = name.casefold()
     try:
         # Manual pagination: pyzotero's follow() pattern hit a None-path bug
         # on some versions; explicit start= avoids it.
@@ -450,7 +462,7 @@ def _find_existing_collection_key_by_name(web, name: str) -> str | None:
             if not chunk:
                 return None
             for c in chunk:
-                if c.get("data", {}).get("name") == name:
+                if c.get("data", {}).get("name", "").casefold() == target:
                     return c["data"]["key"]
             if len(chunk) < 100:
                 return None

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -430,12 +430,44 @@ def _print_next_steps(report: AutoReport, slug: str, *, do_crystals: bool) -> No
     print()
 
 
+def _find_existing_collection_key_by_name(web, name: str) -> str | None:
+    """Look up a Zotero collection by exact name, return its key or None.
+
+    v0.68.4: prevent the duplicate-collection accumulation bug. Previously
+    `_ensure_zotero_collection` always POSTed a new collection, so any code
+    path that called auto_pipeline without a recorded cluster.zotero_collection_key
+    (test reset, manual collection delete on Zotero side, fresh cluster
+    that happens to share a name) would silently create a duplicate. A real
+    incident left 283 empty orphan collections in the maintainer's library
+    over months of test runs.
+    """
+    try:
+        # Manual pagination: pyzotero's follow() pattern hit a None-path bug
+        # on some versions; explicit start= avoids it.
+        start = 0
+        while True:
+            chunk = web.collections(limit=100, start=start)
+            if not chunk:
+                return None
+            for c in chunk:
+                if c.get("data", {}).get("name") == name:
+                    return c["data"]["key"]
+            if len(chunk) < 100:
+                return None
+            start += 100
+    except Exception:
+        return None
+
+
 def _ensure_zotero_collection(registry, cluster, slug: str, report: AutoReport, print_progress: bool) -> None:
     """Auto-create + bind a Zotero collection so `ingest` has a target.
 
     Best-effort: skips silently if Zotero is not configured (analyst persona,
     or RESEARCH_HUB_NO_ZOTERO=1). This keeps the lazy-mode promise that
     `auto "topic"` can run end-to-end without a manual `clusters bind`.
+
+    v0.68.4: probes Zotero for an existing collection with this name before
+    creating, to prevent accumulating duplicate empty collections.
     """
     import os
     if os.environ.get("RESEARCH_HUB_NO_ZOTERO") == "1":
@@ -452,6 +484,13 @@ def _ensure_zotero_collection(registry, cluster, slug: str, report: AutoReport, 
         # Zotero directly. Both expose create_collections() that takes a
         # list[dict]; pass the minimal {"name": ...} payload only.
         web = getattr(zot, "web", None) or zot
+        existing_key = _find_existing_collection_key_by_name(web, cluster.name)
+        if existing_key:
+            cluster.zotero_collection_key = existing_key
+            registry.save()
+            _step_log(report, "zotero.bind", True, 0.0,
+                      f"reused existing collection {existing_key} for {slug}", print_progress)
+            return
         result = web.create_collections([{"name": cluster.name}])
         # pyzotero returns {"successful": {"0": {"key": "ABC123", ...}}, ...}
         successful = (result or {}).get("successful", {}) if isinstance(result, dict) else {}

--- a/src/research_hub/init_wizard.py
+++ b/src/research_hub/init_wizard.py
@@ -210,6 +210,7 @@ def run_init(
             print("  Opening https://www.zotero.org/settings/keys in your browser.")
             print("  Log in, click 'Create new private key', enable Library Read/Write,")
             print("  then copy the key + library ID back here.")
+            print("  If Zotero shows 'Access denied', click 'Log In' first, then reopen the keys page.")
             try:
                 import webbrowser
 

--- a/src/research_hub/setup_command.py
+++ b/src/research_hub/setup_command.py
@@ -74,7 +74,7 @@ def run_setup(args) -> int:
             persona = str(get_config().persona or "researcher").strip().lower()
         except Exception:
             persona = "researcher"
-    if not args.skip_login and persona not in {"analyst", "internal"}:
+    if not interactive and not args.skip_login and persona not in {"analyst", "internal"}:
         print("[setup] Launching NotebookLM login (Ctrl-C to skip)...")
         try:
             run_notebooklm_login()

--- a/tests/test_v062_setup_command.py
+++ b/tests/test_v062_setup_command.py
@@ -32,6 +32,38 @@ def test_setup_runs_init_then_install_then_login(monkeypatch):
     assert calls == ["init", "install:codex", "login"]
 
 
+def test_interactive_setup_does_not_launch_second_login(monkeypatch):
+    from research_hub import setup_command
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "research_hub.init_wizard.run_init",
+        lambda **kwargs: calls.append("init") or 0,
+    )
+    monkeypatch.setattr(
+        "research_hub.cli._cmd_install",
+        lambda args: calls.append(f"install:{args.platform}") or 0,
+    )
+    monkeypatch.setattr(
+        setup_command,
+        "run_notebooklm_login",
+        lambda: calls.append("login") or 0,
+    )
+    monkeypatch.setattr(setup_command, "detect_host", lambda: "claude-code")
+
+    args = SimpleNamespace(
+        vault=None,
+        persona=None,
+        skip_install=False,
+        skip_login=False,
+        skip_sample=True,
+        platform=None,
+        no_browser=False,
+    )
+    assert setup_command.run_setup(args) == 0
+    assert calls == ["init", "install:claude-code"]
+
+
 def test_setup_skip_install_and_skip_login(monkeypatch):
     from research_hub import setup_command
 

--- a/tests/test_v065_setup_validation.py
+++ b/tests/test_v065_setup_validation.py
@@ -66,7 +66,12 @@ def test_run_setup_persona_fallback_when_config_read_fails(monkeypatch):
     )
 
     assert setup_command.run_setup(args) == 0
-    assert calls == ["login"]
+    # v0.68.4: with persona="" the setup is interactive (vault+persona
+    # bound check fails), so the new guard skips the second login launch
+    # — run_init is responsible for it in interactive mode. Previously
+    # this assertion was calls==["login"] because the unconditional
+    # second launch was the bug being fixed (PR #11).
+    assert calls == []
 
 
 def test_run_setup_sample_run_keyboard_interrupt_handled(monkeypatch, capsys):

--- a/tests/test_v068_4_no_duplicate_zotero_collections.py
+++ b/tests/test_v068_4_no_duplicate_zotero_collections.py
@@ -1,0 +1,104 @@
+"""v0.68.4 regression — auto pipeline previously POSTed a new Zotero
+collection on every run that lacked a recorded cluster.zotero_collection_key.
+
+Real incident: 283 empty orphan collections accumulated in the maintainer's
+real Zotero library over months (`test-topic` x 112, `persona-a-test` x 81,
+`Flood Risk` x 5, etc.) because tests + retries + manual collection deletes
+left clusters with no recorded key, and the next run blindly POSTed.
+
+Fix: `_ensure_zotero_collection` now probes Zotero for an existing
+collection with the same name before creating a new one.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from research_hub.auto import _ensure_zotero_collection, AutoReport
+
+
+def _make_web_with_existing(name: str, key: str):
+    """Mock pyzotero web client whose `collections()` returns one entry
+    matching `name`. spec= prevents MagicMock auto-creating a `.web`
+    attribute (the production code does `getattr(zot, 'web', None) or zot`
+    to unwrap the dual-client wrapper; without spec, MagicMock auto-creates
+    the inner `.web` and the unwrap picks that instead of the mock)."""
+    web = MagicMock(spec=["collections", "create_collections"])
+    web.collections.return_value = [{"data": {"key": key, "name": name}}]
+    return web
+
+
+def _make_web_with_no_match():
+    web = MagicMock(spec=["collections", "create_collections"])
+    web.collections.return_value = []
+    web.create_collections.return_value = {
+        "successful": {"0": {"key": "NEWKEY1", "data": {"key": "NEWKEY1"}}}
+    }
+    return web
+
+
+def test_ensure_zotero_collection_reuses_existing_by_name(monkeypatch):
+    web = _make_web_with_existing(name="My Cluster", key="EXISTING")
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: web)
+
+    cluster = SimpleNamespace(name="My Cluster", zotero_collection_key=None)
+    registry = MagicMock()
+    report = AutoReport(cluster_created=False, cluster_slug="my-cluster")
+
+    _ensure_zotero_collection(registry, cluster, "my-cluster", report, print_progress=False)
+
+    assert cluster.zotero_collection_key == "EXISTING"
+    web.create_collections.assert_not_called()  # this is the regression we are
+                                                # preventing — must NOT create
+                                                # a duplicate when name matches
+    registry.save.assert_called_once()
+    assert report.steps[-1].name == "zotero.bind"
+    assert report.steps[-1].ok is True
+    assert "reused" in report.steps[-1].detail.lower()
+
+
+def test_ensure_zotero_collection_creates_when_no_match(monkeypatch):
+    web = _make_web_with_no_match()
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: web)
+
+    cluster = SimpleNamespace(name="Brand New Topic", zotero_collection_key=None)
+    registry = MagicMock()
+    report = AutoReport(cluster_created=False, cluster_slug="brand-new-topic")
+
+    _ensure_zotero_collection(registry, cluster, "brand-new-topic", report, print_progress=False)
+
+    assert cluster.zotero_collection_key == "NEWKEY1"
+    web.create_collections.assert_called_once()
+    args = web.create_collections.call_args[0][0]
+    assert args == [{"name": "Brand New Topic"}]
+
+
+def test_ensure_zotero_collection_does_not_create_on_pagination_match(monkeypatch):
+    """Match must be found even if it's on a later page (collections > 100)."""
+    web = MagicMock(spec=["collections", "create_collections"])
+    page1 = [{"data": {"key": f"K{i}", "name": f"unrelated-{i}"}} for i in range(100)]
+    page2 = [{"data": {"key": "MATCH", "name": "Target"}}]
+    web.collections.side_effect = [page1, page2]
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: web)
+
+    cluster = SimpleNamespace(name="Target", zotero_collection_key=None)
+    registry = MagicMock()
+    report = AutoReport(cluster_created=False, cluster_slug="target")
+
+    _ensure_zotero_collection(registry, cluster, "target", report, print_progress=False)
+
+    assert cluster.zotero_collection_key == "MATCH"
+    web.create_collections.assert_not_called()
+
+
+def test_ensure_zotero_collection_skips_when_no_zotero_env(monkeypatch):
+    monkeypatch.setenv("RESEARCH_HUB_NO_ZOTERO", "1")
+    cluster = SimpleNamespace(name="X", zotero_collection_key=None)
+    registry = MagicMock()
+    report = AutoReport(cluster_created=False, cluster_slug="x")
+
+    _ensure_zotero_collection(registry, cluster, "x", report, print_progress=False)
+
+    assert cluster.zotero_collection_key is None
+    registry.save.assert_not_called()

--- a/tests/test_v068_4_no_duplicate_zotero_collections.py
+++ b/tests/test_v068_4_no_duplicate_zotero_collections.py
@@ -92,6 +92,25 @@ def test_ensure_zotero_collection_does_not_create_on_pagination_match(monkeypatc
     web.create_collections.assert_not_called()
 
 
+def test_ensure_zotero_collection_matches_case_insensitively(monkeypatch):
+    """Code-review follow-up W1: Zotero web UI lets users rename to
+    case-only-different forms ("Flood Risk" vs "flood risk"). Without
+    case-folding, the probe misses such matches and we leak duplicates
+    from the same root-cause class as the original incident."""
+    web = MagicMock(spec=["collections", "create_collections"])
+    web.collections.return_value = [{"data": {"key": "EXISTING_LOWER", "name": "flood risk"}}]
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: web)
+
+    cluster = SimpleNamespace(name="Flood Risk", zotero_collection_key=None)
+    registry = MagicMock()
+    report = AutoReport(cluster_created=False, cluster_slug="flood-risk")
+
+    _ensure_zotero_collection(registry, cluster, "flood-risk", report, print_progress=False)
+
+    assert cluster.zotero_collection_key == "EXISTING_LOWER"
+    web.create_collections.assert_not_called()
+
+
 def test_ensure_zotero_collection_skips_when_no_zotero_env(monkeypatch):
     monkeypatch.setenv("RESEARCH_HUB_NO_ZOTERO", "1")
     cluster = SimpleNamespace(name="X", zotero_collection_key=None)


### PR DESCRIPTION
## Summary

Two independent fixes from a single user-reported incident.

- **fix(setup)**: `research-hub setup` was launching the NotebookLM Google login twice (once from `run_init()`, once from `run_setup()`). Gate the second launch behind non-interactive mode. Also add an inline tip in init_wizard for the common case where `zotero.org/settings/keys` returns "Access denied" because the browser isn't logged in to Zotero (not because the API key is bad).
- **fix(auto)**: `_ensure_zotero_collection` POSTed a new collection on every call without checking for an existing one with the same name. Real incident: 283 empty orphan collections accumulated in the maintainer's library — `test-topic` x 112, `persona-a-test` x 81, `Flood Risk` x 5, etc. — over months of test runs + retries + manual collection deletes that left clusters with no recorded `zotero_collection_key`. Fix: probe `web.collections()` by exact name first, reuse if found.

## Test plan

- [x] `pytest tests/test_v062_setup_command.py tests/test_v064_zotero_url_open.py tests/test_v065_nlm_login_diag.py -q` → 12 passed
- [x] `pytest tests/test_v046_auto.py tests/test_v049_auto_polish.py tests/test_v068_4_no_duplicate_zotero_collections.py -q` → 24 passed
- [x] `python -m research_hub doctor` → all OK / INFO, no FAIL
- [x] New regression: `tests/test_v068_4_no_duplicate_zotero_collections.py` (4 tests)
- [x] New regression: `test_interactive_setup_does_not_launch_second_login` in `tests/test_v062_setup_command.py`

## Notes

- Sandbox-blocked the maintainer's Zotero cleanup of the 283 orphan collections; that's a one-shot data cleanup the user will run manually with `cleanup_orphan_empty_zotero_collections.py`.
- Branch was created locally on top of master because direct push was blocked. Local master has these 2 commits ahead but origin/master is unchanged — will reconcile after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)