### PR TITLE
feat(v0.70.0): LLM-judge fit-check between search and ingest in auto pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# v0.70.0: enforce LF line endings for files that are byte-compared in CI.
+# `tests/test_v066_research_workspace_docs.py::test_packaged_skill_mirror_byte_identical`
+# diffs `skills/<name>/SKILL.md` against `src/research_hub/skills_data/<name>/SKILL.md`.
+# Without this, a Windows runner with `core.autocrlf=true` could mangle one
+# path's line endings on checkout (the other path stays LF because it's under
+# `src/`), making the byte-compare flake.
+
+# Skills (source + packaged mirror)
+skills/**/SKILL.md          text eol=lf
+skills/**/evals/evals.json  text eol=lf
+src/research_hub/skills_data/**/SKILL.md          text eol=lf
+src/research_hub/skills_data/**/evals/evals.json  text eol=lf
+
+# Python source — keep LF everywhere for cross-platform reproducibility
+*.py text eol=lf
+
+# pyproject + workflow YAML — LF (used by GitHub Actions on Linux runners)
+pyproject.toml text eol=lf
+.github/workflows/*.yml text eol=lf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.69.0"
+version = "0.70.0"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/skills/paper-memory-builder/SKILL.md
+++ b/skills/paper-memory-builder/SKILL.md
@@ -55,6 +55,10 @@ Write to `<project-root>/.paper/`:
 - `claims.yml` — every paper-level claim, with evidence pointers + status.
 - `figures.yml` — every figure inventory, with key numbers + supported
   claims.
+- `revision_history.yml` — append-only log of revision rounds (when a
+  claim or figure changed, in which round, why). See
+  `references/revision_history_schema.md` for the schema and the
+  append-vs-overwrite rules.
 
 Do **not** touch `journal_format.md`, `reviewer_comments.md`, or
 `style_overrides.md` — those belong to `academic-writing-skills`.
@@ -90,6 +94,31 @@ figures:
 ```
 
 Required per figure: `id`, `file`, `supports_claims` (may be `[]`).
+
+### `.paper/revision_history.yml` structure
+
+```yaml
+revisions:
+  - round: 1
+    date: "2026-04-15"
+    trigger: "Initial draft v1"
+    changed_claims: []          # all claims new
+    changed_figures: []
+    summary: "First complete draft."
+  - round: 2
+    date: "2026-05-02"
+    trigger: "Reviewer 2 round 1: doubt on calibration window"
+    changed_claims: ["C1", "C4"]
+    changed_figures: ["Fig3"]
+    summary: "Tightened calibration window claim, added robustness check (Fig S3), softened C4 claim wording."
+```
+
+Required per revision: `round`, `date`, `trigger`, `summary`.
+`changed_claims` and `changed_figures` may be `[]` for fresh drafts.
+
+**Append, do not overwrite.** Each new revision round appends a new
+list entry. Past rounds stay verbatim — they're the audit trail. The
+full schema is in `references/revision_history_schema.md`.
 
 ## Token-saving behavior
 

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.69.0"
+__version__ = "0.70.0"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -147,6 +147,8 @@ def auto_pipeline(
     field: Optional[str] = None,
     do_nlm: bool = True,
     do_crystals: bool = False,
+    do_fit_check: bool = True,
+    fit_check_threshold: int = 3,
     llm_cli: Optional[str] = None,
     dry_run: bool = False,
     print_progress: bool = True,
@@ -210,9 +212,13 @@ def auto_pipeline(
     if dry_run:
         plan_lines = [
             f"  search {topic!r} (max_papers={max_papers}, backends=arxiv+semantic_scholar)",
-            f"  fit-check filter (heuristic)",
-            f"  ingest into cluster {slug}",
         ]
+        if do_fit_check:
+            cli_for_plan = llm_cli or detect_llm_cli() or "(none on PATH — will skip)"
+            plan_lines.append(
+                f"  fit-check via LLM judge ({cli_for_plan}, threshold={fit_check_threshold})"
+            )
+        plan_lines.append(f"  ingest into cluster {slug}")
         if do_nlm:
             plan_lines.extend([
                 f"  notebooklm bundle --cluster {slug}",
@@ -248,6 +254,17 @@ def auto_pipeline(
         report.ok = False
         report.error = "Search returned 0 papers ??try a different topic or backend"
         return report
+
+    # v0.70.0: LLM-judge fit-check between search and ingest. Drops off-topic
+    # results before they hit Zotero/Obsidian. Best-effort: skips silently
+    # when no LLM CLI on PATH so users without claude/codex/gemini still get
+    # the pre-v0.70.0 behavior (ingest everything search returns).
+    if do_fit_check:
+        papers = _run_fit_check_step(
+            cfg, papers, topic, slug, llm_cli,
+            fit_check_threshold, report, started, print_progress,
+        )
+        report.papers_ingested = len(papers)
 
     # Write papers_input.json to cfg.root (the default location pipeline reads from)
     papers_input_path = cfg.root / "papers_input.json"
@@ -469,6 +486,90 @@ def _find_existing_collection_key_by_name(web, name: str) -> str | None:
             start += 100
     except Exception:
         return None
+
+
+def _run_fit_check_step(
+    cfg,
+    papers: list[dict],
+    topic: str,
+    slug: str,
+    llm_cli: Optional[str],
+    threshold: int,
+    report: AutoReport,
+    started: float,
+    print_progress: bool,
+) -> list[dict]:
+    """v0.70.0: LLM-judge filter between search and ingest.
+
+    Drops off-topic papers BEFORE they hit Zotero/Obsidian, fixing the
+    "auto found 8 papers but 2 are off-topic" problem reported on the
+    flood-relocation cluster (Llorca AV-relocation + Komleva Soviet-era
+    reservoir slipped in via keyword "household relocation" alone).
+
+    Reuses the existing `fit_check.emit_prompt` + `fit_check.apply_scores`
+    machinery (Gate 1) — same scoring rubric used by the manual
+    `discover new` / `discover continue` flow.
+
+    Best-effort:
+    - No LLM CLI on PATH → skip silently, keep all papers (graceful degrade).
+    - LLM returns malformed JSON → skip, keep all (don't drop on parser error).
+    - All papers rejected (threshold too high?) → keep all (fallback: better
+      to ingest noise than nothing).
+    """
+    if not papers:
+        return papers
+
+    from research_hub.auto import detect_llm_cli  # avoid circular at module load
+
+    cli = llm_cli or detect_llm_cli()
+    if not cli:
+        _step_log(report, "fit_check", True, _elapsed(started, report),
+                  f"skipped (no LLM CLI on PATH); kept all {len(papers)}", print_progress)
+        return papers
+
+    try:
+        from research_hub.fit_check import emit_prompt, apply_scores
+        # If a cluster overview exists, use that. Otherwise fall back to the
+        # raw topic — first-time `auto` runs have no overview yet.
+        definition = topic
+        try:
+            from research_hub.fit_check import _read_definition_from_overview
+            existing = _read_definition_from_overview(cfg, slug)
+            if existing:
+                definition = existing
+        except Exception:
+            pass
+
+        prompt = emit_prompt(slug, papers, definition=definition)
+        raw = _invoke_llm_cli(cli, prompt)
+        payload = _extract_first_json(raw)
+        if payload is None:
+            _step_log(report, "fit_check", False, _elapsed(started, report),
+                      f"LLM ({cli}) returned unparseable JSON; kept all {len(papers)}", print_progress)
+            return papers
+
+        fit_report = apply_scores(slug, papers, payload, threshold=threshold)
+        accepted_dois = {a.doi.lower() for a in fit_report.accepted if a.doi}
+        accepted_titles = {a.title.strip().lower() for a in fit_report.accepted if a.title}
+        kept = [
+            p for p in papers
+            if p.get("doi", "").lower() in accepted_dois
+            or p.get("title", "").strip().lower() in accepted_titles
+        ]
+        if not kept:
+            _step_log(report, "fit_check", True, _elapsed(started, report),
+                      f"all {len(papers)} rejected by threshold={threshold}; "
+                      f"keeping all as fallback (lower threshold or revise topic)",
+                      print_progress)
+            return papers
+        _step_log(report, "fit_check", True, _elapsed(started, report),
+                  f"kept {len(kept)}/{len(papers)} (threshold={threshold}, cli={cli})",
+                  print_progress)
+        return kept
+    except Exception as exc:
+        _step_log(report, "fit_check", False, _elapsed(started, report),
+                  f"fit_check error: {exc}; kept all {len(papers)}", print_progress)
+        return papers
 
 
 def _ensure_zotero_collection(registry, cluster, slug: str, report: AutoReport, print_progress: bool) -> None:

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -2248,6 +2248,8 @@ def _auto(
     field,
     do_nlm,
     do_crystals,
+    do_fit_check: bool = True,
+    fit_check_threshold: int = 3,
     llm_cli,
     dry_run,
     append: bool = False,
@@ -2273,6 +2275,8 @@ def _auto(
         field=field,
         do_nlm=do_nlm,
         do_crystals=do_crystals,
+        do_fit_check=do_fit_check,
+        fit_check_threshold=fit_check_threshold,
         llm_cli=llm_cli,
         dry_run=dry_run,
         print_progress=True,
@@ -2572,8 +2576,12 @@ def build_parser() -> argparse.ArgumentParser:
                              help="Skip NotebookLM bundle/upload/generate/download")
     auto_parser.add_argument("--with-crystals", action="store_true",
                              help="Also generate crystals via detected LLM CLI (claude/codex/gemini on PATH)")
+    auto_parser.add_argument("--no-fit-check", action="store_true",
+                             help="Skip the v0.70.0 LLM-judge fit-check between search and ingest (default: on when LLM CLI present)")
+    auto_parser.add_argument("--fit-check-threshold", type=int, default=3,
+                             help="Minimum 0-5 score for a paper to pass fit-check (default: 3 = tangentially related and above)")
     auto_parser.add_argument("--llm-cli", default=None, choices=["claude", "codex", "gemini"],
-                             help="Force a specific LLM CLI for --with-crystals (default: auto-detect)")
+                             help="Force a specific LLM CLI for --with-crystals / fit-check (default: auto-detect)")
     auto_parser.add_argument("--dry-run", action="store_true",
                              help="Print plan without executing")
     auto_parser.add_argument(
@@ -3831,6 +3839,8 @@ def main(argv: list[str] | None = None) -> int:
             field=args.field,
             do_nlm=not args.no_nlm,
             do_crystals=args.with_crystals,
+            do_fit_check=not args.no_fit_check,
+            fit_check_threshold=args.fit_check_threshold,
             llm_cli=args.llm_cli,
             dry_run=args.dry_run,
             append=args.append,

--- a/src/research_hub/mcp_server.py
+++ b/src/research_hub/mcp_server.py
@@ -2167,6 +2167,8 @@ def auto_research_topic(
     field: str = "",
     do_nlm: bool = True,
     do_crystals: bool = False,
+    do_fit_check: bool = True,
+    fit_check_threshold: int = 3,
     llm_cli: str = "",
     dry_run: bool = False,
 ) -> dict[str, Any]:
@@ -2195,6 +2197,8 @@ def auto_research_topic(
             field=field or None,
             do_nlm=do_nlm,
             do_crystals=do_crystals,
+            do_fit_check=do_fit_check,
+            fit_check_threshold=fit_check_threshold,
             llm_cli=llm_cli or None,
             dry_run=dry_run,
             print_progress=False,

--- a/src/research_hub/skills_data/paper-memory-builder/SKILL.md
+++ b/src/research_hub/skills_data/paper-memory-builder/SKILL.md
@@ -55,6 +55,10 @@ Write to `<project-root>/.paper/`:
 - `claims.yml` — every paper-level claim, with evidence pointers + status.
 - `figures.yml` — every figure inventory, with key numbers + supported
   claims.
+- `revision_history.yml` — append-only log of revision rounds (when a
+  claim or figure changed, in which round, why). See
+  `references/revision_history_schema.md` for the schema and the
+  append-vs-overwrite rules.
 
 Do **not** touch `journal_format.md`, `reviewer_comments.md`, or
 `style_overrides.md` — those belong to `academic-writing-skills`.
@@ -90,6 +94,31 @@ figures:
 ```
 
 Required per figure: `id`, `file`, `supports_claims` (may be `[]`).
+
+### `.paper/revision_history.yml` structure
+
+```yaml
+revisions:
+  - round: 1
+    date: "2026-04-15"
+    trigger: "Initial draft v1"
+    changed_claims: []          # all claims new
+    changed_figures: []
+    summary: "First complete draft."
+  - round: 2
+    date: "2026-05-02"
+    trigger: "Reviewer 2 round 1: doubt on calibration window"
+    changed_claims: ["C1", "C4"]
+    changed_figures: ["Fig3"]
+    summary: "Tightened calibration window claim, added robustness check (Fig S3), softened C4 claim wording."
+```
+
+Required per revision: `round`, `date`, `trigger`, `summary`.
+`changed_claims` and `changed_figures` may be `[]` for fresh drafts.
+
+**Append, do not overwrite.** Each new revision round appends a new
+list entry. Past rounds stay verbatim — they're the audit trail. The
+full schema is in `references/revision_history_schema.md`.
 
 ## Token-saving behavior
 

--- a/tests/test_v066_research_workspace_docs.py
+++ b/tests/test_v066_research_workspace_docs.py
@@ -64,12 +64,31 @@ def test_packaged_skill_mirror_exists(skill):
     )
 
 
+def _normalized_bytes(path: Path) -> bytes:
+    """Read file, normalize CRLF/CR to LF.
+
+    v0.70.0: PR #15 CI showed this comparison failing intermittently on
+    Linux runners after a `pip install -e` editable install — locally the
+    two files are byte-identical (md5 matches; git stores 4863 identical
+    bytes for both paths). The two GitHub Actions runs for the same commit
+    produced opposite verdicts. Most likely an editable-install side effect
+    rewrites one path with platform-native line endings even though both
+    sources are LF in git.
+
+    Normalize the comparison so the test asserts content equality, not
+    line-ending equality. Drift in actual content (a real divergence we
+    care about) still fails. Drift in only line endings (CI-environment
+    artifact we don't care about) no longer flakes.
+    """
+    return path.read_bytes().replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+
+
 @pytest.mark.parametrize("skill", V066_SKILLS)
 def test_packaged_skill_mirror_byte_identical(skill):
     src = SKILLS_ROOT / skill / "SKILL.md"
     mirror = SKILLS_DATA_ROOT / skill / "SKILL.md"
-    assert src.read_bytes() == mirror.read_bytes(), (
-        f"{skill}: skills/ vs skills_data/ SKILL.md drifted; re-mirror"
+    assert _normalized_bytes(src) == _normalized_bytes(mirror), (
+        f"{skill}: skills/ vs skills_data/ SKILL.md content drifted; re-mirror"
     )
 
 
@@ -78,8 +97,8 @@ def test_packaged_evals_mirror_byte_identical(skill):
     src = SKILLS_ROOT / skill / "evals" / "evals.json"
     mirror = SKILLS_DATA_ROOT / skill / "evals" / "evals.json"
     assert src.exists() and mirror.exists()
-    assert src.read_bytes() == mirror.read_bytes(), (
-        f"{skill}: evals.json drifted between skills/ and skills_data/"
+    assert _normalized_bytes(src) == _normalized_bytes(mirror), (
+        f"{skill}: evals.json content drifted between skills/ and skills_data/"
     )
 
 

--- a/tests/test_v070_auto_fit_check.py
+++ b/tests/test_v070_auto_fit_check.py
@@ -1,0 +1,291 @@
+"""v0.70.0 — auto pipeline LLM-judge fit-check between search and ingest.
+
+Real incident motivating this change: an `auto` run for "post-flood
+household relocation" returned 8 papers from search backends, but 2 of
+them were off-topic — Llorca 2022 (autonomous vehicles + relocation,
+nothing about floods) and Komleva 2025 (Soviet-era reservoir forced
+resettlement, not climate adaptation). Both slipped past the
+keyword-based fit_check because they shared vocabulary.
+
+This test file pins the v0.70.0 behavior:
+  - fit-check runs between search and ingest (not after)
+  - LLM-rejected papers never hit Zotero/Obsidian
+  - graceful fallback when no LLM CLI on PATH (keep all)
+  - graceful fallback when LLM returns malformed JSON (keep all)
+  - safety: if EVERY paper is rejected, keep all (better noise than nothing)
+  - threshold parameter actually filters
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from research_hub.auto import _run_fit_check_step, AutoReport, auto_pipeline
+
+
+# -- _run_fit_check_step unit tests -------------------------------------
+
+
+def _make_papers(*titles_and_dois):
+    return [
+        {"title": t, "doi": d, "abstract": f"Abstract for {t}", "year": 2024, "authors": []}
+        for t, d in titles_and_dois
+    ]
+
+
+def _mock_step_log_capture():
+    """Capture _step_log calls so we can assert on the message detail."""
+    captured: list[tuple] = []
+    def fake(report, name, ok, dur, detail, _print):
+        captured.append((name, ok, detail))
+    return captured, fake
+
+
+def test_fit_check_keeps_all_when_no_llm_cli(monkeypatch):
+    """Best-effort: no CLI on PATH → skip silently, return all papers."""
+    monkeypatch.setattr("research_hub.auto.detect_llm_cli", lambda: None)
+    cfg = SimpleNamespace(raw=None)
+    papers = _make_papers(("A", "10/a"), ("B", "10/b"))
+    report = AutoReport(cluster_slug="x", cluster_created=False)
+
+    kept = _run_fit_check_step(cfg, papers, "topic", "x", None, 3, report, 0.0, False)
+
+    assert len(kept) == 2
+    assert kept == papers
+    assert report.steps[-1].name == "fit_check"
+    assert "skipped" in report.steps[-1].detail.lower()
+
+
+def test_fit_check_filters_by_llm_score(monkeypatch):
+    """Happy path: LLM scores 2 papers, threshold drops the low one."""
+    monkeypatch.setattr("research_hub.auto.detect_llm_cli", lambda: "claude")
+    monkeypatch.setattr("research_hub.auto._invoke_llm_cli", lambda cli, prompt: '''
+        {"scores": [
+            {"doi": "10/a", "score": 5, "reason": "on topic"},
+            {"doi": "10/b", "score": 1, "reason": "off topic"}
+        ]}
+    ''')
+    cfg = SimpleNamespace(raw=None, hub=None)
+    papers = _make_papers(("Paper A", "10/a"), ("Paper B", "10/b"))
+    report = AutoReport(cluster_slug="x", cluster_created=False)
+
+    kept = _run_fit_check_step(cfg, papers, "topic", "x", None, 3, report, 0.0, False)
+
+    assert len(kept) == 1
+    assert kept[0]["doi"] == "10/a"
+    detail = report.steps[-1].detail
+    assert "kept 1/2" in detail
+
+
+def test_fit_check_keeps_all_on_unparseable_llm_json(monkeypatch):
+    """LLM responded but JSON is broken → log failure, keep all (don't drop)."""
+    monkeypatch.setattr("research_hub.auto.detect_llm_cli", lambda: "claude")
+    monkeypatch.setattr("research_hub.auto._invoke_llm_cli", lambda cli, prompt: "not JSON")
+    cfg = SimpleNamespace(raw=None, hub=None)
+    papers = _make_papers(("A", "10/a"), ("B", "10/b"))
+    report = AutoReport(cluster_slug="x", cluster_created=False)
+
+    kept = _run_fit_check_step(cfg, papers, "topic", "x", None, 3, report, 0.0, False)
+
+    assert len(kept) == 2
+    assert report.steps[-1].name == "fit_check"
+    assert report.steps[-1].ok is False
+    assert "unparseable" in report.steps[-1].detail.lower()
+
+
+def test_fit_check_safety_fallback_when_all_rejected(monkeypatch):
+    """If threshold rejects EVERY paper (rubric mismatch / threshold too
+    high), fall back to keeping all rather than ingesting nothing."""
+    monkeypatch.setattr("research_hub.auto.detect_llm_cli", lambda: "claude")
+    monkeypatch.setattr("research_hub.auto._invoke_llm_cli", lambda cli, prompt: '''
+        {"scores": [
+            {"doi": "10/a", "score": 1, "reason": "low"},
+            {"doi": "10/b", "score": 0, "reason": "off"}
+        ]}
+    ''')
+    cfg = SimpleNamespace(raw=None, hub=None)
+    papers = _make_papers(("A", "10/a"), ("B", "10/b"))
+    report = AutoReport(cluster_slug="x", cluster_created=False)
+
+    kept = _run_fit_check_step(cfg, papers, "topic", "x", None, 3, report, 0.0, False)
+
+    # safety fallback: all kept, log says so
+    assert len(kept) == 2
+    assert "fallback" in report.steps[-1].detail.lower()
+
+
+def test_fit_check_lower_threshold_keeps_more(monkeypatch):
+    """threshold=2 should keep papers scoring 2 that threshold=3 rejects."""
+    monkeypatch.setattr("research_hub.auto.detect_llm_cli", lambda: "claude")
+    monkeypatch.setattr("research_hub.auto._invoke_llm_cli", lambda cli, prompt: '''
+        {"scores": [
+            {"doi": "10/a", "score": 4, "reason": "ok"},
+            {"doi": "10/b", "score": 2, "reason": "borderline"}
+        ]}
+    ''')
+    cfg = SimpleNamespace(raw=None, hub=None)
+    papers = _make_papers(("A", "10/a"), ("B", "10/b"))
+    report = AutoReport(cluster_slug="x", cluster_created=False)
+
+    kept_low = _run_fit_check_step(cfg, papers, "topic", "x", None, 2, report, 0.0, False)
+    assert len(kept_low) == 2  # threshold=2 keeps both
+
+    report2 = AutoReport(cluster_slug="x", cluster_created=False)
+    kept_high = _run_fit_check_step(cfg, papers, "topic", "x", None, 3, report2, 0.0, False)
+    assert len(kept_high) == 1  # threshold=3 drops "10/b"
+    assert kept_high[0]["doi"] == "10/a"
+
+
+def test_fit_check_returns_empty_when_input_empty(monkeypatch):
+    """Edge case: search returned 0 papers → fit-check returns 0 without
+    invoking the LLM (would crash on empty prompt)."""
+    invoked = []
+    monkeypatch.setattr("research_hub.auto._invoke_llm_cli",
+                        lambda cli, prompt: invoked.append(prompt) or '{"scores": []}')
+    cfg = SimpleNamespace(raw=None, hub=None)
+    report = AutoReport(cluster_slug="x", cluster_created=False)
+
+    kept = _run_fit_check_step(cfg, [], "topic", "x", "claude", 3, report, 0.0, False)
+
+    assert kept == []
+    assert invoked == []  # short-circuited
+
+
+def test_fit_check_explicit_cli_overrides_detection(monkeypatch):
+    """Passing llm_cli should bypass detect_llm_cli."""
+    monkeypatch.setattr("research_hub.auto.detect_llm_cli", lambda: None)  # no CLI
+    monkeypatch.setattr("research_hub.auto._invoke_llm_cli",
+                        lambda cli, prompt: '{"scores": [{"doi": "10/a", "score": 5}]}')
+    cfg = SimpleNamespace(raw=None, hub=None)
+    papers = _make_papers(("A", "10/a"))
+    report = AutoReport(cluster_slug="x", cluster_created=False)
+
+    kept = _run_fit_check_step(cfg, papers, "topic", "x", "codex", 3, report, 0.0, False)
+
+    assert len(kept) == 1
+    # detail should mention codex was used
+    assert "codex" in report.steps[-1].detail
+
+
+# -- auto_pipeline integration tests ------------------------------------
+
+
+@pytest.fixture
+def mock_auto_deps():
+    """Wire in mocks for cfg, registry, search, ingest, NLM — same shape
+    as test_v046_auto.py's mock_deps fixture."""
+    with patch("research_hub.auto.get_config") as mock_get_config, \
+         patch("research_hub.auto.ClusterRegistry") as mock_cluster_registry, \
+         patch("research_hub.auto.run_pipeline") as mock_run_pipeline, \
+         patch("research_hub.auto.bundle_cluster") as mock_bundle, \
+         patch("research_hub.auto.upload_cluster") as mock_upload, \
+         patch("research_hub.auto.generate_artifact") as mock_generate, \
+         patch("research_hub.auto.download_briefing_for_cluster") as mock_download, \
+         patch("research_hub.auto._run_search") as mock_run_search:
+
+        mock_cfg = MagicMock()
+        mock_cfg.root = MagicMock()
+        (mock_cfg.root / "papers_input.json").write_text = MagicMock()
+        mock_cfg.raw = MagicMock()
+        (mock_cfg.raw / "x").exists = lambda: False  # so report.papers_ingested stays from filter
+        mock_get_config.return_value = mock_cfg
+
+        registry_instance = MagicMock()
+        # `registry.get(slug)` → cluster object with no zotero key
+        cluster = MagicMock()
+        cluster.zotero_collection_key = "EXISTING"
+        registry_instance.get.return_value = cluster
+        mock_cluster_registry.return_value = registry_instance
+
+        mock_run_pipeline.return_value = 0
+
+        yield {
+            "get_config": mock_get_config,
+            "cfg": mock_cfg,
+            "registry": registry_instance,
+            "run_pipeline": mock_run_pipeline,
+            "run_search": mock_run_search,
+        }
+
+
+def test_auto_pipeline_runs_fit_check_by_default(mock_auto_deps, monkeypatch):
+    """do_fit_check defaults to True. Search returns 3, LLM keeps 1, ingest
+    only sees 1."""
+    mock_auto_deps["run_search"].return_value = _make_papers(
+        ("On-topic", "10/a"), ("Off-topic AV", "10/b"), ("Off-topic Soviet", "10/c"),
+    )
+    monkeypatch.setattr("research_hub.auto.detect_llm_cli", lambda: "claude")
+    monkeypatch.setattr("research_hub.auto._invoke_llm_cli", lambda cli, prompt: '''
+        {"scores": [
+            {"doi": "10/a", "score": 5},
+            {"doi": "10/b", "score": 1},
+            {"doi": "10/c", "score": 1}
+        ]}
+    ''')
+
+    report = auto_pipeline(
+        "test topic", do_nlm=False, print_progress=False,
+    )
+
+    assert report.ok
+    assert report.papers_ingested == 1  # filtered down from 3
+    fit_steps = [s for s in report.steps if s.name == "fit_check"]
+    assert len(fit_steps) == 1
+    assert "kept 1/3" in fit_steps[0].detail
+
+
+def test_auto_pipeline_skips_fit_check_when_disabled(mock_auto_deps, monkeypatch):
+    """do_fit_check=False → no fit_check step, ingest sees all results."""
+    mock_auto_deps["run_search"].return_value = _make_papers(
+        ("X", "10/x"), ("Y", "10/y"),
+    )
+    invoked = []
+    monkeypatch.setattr("research_hub.auto._invoke_llm_cli",
+                        lambda cli, prompt: invoked.append(prompt) or "")
+
+    report = auto_pipeline(
+        "test topic", do_nlm=False, do_fit_check=False, print_progress=False,
+    )
+
+    assert report.ok
+    assert report.papers_ingested == 2
+    assert all(s.name != "fit_check" for s in report.steps)
+    assert invoked == []  # LLM never invoked
+
+
+def test_auto_pipeline_dry_run_plan_mentions_fit_check(mock_auto_deps, monkeypatch, capsys):
+    """Dry-run plan output should list the fit_check step when enabled."""
+    mock_auto_deps["registry"].get.return_value = None  # cluster does not exist
+    monkeypatch.setattr("research_hub.auto.detect_llm_cli", lambda: "claude")
+
+    auto_pipeline("test topic", dry_run=True, print_progress=True)
+    output = capsys.readouterr().out
+    assert "fit-check via LLM judge" in output
+    assert "claude" in output
+    assert "threshold=3" in output
+
+
+def test_auto_pipeline_fit_check_threshold_param_propagates(mock_auto_deps, monkeypatch):
+    """fit_check_threshold=2 should pass through to _run_fit_check_step
+    and let borderline (score=2) papers through."""
+    mock_auto_deps["run_search"].return_value = _make_papers(
+        ("Strong", "10/a"), ("Borderline", "10/b"),
+    )
+    monkeypatch.setattr("research_hub.auto.detect_llm_cli", lambda: "claude")
+    monkeypatch.setattr("research_hub.auto._invoke_llm_cli", lambda cli, prompt: '''
+        {"scores": [
+            {"doi": "10/a", "score": 5},
+            {"doi": "10/b", "score": 2}
+        ]}
+    ''')
+
+    report = auto_pipeline(
+        "topic", do_nlm=False, fit_check_threshold=2, print_progress=False,
+    )
+
+    assert report.papers_ingested == 2
+    fit_step = [s for s in report.steps if s.name == "fit_check"][0]
+    assert "threshold=2" in fit_step.detail


### PR DESCRIPTION
## Summary

Off-topic papers were slipping past `auto`'s ingest because the only paper-quality gates were dedup (drops same-DOI dupes) and a keyword-overlap heuristic (`term_overlap`) that fired AFTER ingest. Real incident: the live `auto` run for "post-flood household relocation" returned 8 papers, of which 2 were off-topic — Llorca 2022 (autonomous-vehicles + relocation) and Komleva 2025 (Soviet-era reservoir resettlement). 25% noise rate on a real research query.

This PR inserts a third quality gate BEFORE ingest, using the existing fit-check Gate-1 machinery (LLM scores each paper 0-5 against the cluster topic) plus the existing `auto._invoke_llm_cli` helper.

## Behavior

```
search → SearchResult list
  ↓
v0.70.0 NEW: LLM-judge fit-check (this PR)
  ↓
ingest into Zotero + Obsidian
  ↓
(existing) keyword fit_check on each abstract
```

Default: `do_fit_check=True`. If LLM CLI is on PATH (claude/codex/gemini) → run the judge. If no CLI → skip silently (pre-v0.70.0 behavior preserved).

## Safety paths (graceful degrade, never drop)

- No CLI on PATH → keep all, log "skipped"
- LLM returns malformed JSON → keep all, log failure
- ALL papers rejected by threshold → keep all as fallback (better noise than nothing)

## CLI surface

```bash
research-hub auto "topic"                          # default: fit-check on
research-hub auto "topic" --no-fit-check           # opt out
research-hub auto "topic" --fit-check-threshold 4  # stricter (4-5 only)
research-hub auto "topic" --llm-cli codex          # force CLI
```

MCP tool `auto_research_topic` gains matching `do_fit_check` + `fit_check_threshold` params.

## Test plan

- [x] `pytest tests/test_v070_auto_fit_check.py -v` → 11 passed
  - 7 `_run_fit_check_step` unit tests (no-CLI, filter-by-score, malformed-JSON, all-rejected fallback, threshold, empty-input, explicit-CLI override)
  - 4 `auto_pipeline` integration tests (default-on, opt-out, dry-run plan, threshold propagation)
- [x] `pytest tests/test_v046_auto.py tests/test_v049_auto_polish.py tests/test_v068_3_version_sync.py -q` → 23 passed
- [x] `pytest tests/ -q -k "not stress"` → **1946 passed**, 0 failed, 16 skipped, 2 xfailed

## Verification (after merge)

```bash
research-hub auto "post-flood household relocation" --max-papers 10 --no-nlm --dry-run
# plan should list:  fit-check via LLM judge (claude, threshold=3)

research-hub auto "post-flood household relocation" --max-papers 10 --no-nlm
# step log should show:  fit_check  kept N/10 (threshold=3, cli=claude)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)