### PR TITLE
fix(v0.68.5): plumb volume/issue/pages end-to-end + block real browser opens in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.68.4"
+version = "0.68.5"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.68.4"
+__version__ = "0.68.5"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/discover.py
+++ b/src/research_hub/discover.py
@@ -840,6 +840,13 @@ def _to_papers_input(candidates: list[dict], cluster_slug: str | None) -> list[d
             "methodology": methodology_text,
             "relevance": "[TODO: fill relevance to cluster]",
             "tags": tags,
+            # v0.68.5: propagate bibliographic locator fields end-to-end so
+            # Zotero items + Obsidian frontmatter get complete citation
+            # metadata. Backends that don't return these (arxiv volume/issue,
+            # most semantic-scholar hits) leave them as "".
+            "volume": str(candidate.get("volume") or ""),
+            "issue": str(candidate.get("issue") or ""),
+            "pages": str(candidate.get("pages") or ""),
         }
         if arxiv_id:
             entry["arxiv_id"] = arxiv_id

--- a/src/research_hub/search/arxiv_backend.py
+++ b/src/research_hub/search/arxiv_backend.py
@@ -113,6 +113,18 @@ class ArxivBackend:
         published = entry.findtext("atom:published", default="", namespaces=_NS)
         year = int(published[:4]) if len(published) >= 4 and published[:4].isdigit() else None
         doi = entry.findtext("arxiv:doi", default="", namespaces=_NS) or ""
+
+        # v0.68.5: arXiv preprints have no journal volume/issue. The
+        # `arxiv:comment` field sometimes contains a "<n> pages" hint
+        # (e.g. "12 pages, 5 figures") which is the closest analog to a
+        # page count for unpublished work. Capture only the digit when the
+        # comment matches; leave volume/issue empty (no analog exists).
+        comment = entry.findtext("arxiv:comment", default="", namespaces=_NS) or ""
+        pages = ""
+        page_match = re.search(r"(\d+)\s*pages?\b", comment, re.IGNORECASE)
+        if page_match:
+            pages = page_match.group(1)
+
         return SearchResult(
             title=_collapse_whitespace(entry.findtext("atom:title", default="", namespaces=_NS)),
             doi=doi,
@@ -133,6 +145,7 @@ class ArxivBackend:
             pdf_url=f"https://arxiv.org/pdf/{arxiv_id}.pdf",
             source=self.name,
             categories=_extract_categories(entry),
+            pages=pages,
         )
 
     def _parse_feed(self, xml_text: str) -> list[SearchResult]:

--- a/src/research_hub/search/base.py
+++ b/src/research_hub/search/base.py
@@ -26,6 +26,13 @@ class SearchResult:
     doc_type: str = ""
     categories: list[str] = field(default_factory=list)
     publication_types: list[str] = field(default_factory=list)
+    # v0.68.5: bibliographic locator fields. Populated by openalex/crossref
+    # when the API returns them; left "" by arxiv (preprints have no journal
+    # volume/issue) and by semantic-scholar when its `journal` block is absent.
+    # Required for complete citations (Author year. Title. Journal vol(issue):pp).
+    volume: str = ""
+    issue: str = ""
+    pages: str = ""
 
     @classmethod
     def from_s2_json(cls, item: dict) -> "SearchResult":
@@ -42,6 +49,11 @@ class SearchResult:
             arxiv_id = arxiv_id.split(":", 1)[1]
         if "v" in arxiv_id and arxiv_id.startswith(tuple(str(i) for i in range(10))):
             arxiv_id = arxiv_id.split("v", 1)[0]
+        # v0.68.5: Semantic Scholar exposes journal locator fields under the
+        # `journal` block. The block is optional and inconsistently populated;
+        # fall back to "" when absent so downstream writers (Zotero, Obsidian)
+        # see a real string rather than None.
+        journal = item.get("journal") or {}
         return cls(
             title=item.get("title") or "",
             doi=external_ids.get("DOI", "") or "",
@@ -60,6 +72,8 @@ class SearchResult:
                 for pub_type in (item.get("publicationTypes") or [])[:3]
                 if str(pub_type).strip()
             ],
+            volume=str(journal.get("volume") or ""),
+            pages=str(journal.get("pages") or ""),
         )
 
     @property

--- a/src/research_hub/search/crossref.py
+++ b/src/research_hub/search/crossref.py
@@ -64,7 +64,10 @@ class CrossrefBackend:
         params: dict[str, str | int] = {
             "query": query,
             "rows": min(limit, 100),
-            "select": "DOI,title,author,issued,container-title,type,is-referenced-by-count",
+            "select": (
+                "DOI,title,author,issued,container-title,type,is-referenced-by-count,"
+                "volume,issue,page"
+            ),
         }
         filters = []
         if year_from is not None:
@@ -117,6 +120,9 @@ class CrossrefBackend:
         venue_list = work.get("container-title") or []
         venue = venue_list[0] if venue_list else ""
         doi = (work.get("DOI") or "").lower()
+        # v0.68.5: Crossref returns `page` as a single string already in the
+        # canonical "first-last" form (e.g. "123-145"). volume / issue may be
+        # missing for some doc types; fall back to "" rather than None.
         return SearchResult(
             title=title,
             doi=doi,
@@ -128,4 +134,7 @@ class CrossrefBackend:
             citation_count=int(work.get("is-referenced-by-count", 0) or 0),
             source=self.name,
             doc_type=work.get("type", "") or "",
+            volume=str(work.get("volume") or ""),
+            issue=str(work.get("issue") or ""),
+            pages=str(work.get("page") or ""),
         )

--- a/src/research_hub/search/openalex.py
+++ b/src/research_hub/search/openalex.py
@@ -90,6 +90,19 @@ class OpenAlexBackend:
                 arxiv_id = match.group(1)
                 break
 
+        # v0.68.5: extract bibliographic locator fields from the `biblio`
+        # block. OpenAlex stores them as strings (e.g. {"volume":"45",
+        # "issue":"3","first_page":"123","last_page":"145"}); join first/last
+        # into the canonical "123-145" pages form, fall back to first_page
+        # alone when last_page is empty.
+        biblio = work.get("biblio") or {}
+        first_page = str(biblio.get("first_page") or "").strip()
+        last_page = str(biblio.get("last_page") or "").strip()
+        if first_page and last_page and first_page != last_page:
+            pages = f"{first_page}-{last_page}"
+        else:
+            pages = first_page or last_page
+
         return SearchResult(
             title=work.get("title") or "",
             doi=doi,
@@ -111,6 +124,9 @@ class OpenAlexBackend:
             ),
             source=self.name,
             doc_type=work.get("type", "") or "",
+            volume=str(biblio.get("volume") or ""),
+            issue=str(biblio.get("issue") or ""),
+            pages=pages,
         )
 
     def search(
@@ -126,7 +142,7 @@ class OpenAlexBackend:
             "per-page": min(limit, 200),
             "select": (
                 "id,doi,title,publication_year,authorships,primary_location,locations,"
-                "cited_by_count,abstract_inverted_index,open_access,type"
+                "cited_by_count,abstract_inverted_index,open_access,type,biblio"
             ),
             "mailto": _MAILTO,
         }
@@ -174,7 +190,7 @@ class OpenAlexBackend:
                     "per-page": 1,
                     "select": (
                         "id,doi,title,publication_year,authorships,primary_location,locations,"
-                        "cited_by_count,abstract_inverted_index,open_access,type"
+                        "cited_by_count,abstract_inverted_index,open_access,type,biblio"
                     ),
                     "mailto": _MAILTO,
                 },

--- a/src/research_hub/search/semantic_scholar.py
+++ b/src/research_hub/search/semantic_scholar.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 
 SEMANTIC_SCHOLAR_BASE = "https://api.semanticscholar.org/graph/v1"
 DEFAULT_FIELDS = (
-    "title,abstract,year,authors,externalIds,venue,citationCount,url,openAccessPdf,publicationTypes"
+    "title,abstract,year,authors,externalIds,venue,citationCount,url,openAccessPdf,publicationTypes,"
+    "journal"
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,25 @@ def pytest_configure(config) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _block_real_webbrowser_open(monkeypatch):
+    """v0.68.5: globally stub `webbrowser.open` for every test.
+
+    Several init_wizard / setup_command interactive tests call into code
+    paths that do `webbrowser.open("https://www.zotero.org/settings/keys")`
+    or `webbrowser.open("http://...dashboard...")`. Without a global stub,
+    a full `pytest` run would launch a real browser tab on every such test
+    — observed in CI logs and on the maintainer's machine. The previous
+    per-file stub only covered one test.
+
+    Tests that need to ASSERT a webbrowser.open was called can re-patch it
+    locally with their own monkeypatch.setattr — the per-test patch wins
+    over this autouse one.
+    """
+    import webbrowser
+    monkeypatch.setattr(webbrowser, "open", lambda *args, **kwargs: True)
+
+
 @pytest.fixture
 def reset_research_hub_modules():
     """Returns a callable that resets named research_hub.* submodules.

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -483,6 +483,10 @@ def test_mcp_enrich_candidates_resolves_doi(monkeypatch):
             "doc_type": "",
             "categories": [],
             "publication_types": [],
+            # v0.68.5: SearchResult gained these 3 bibliographic locator fields.
+            "volume": "",
+            "issue": "",
+            "pages": "",
         }
     ]
 

--- a/tests/test_v068_5_metadata_completeness.py
+++ b/tests/test_v068_5_metadata_completeness.py
@@ -1,0 +1,230 @@
+"""v0.68.5 — bibliographic locator fields (volume, issue, pages) must
+flow end-to-end from search backend → SearchResult → papers_input dict.
+
+Real incident: 8 ingested flood-relocation papers all had empty
+volume/issue/pages in Zotero + Obsidian, even though OpenAlex and
+Crossref returned the data. Root cause: SearchResult dataclass had no
+fields for them, so backends couldn't populate even if they wanted to.
+
+Tests target each integration point:
+  1. SearchResult dataclass exposes the three fields
+  2. Each of the 4 backends extracts them when present in API response
+  3. _to_papers_input propagates them into the ingest dict
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from research_hub.discover import _to_papers_input
+from research_hub.search.base import SearchResult
+from research_hub.search.crossref import CrossrefBackend
+from research_hub.search.openalex import OpenAlexBackend
+from research_hub.search.arxiv_backend import ArxivBackend
+
+
+def test_searchresult_dataclass_has_volume_issue_pages_fields():
+    """v0.68.5: dataclass must expose the 3 new bibliographic fields with
+    str defaults (not None — downstream writers expect strings)."""
+    r = SearchResult(title="x")
+    assert r.volume == ""
+    assert r.issue == ""
+    assert r.pages == ""
+
+    r2 = SearchResult(title="x", volume="45", issue="3", pages="123-145")
+    assert r2.volume == "45"
+    assert r2.issue == "3"
+    assert r2.pages == "123-145"
+
+
+def test_openalex_extracts_volume_issue_pages_from_biblio():
+    """OpenAlex returns biblio.{volume,issue,first_page,last_page};
+    parser must combine first_page + last_page into 'first-last' form."""
+    client = OpenAlexBackend()
+    work = {
+        "id": "https://openalex.org/W123",
+        "doi": "https://doi.org/10.1/test",
+        "title": "Sample paper",
+        "publication_year": 2024,
+        "authorships": [],
+        "primary_location": {"source": {"display_name": "Journal X"}},
+        "locations": [],
+        "open_access": {"is_oa": False},
+        "type": "article",
+        "biblio": {
+            "volume": "45",
+            "issue": "3",
+            "first_page": "123",
+            "last_page": "145",
+        },
+    }
+    result = client._parse_work(work)
+    assert result.volume == "45"
+    assert result.issue == "3"
+    assert result.pages == "123-145"
+
+
+def test_openalex_handles_single_page_biblio():
+    """When first_page == last_page or last_page is missing, emit just
+    the first_page (no spurious 'X-X' or 'X-' form)."""
+    client = OpenAlexBackend()
+    work_single = {
+        "title": "x", "biblio": {"first_page": "42", "last_page": ""},
+        "open_access": {}, "primary_location": {},
+    }
+    assert client._parse_work(work_single).pages == "42"
+
+    work_same = {
+        "title": "x", "biblio": {"first_page": "42", "last_page": "42"},
+        "open_access": {}, "primary_location": {},
+    }
+    assert client._parse_work(work_same).pages == "42"
+
+
+def test_openalex_select_param_includes_biblio():
+    """The biblio block must be in the API request `select`, otherwise
+    OpenAlex won't return it and the parser sees nothing."""
+    import inspect
+    src = inspect.getsource(OpenAlexBackend.search)
+    assert "biblio" in src, "OpenAlex search() must request 'biblio' in select"
+
+
+def test_crossref_extracts_volume_issue_pages_from_response():
+    """Crossref returns volume/issue as strings + page in canonical
+    'first-last' form (already collapsed)."""
+    client = CrossrefBackend()
+    work = {
+        "DOI": "10.1/test",
+        "title": ["A paper"],
+        "author": [{"family": "Doe", "given": "Jane"}],
+        "issued": {"date-parts": [[2024]]},
+        "container-title": ["Journal Y"],
+        "type": "journal-article",
+        "is-referenced-by-count": 5,
+        "volume": "12",
+        "issue": "4",
+        "page": "200-215",
+    }
+    result = client._parse_work(work)
+    assert result.volume == "12"
+    assert result.issue == "4"
+    assert result.pages == "200-215"
+
+
+def test_crossref_select_param_includes_volume_issue_page():
+    import inspect
+    src = inspect.getsource(CrossrefBackend.search)
+    for token in ("volume", "issue", "page"):
+        assert token in src, f"Crossref search() must request {token!r} in select"
+
+
+def test_crossref_handles_missing_locator_fields():
+    """Some Crossref entries have no volume/issue/page — must default to ''."""
+    client = CrossrefBackend()
+    work = {
+        "DOI": "10.1/x", "title": ["x"], "author": [],
+        "issued": {"date-parts": [[2024]]}, "container-title": [],
+        "type": "journal-article",
+    }
+    result = client._parse_work(work)
+    assert result.volume == ""
+    assert result.issue == ""
+    assert result.pages == ""
+
+
+def test_semantic_scholar_extracts_volume_pages_from_journal_block():
+    """S2 returns journal.{volume,pages} when available. issue is not
+    exposed by S2's schema; leave it ''."""
+    item = {
+        "title": "Some paper",
+        "abstract": "Abstract",
+        "year": 2024,
+        "authors": [{"name": "Jane Doe"}],
+        "externalIds": {"DOI": "10.1/test"},
+        "venue": "J",
+        "journal": {"volume": "10", "pages": "1-20", "name": "J"},
+    }
+    result = SearchResult.from_s2_json(item)
+    assert result.volume == "10"
+    assert result.pages == "1-20"
+    assert result.issue == ""  # S2 doesn't expose issue
+
+
+def test_semantic_scholar_handles_missing_journal_block():
+    """When S2 omits journal entirely, all 3 fields default to ''."""
+    item = {"title": "x", "externalIds": {}}
+    result = SearchResult.from_s2_json(item)
+    assert result.volume == ""
+    assert result.issue == ""
+    assert result.pages == ""
+
+
+def test_arxiv_extracts_pages_from_comment_when_matches_pattern():
+    """arXiv has no journal volume/issue. The arxiv:comment field
+    sometimes carries '<n> pages' which is the closest analog."""
+    xml = """<entry xmlns="http://www.w3.org/2005/Atom"
+                   xmlns:arxiv="http://arxiv.org/schemas/atom">
+      <id>http://arxiv.org/abs/2401.12345v1</id>
+      <title>Sample preprint</title>
+      <summary>An abstract.</summary>
+      <published>2024-01-15T00:00:00Z</published>
+      <arxiv:comment>12 pages, 5 figures, NeurIPS 2024 submission</arxiv:comment>
+    </entry>"""
+    entry = ET.fromstring(xml)
+    client = ArxivBackend()
+    result = client._parse_entry(entry)
+    assert result is not None
+    assert result.pages == "12"
+    # arXiv preprints have no journal volume/issue
+    assert result.volume == ""
+    assert result.issue == ""
+
+
+def test_arxiv_pages_empty_when_comment_has_no_page_count():
+    xml = """<entry xmlns="http://www.w3.org/2005/Atom"
+                   xmlns:arxiv="http://arxiv.org/schemas/atom">
+      <id>http://arxiv.org/abs/2401.99999v1</id>
+      <title>x</title>
+      <summary>x</summary>
+      <published>2024-01-01T00:00:00Z</published>
+      <arxiv:comment>preliminary draft, comments welcome</arxiv:comment>
+    </entry>"""
+    entry = ET.fromstring(xml)
+    client = ArxivBackend()
+    result = client._parse_entry(entry)
+    assert result.pages == ""
+
+
+def test_to_papers_input_propagates_volume_issue_pages():
+    """End-to-end: a candidate with all 3 locator fields must surface
+    them in the ingest dict that pipeline.run_pipeline reads."""
+    candidate = {
+        "title": "Paper",
+        "doi": "10.1/x",
+        "authors": ["Jane Doe"],
+        "year": 2024,
+        "abstract": "abstract",
+        "venue": "Journal Z",
+        "source": "openalex",
+        "volume": "45",
+        "issue": "3",
+        "pages": "123-145",
+    }
+    [entry] = _to_papers_input([candidate], cluster_slug="c")
+    assert entry["volume"] == "45"
+    assert entry["issue"] == "3"
+    assert entry["pages"] == "123-145"
+
+
+def test_to_papers_input_defaults_locators_to_empty_string_when_absent():
+    """Backward-compat: candidates from older code paths that don't include
+    these keys must still produce well-formed entries (empty strings, not
+    KeyError)."""
+    candidate = {
+        "title": "Old-style", "doi": "10.1/y", "authors": [], "year": 2024,
+        "abstract": "", "venue": "", "source": "arxiv",
+    }
+    [entry] = _to_papers_input([candidate], cluster_slug="c")
+    assert entry["volume"] == ""
+    assert entry["issue"] == ""
+    assert entry["pages"] == ""


### PR DESCRIPTION
## Summary

Bibliographic locator fields (volume, issue, pages) were stubbed as empty strings all the way from search backend → Zotero + Obsidian, despite OpenAlex/Crossref returning the data. Real incident: 8 ingested flood-relocation papers all had empty volume/issue/pages.

Root cause: `SearchResult` dataclass at `search/base.py` didn't even define these fields, so no backend could populate them.

## Changes

- `search/base.py` — add `volume`, `issue`, `pages` fields to `SearchResult` (str, default "")
- `search/openalex.py` — extract from `work["biblio"]`, collapse first/last page into "first-last", add `biblio` to API select
- `search/crossref.py` — extract from `work["volume"|"issue"|"page"]`, add tokens to API select
- `search/semantic_scholar.py` — extract from `item["journal"]`, add `journal` to DEFAULT_FIELDS (issue not exposed by S2)
- `search/arxiv_backend.py` — extract pages from `arxiv:comment` regex `\d+\s*pages?` (preprints have no journal volume/issue)
- `discover.py:_to_papers_input` — propagate the 3 fields into the ingest dict

## Bonus fix

`tests/conftest.py` gains an autouse fixture that globally stubs `webbrowser.open`. Several init_wizard / setup_command tests trigger `webbrowser.open("https://zotero.org/settings/keys")` and would launch a real browser tab on every full pytest run. Tests that need to assert on webbrowser.open re-patch locally — the autouse stub is overridden cleanly.

## Test plan

- [x] `pytest tests/test_v068_5_metadata_completeness.py -v` → **13 passed** (new tests, one per backend + dataclass + propagation)
- [x] `pytest tests/test_mcp_server.py -q` → 22 passed (updated dict-shape assertion)
- [x] `pytest tests/ -q -k "not stress"` → **1918 passed, 0 failed**, 16 skipped, 2 xfailed
- [x] No real browser opens during full pytest run

## Verification (manual)

```python
from research_hub.search import SearchResult
r = SearchResult(title="x")
print(r.volume, r.issue, r.pages)  # all "" by default
```

After merge: re-run `research-hub auto "<topic>"` against a small topic, inspect Zotero collection — volume/issue/pages should be populated for openalex/crossref hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)