### PR TITLE
feat(v0.68.4): hub tag completeness + README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
 ![research-hub dashboard demo, real screen recording](docs/images/dashboard-walkthrough.gif)
 
 [![PyPI](https://img.shields.io/pypi/v/research-hub-pipeline.svg)](https://pypi.org/project/research-hub-pipeline/)
-[![Tests](https://img.shields.io/badge/tests-1759%20passing-brightgreen.svg)](docs/audit_v0.45.md)
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](pyproject.toml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
+[![Zotero](https://img.shields.io/badge/Zotero-CC2936?logo=zotero&logoColor=white)](https://www.zotero.org/)
+[![Obsidian](https://img.shields.io/badge/Obsidian-7C3AED?logo=obsidian&logoColor=white)](https://obsidian.md/)
+[![NotebookLM](https://img.shields.io/badge/NotebookLM-4285F4?logo=google&logoColor=white)](https://notebooklm.google.com/)
 
 Traditional Chinese: [README.zh-TW.md](README.zh-TW.md) | [Watch the full-res mp4](docs/demo/dashboard-walkthrough.mp4)
 
@@ -295,11 +298,10 @@ Docs: [First 10 minutes](docs/first-10-minutes.md), [lazy mode](docs/lazy-mode.m
 
 Status:
 
-- Latest: v0.64.2; see [CHANGELOG](CHANGELOG.md) for package history.
-- Tests: 1759 passing.
+- Latest: v0.68.3; see [CHANGELOG](CHANGELOG.md) for package history.
 - MCP tools: 83.
 - REST endpoints: 12 at `/api/v1/*`.
-- Bundled skills: `research-hub` and `research-hub-multi-ai`.
+- Bundled skills: 9 (see `skills/` directory).
 
 Developer setup:
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -3,9 +3,17 @@
 > **把你的研究工具變成 AI 可以操作的工作區。**
 > 你可以同時使用 Zotero、Obsidian、NotebookLM，也可以先從任意兩個工具開始。research-hub 提供 CLI、MCP server、REST API、Dashboard，讓 AI 助手能重複執行文獻搜尋、整理、摘要與維護流程。
 
-[English README](README.md) | [完整示範影片](docs/demo/dashboard-walkthrough.mp4)
-
 ![research-hub dashboard demo](docs/images/dashboard-walkthrough.gif)
+
+[![PyPI](https://img.shields.io/pypi/v/research-hub-pipeline.svg)](https://pypi.org/project/research-hub-pipeline/)
+[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](pyproject.toml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
+[![Zotero](https://img.shields.io/badge/Zotero-CC2936?logo=zotero&logoColor=white)](https://www.zotero.org/)
+[![Obsidian](https://img.shields.io/badge/Obsidian-7C3AED?logo=obsidian&logoColor=white)](https://obsidian.md/)
+[![NotebookLM](https://img.shields.io/badge/NotebookLM-4285F4?logo=google&logoColor=white)](https://notebooklm.google.com/)
+
+[English README](README.md) | [完整示範影片](docs/demo/dashboard-walkthrough.mp4)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.68.3"
+version = "0.68.4"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.68.3"
+__version__ = "0.68.4"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/discover.py
+++ b/src/research_hub/discover.py
@@ -806,22 +806,44 @@ def _to_papers_input(candidates: list[dict], cluster_slug: str | None) -> list[d
             value = str(pub_type).strip()
             if value:
                 tags.append(f"type/{value}")
+        # v0.68.4: propagate the search backend so _compose_hub_tags can
+        # emit src/<backend>. Previously dropped here, leaving every paper
+        # with only research-hub + cluster/<slug> tags (2/4 namespaces).
+        backend_source = candidate.get("source") or candidate.get("found_in") or ""
+
+        # v0.68.4: when the backend returned a real abstract, seed the note
+        # fields with it instead of TODO skeletons. Reviewers can still edit,
+        # but they have actual content to start from.
+        abstract_text = candidate.get("abstract") or ""
+        has_real_abstract = bool(abstract_text.strip()) and abstract_text.strip().lower() not in {"(no abstract)", "no abstract"}
+
+        if has_real_abstract:
+            summary_text = abstract_text[:500]
+            key_findings = ["[review and extract from Abstract section above]"]
+            methodology_text = "[review abstract; refine after reading PDF]"
+        else:
+            summary_text = f"[TODO] {title}"[:200]
+            key_findings = ["[TODO: fill from abstract]"]
+            methodology_text = "[TODO: fill from abstract]"
+
         entry = {
             "title": title,
             "doi": doi,
             "authors": _authors_to_creators(names),
             "year": candidate.get("year") or 0,
-            "abstract": candidate.get("abstract") or "(no abstract)",
+            "abstract": abstract_text or "(no abstract)",
             "journal": candidate.get("venue") or "preprint",
             "slug": slug,
             "sub_category": cluster_slug or "",
-            "summary": f"[TODO] {title}"[:200],
-            "key_findings": ["[TODO: fill from abstract]"],
-            "methodology": "[TODO: fill from abstract]",
+            "summary": summary_text,
+            "key_findings": key_findings,
+            "methodology": methodology_text,
             "relevance": "[TODO: fill relevance to cluster]",
             "tags": tags,
         }
         if arxiv_id:
             entry["arxiv_id"] = arxiv_id
+        if backend_source:
+            entry["source"] = backend_source
         papers.append(entry)
     return papers

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -39,9 +39,11 @@ def _compose_hub_tags(pp: dict, cluster_slug: str | None) -> list[str]:
     cluster_token = (str(cluster_slug).strip() if cluster_slug is not None else "")
     if cluster_token and cluster_token.lower() not in {"none", "null"}:
         hub_tags.append(f"cluster/{cluster_token}")
-    doc_type = pp.get("doc_type") or pp.get("publication_type")
-    if doc_type:
-        hub_tags.append(f"type/{doc_type}")
+    # v0.68.4: default to journalArticle when the search backend didn't
+    # supply a doc_type — the pipeline always creates journalArticle items
+    # (see pipeline.py zot.item_template call), so this matches reality.
+    doc_type = pp.get("doc_type") or pp.get("publication_type") or "journalArticle"
+    hub_tags.append(f"type/{doc_type}")
     backend = pp.get("source") or pp.get("found_in")
     if backend:
         hub_tags.append(f"src/{backend}")

--- a/tests/test_cli_search.py
+++ b/tests/test_cli_search.py
@@ -65,7 +65,9 @@ def test_cli_search_to_papers_input_produces_ingest_ready_shape(tmp_path, monkey
     assert payload[0]["sub_category"] == "foo-bar"
     assert payload[0]["slug"]
     assert payload[0]["authors"][0]["lastName"] == "Doe"
-    assert payload[0]["summary"].startswith("[TODO]")
+    # v0.68.4: when the search backend returned a real abstract, the
+    # summary is seeded from it instead of the old "[TODO] <title>" stub.
+    assert payload[0]["summary"] == "Abstract"
 
 
 def test_cli_search_year_range_parses_2024_2025():

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -304,6 +304,11 @@ def test_discover_continue_papers_input_has_creator_dict_authors(tmp_path):
 
 
 def test_discover_continue_papers_input_has_todo_placeholders(tmp_path):
+    """v0.68.4: when the search backend returned a real abstract,
+    summary is now seeded from it ("Abstract one.") and methodology
+    becomes "[review abstract; refine after reading PDF]" — TODO marker
+    only appears now when the abstract is genuinely empty. relevance is
+    still TODO because the backend can't infer cluster fit."""
     from research_hub.discover import discover_continue
 
     cfg = _write_state_and_candidates(tmp_path)
@@ -315,9 +320,10 @@ def test_discover_continue_papers_input_has_todo_placeholders(tmp_path):
     )
     payload = json.loads(out_path.read_text(encoding="utf-8"))
 
-    assert payload[0]["summary"].startswith("[TODO]")
+    assert payload[0]["summary"] == "Abstract one."
     assert payload[0]["key_findings"]
-    assert payload[0]["methodology"].startswith("[TODO:")
+    assert "review abstract" in payload[0]["methodology"]
+    assert payload[0]["relevance"].startswith("[TODO")
 
 
 def test_compute_auto_threshold_median_minus_one():

--- a/tests/test_init_wizard.py
+++ b/tests/test_init_wizard.py
@@ -93,6 +93,12 @@ def test_init_interactive_prompts(tmp_path, monkeypatch, capsys):
     )
     # v0.62: mandatory NLM login auto-launches when chrome_ok; stub it out
     monkeypatch.setattr("research_hub.setup_command.run_notebooklm_login", lambda: None)
+    # v0.68.4: stub webbrowser.open so the test does not actually launch a
+    # real browser to https://www.zotero.org/settings/keys when the user
+    # hasn't pre-supplied a key. (Test was popping the page on every full
+    # `pytest` run.)
+    browser_calls: list[str] = []
+    monkeypatch.setattr("webbrowser.open", lambda url, *a, **k: browser_calls.append(url) or True)
 
     assert init_wizard.run_init() == 0
 
@@ -112,6 +118,11 @@ def test_init_interactive_prompts(tmp_path, monkeypatch, capsys):
     ]
     assert "First-run readiness check" in output
     assert "patchright can launch Chrome" in output
+    # v0.68.4: regression — interactive flow MUST route through the
+    # mocked webbrowser.open (not pop a real browser). This test was
+    # actually launching the Zotero keys page on every full pytest run
+    # before the mock was added.
+    assert browser_calls == ["https://www.zotero.org/settings/keys"]
 
 
 def test_init_creates_vault_subdirs(tmp_path, monkeypatch):

--- a/tests/test_v061_pipeline_tags.py
+++ b/tests/test_v061_pipeline_tags.py
@@ -2,11 +2,17 @@ from research_hub.pipeline import _compose_hub_tags
 
 
 def test_compose_hub_tags_minimum_includes_research_hub():
-    assert _compose_hub_tags({}, None) == ["research-hub"]
+    # v0.68.4: type/journalArticle is now a default; pipeline always
+    # creates that Zotero item type so the tag now matches reality.
+    assert _compose_hub_tags({}, None) == ["research-hub", "type/journalArticle"]
 
 
 def test_compose_hub_tags_with_cluster():
-    assert _compose_hub_tags({}, "my-slug") == ["research-hub", "cluster/my-slug"]
+    assert _compose_hub_tags({}, "my-slug") == [
+        "research-hub",
+        "cluster/my-slug",
+        "type/journalArticle",
+    ]
 
 
 def test_compose_hub_tags_full_decoration():

--- a/tests/test_v061_zotero_backfill.py
+++ b/tests/test_v061_zotero_backfill.py
@@ -101,18 +101,25 @@ def test_backfill_adds_missing_hub_tags(tmp_path, monkeypatch):
     report = run_backfill(cfg, apply=True)
 
     assert report.dry_run is False
+    # v0.68.4: _compose_hub_tags now defaults type/<itemType> to
+    # journalArticle when the paper dict has no doc_type, so backfill
+    # emits one more tag than before.
     assert [tag["tag"] for tag in zot.updated[0]["tags"]] == [
         "foo",
         "research-hub",
         "cluster/agents",
+        "type/journalArticle",
         "src/zotero",
     ]
 
 
 def test_backfill_does_not_duplicate_existing_hub_tag(tmp_path, monkeypatch):
     cfg = _cfg(tmp_path)
+    # v0.68.4: include type/journalArticle in pre-existing tags since
+    # _compose_hub_tags now emits it by default — without it the backfill
+    # would add it and break the "no duplicate" assertion.
     zot = FakeZotero(
-        [_item(["foo", "research-hub", "cluster/agents", "src/zotero"])],
+        [_item(["foo", "research-hub", "cluster/agents", "type/journalArticle", "src/zotero"])],
         children=[{"data": {"itemType": "note"}}],
     )
     _patch_dual(monkeypatch, zot)

--- a/tests/test_v065_compose_tags_none_guard.py
+++ b/tests/test_v065_compose_tags_none_guard.py
@@ -10,10 +10,12 @@ from research_hub.pipeline import _compose_hub_tags
 @pytest.mark.parametrize("cluster_slug", [None, "", "   ", "None", "none", "null", "NULL"])
 def test_compose_hub_tags_skips_bogus_cluster_slug(cluster_slug):
     """None / empty / whitespace / literal None-strings must NOT produce
-    a cluster/<slug> tag."""
+    a cluster/<slug> tag. (v0.68.4: type/journalArticle default still
+    appears since the pipeline always creates that Zotero item type.)"""
     tags = _compose_hub_tags({}, cluster_slug)
-    assert tags == ["research-hub"], (
-        f"cluster_slug={cluster_slug!r} should produce only 'research-hub', got {tags}"
+    assert "research-hub" in tags
+    assert not any(t.startswith("cluster/") for t in tags), (
+        f"cluster_slug={cluster_slug!r} produced a cluster/ tag: {tags}"
     )
 
 

--- a/tests/test_v068_4_hub_tag_completeness.py
+++ b/tests/test_v068_4_hub_tag_completeness.py
@@ -1,0 +1,121 @@
+"""v0.68.4 — auto pipeline previously emitted only 2/4 hub tag namespaces
+(`research-hub` + `cluster/<slug>`) on ingested papers, leaving downstream
+queries that filter by `type/` or `src/` blind.
+
+Real incident: a real ingest of "post-flood household relocation" produced
+8 papers in Zotero collection C7S7A9KA — every paper missing both
+`type/journalArticle` and `src/<backend>` tags. Backfill required a manual
+script. These tests prevent the regression.
+
+Also covers Bug C: when the search backend returned a real abstract,
+notes were still TODO skeletons. Now the abstract seeds the summary.
+"""
+
+from __future__ import annotations
+
+from research_hub.pipeline import _compose_hub_tags
+from research_hub.discover import _to_papers_input
+
+
+def test_compose_hub_tags_defaults_type_to_journal_article():
+    """The pipeline always creates journalArticle Zotero items, so when
+    the search backend didn't supply a doc_type we should still emit
+    `type/journalArticle` rather than dropping the namespace."""
+    pp = {"title": "Some paper"}  # no doc_type, no publication_type
+    tags = _compose_hub_tags(pp, cluster_slug="my-cluster")
+    assert "type/journalArticle" in tags
+
+
+def test_compose_hub_tags_includes_src_when_backend_present():
+    pp = {"title": "Some paper", "source": "openalex"}
+    tags = _compose_hub_tags(pp, cluster_slug="my-cluster")
+    assert "src/openalex" in tags
+
+
+def test_compose_hub_tags_full_namespace_for_typical_ingest():
+    """End-to-end shape check: a paper coming from openalex into a
+    cluster should land all 4 hub tag namespaces."""
+    pp = {"title": "X", "source": "openalex"}
+    tags = _compose_hub_tags(pp, cluster_slug="post-flood-household-relocation")
+    assert set(tags) >= {
+        "research-hub",
+        "cluster/post-flood-household-relocation",
+        "type/journalArticle",
+        "src/openalex",
+    }
+
+
+def test_to_papers_input_propagates_source_field():
+    """Bug A regression: _to_papers_input dropped the `source` field
+    so _compose_hub_tags couldn't emit src/<backend>."""
+    candidate = {
+        "title": "Paper A",
+        "doi": "10.1/x",
+        "authors": ["Alice Smith"],
+        "year": 2025,
+        "abstract": "Some abstract.",
+        "source": "openalex",
+    }
+    [entry] = _to_papers_input([candidate], cluster_slug="my-cluster")
+    assert entry.get("source") == "openalex"
+
+
+def test_to_papers_input_propagates_found_in_when_source_absent():
+    candidate = {
+        "title": "Paper B",
+        "doi": "10.1/y",
+        "authors": ["Bob Jones"],
+        "year": 2025,
+        "abstract": "Abstract",
+        "found_in": "crossref",  # alternate field name some backends use
+    }
+    [entry] = _to_papers_input([candidate], cluster_slug="c")
+    assert entry.get("source") == "crossref"
+
+
+def test_to_papers_input_seeds_summary_with_real_abstract():
+    """Bug C regression: when the backend returned a real abstract,
+    summary was still '[TODO] <title>' instead of the abstract content."""
+    abstract = "We study how households relocate after major floods using survey data from 1200 respondents."
+    candidate = {
+        "title": "Household relocation post-flood",
+        "doi": "10.1/z",
+        "authors": ["Chen Li"],
+        "year": 2025,
+        "abstract": abstract,
+        "source": "openalex",
+    }
+    [entry] = _to_papers_input([candidate], cluster_slug="c")
+    assert "TODO" not in entry["summary"]
+    assert entry["summary"].startswith("We study how households relocate")
+
+
+def test_to_papers_input_keeps_todo_when_no_abstract():
+    """When backend genuinely has no abstract, fall back to TODO marker
+    so the user sees an explicit prompt to fill it in."""
+    candidate = {
+        "title": "No-abstract paper",
+        "doi": "10.1/w",
+        "authors": ["Ed Long"],
+        "year": 2025,
+        "abstract": "",
+        "source": "semantic-scholar",
+    }
+    [entry] = _to_papers_input([candidate], cluster_slug="c")
+    assert "TODO" in entry["summary"]
+    assert entry["abstract"] == "(no abstract)"
+
+
+def test_to_papers_input_treats_no_abstract_string_as_missing():
+    """Some backends literally return the string '(no abstract)' rather
+    than empty — treat that as missing too."""
+    candidate = {
+        "title": "Sentinel-string paper",
+        "doi": "10.1/v",
+        "authors": ["Faye Zhao"],
+        "year": 2025,
+        "abstract": "(no abstract)",
+        "source": "arxiv",
+    }
+    [entry] = _to_papers_input([candidate], cluster_slug="c")
+    assert "TODO" in entry["summary"]


### PR DESCRIPTION
## Summary

Three bugs in the auto pipeline left ingested papers with only 2/4 hub tag namespaces (`research-hub` + `cluster/<slug>`) and TODO-skeleton notes even when the search backend returned a real abstract.

- **Bug A**: `discover.py:_to_papers_input` dropped `source` field → `src/<backend>` tag never emitted
- **Bug B**: `pipeline.py:_compose_hub_tags` skipped `type/` namespace when search backend returned no `doc_type` → default to `type/journalArticle` since the pipeline always creates that Zotero item type
- **Bug C**: TODO-skeleton notes shadowed real abstracts → seed summary from abstract when available

Plus two small UX items from the same incident:
- README: drop hardcoded "Tests: 1759 passing" status (auto-stale), add Zotero / Obsidian / NotebookLM badges
- README.zh-TW: mirror the badge row

Bumps version 0.68.3 → 0.68.4.

## Real-incident impact

`auto` run for "post-flood household relocation" produced 8 papers in Zotero collection C7S7A9KA. Every paper missing both `type/` and `src/` tags. Every note was a TODO skeleton. Manual backfill via OpenAlex DOI lookup recovered 5 of 6 missing abstracts; 1 paper (Maharjan 2025, niche IJDRR journal) had no abstract from any backend.

## Test plan

- [x] `pytest tests/test_v068_4_hub_tag_completeness.py -v` → 8 passed
- [x] `pytest tests/test_v065_compose_tags_none_guard.py tests/test_v063_search_tags.py tests/test_v061_pipeline_tags.py tests/test_v041_search_to_input.py tests/test_v068_3_version_sync.py -q` → 24 passed (regression + new contract)
- [x] `pytest tests/test_pipeline_e2e.py tests/test_cli_search.py -q` → 32 passed
- [x] `pytest tests/test_init_wizard.py -q` → 10 passed (browser mock added; no real launch on full pytest)

## Notes

- This is a separate concern from PR #11 (setup/browser-login fix). They share an incident report but the diff doesn't overlap.
- v0.68.3 → v0.68.4 — guard rail tests in `test_v068_3_version_sync.py` still pass with the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)