### PR TITLE
fix(v0.70.1): NLM session pre-flight check + cross-vault session import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.70.0"
+version = "0.70.1"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.70.0"
+__version__ = "0.70.1"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -1873,6 +1873,26 @@ def _zotero_backfill(args) -> int:
     return 0
 
 
+def _preflight_nlm_session(cfg, *, op_name: str) -> int | None:
+    """v0.70.1: surface "session expired / not logged in" BEFORE the
+    browser launches a 30-second deep-stack failure. Returns None when
+    OK to proceed, or an exit code (1) with a one-line actionable hint
+    printed to stderr when not."""
+    from research_hub.notebooklm.browser import default_session_dir, default_state_file
+    from research_hub.notebooklm.session_health import check_session_health
+
+    session_dir = default_session_dir(cfg.research_hub_dir)
+    state_file = default_state_file(cfg.research_hub_dir)
+    health = check_session_health(session_dir, state_file)
+    if health.looks_logged_in:
+        return None
+    print(
+        f"[notebooklm {op_name}] session check failed: {health.actionable_hint()}",
+        file=sys.stderr,
+    )
+    return 1
+
+
 def _notebooklm_bundle(cluster_slug: str, download_pdfs: bool = False) -> int:
     from research_hub.notebooklm.bundle import bundle_cluster
 
@@ -1900,6 +1920,10 @@ def _nlm_upload(
     from research_hub.notebooklm.upload import upload_cluster
 
     cfg = get_config()
+    if not dry_run:
+        rc = _preflight_nlm_session(cfg, op_name="upload")
+        if rc is not None:
+            return rc
     registry = ClusterRegistry(cfg.clusters_file)
     cluster = registry.get(cluster_slug)
     if cluster is None:
@@ -1932,6 +1956,9 @@ def _nlm_download(cluster_slug: str, artifact_type: str, headless: bool) -> int:
     from research_hub.notebooklm.upload import download_briefing_for_cluster
 
     cfg = get_config()
+    rc = _preflight_nlm_session(cfg, op_name="download")
+    if rc is not None:
+        return rc
     registry = ClusterRegistry(cfg.clusters_file)
     cluster = registry.get(cluster_slug)
     if cluster is None:
@@ -1969,6 +1996,9 @@ def _nlm_generate(cluster_slug: str, artifact_type: str, headless: bool) -> int:
     from research_hub.notebooklm.upload import generate_artifact
 
     cfg = get_config()
+    rc = _preflight_nlm_session(cfg, op_name="generate")
+    if rc is not None:
+        return rc
     registry = ClusterRegistry(cfg.clusters_file)
     cluster = registry.get(cluster_slug)
     if cluster is None:
@@ -1989,6 +2019,11 @@ def _nlm_generate(cluster_slug: str, artifact_type: str, headless: bool) -> int:
 
 def _nlm_ask(cluster_slug: str, *, question: str, headless: bool, timeout_sec: int) -> int:
     from research_hub.notebooklm.ask import ask_cluster_notebook
+
+    cfg_for_check = get_config()
+    rc = _preflight_nlm_session(cfg_for_check, op_name="ask")
+    if rc is not None:
+        return rc
 
     cfg = get_config()
     registry = ClusterRegistry(cfg.clusters_file)
@@ -3412,6 +3447,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Max seconds to wait for login (default: 300)",
     )
     nlm_login.add_argument(
+        "--import-from",
+        default=None,
+        metavar="VAULT_PATH",
+        help="v0.70.1: copy a logged-in NotebookLM session profile from another vault "
+             "instead of running the interactive Google sign-in. VAULT_PATH points at "
+             "the OTHER vault root (the one already logged in). Skips the browser dance.",
+    )
+    nlm_login.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="With --import-from: replace the current vault's logged-in session if one exists.",
+    )
+    nlm_login.add_argument(
         "--keep-open",
         action="store_true",
         help="(CDP mode) Do NOT auto-close on login detection. Keeps Chrome open "
@@ -4294,6 +4342,30 @@ def main(argv: list[str] | None = None) -> int:
 
             cfg = get_config()
             session_dir = default_session_dir(cfg.research_hub_dir)
+            # v0.70.1: --import-from short-circuits the interactive flow by
+            # copying a logged-in session profile from another vault.
+            if args.import_from:
+                from research_hub.notebooklm.session_health import import_session
+                src_vault = _Path(args.import_from).expanduser().resolve()
+                src_research_hub = src_vault / ".research_hub"
+                src_session = default_session_dir(src_research_hub)
+                src_state = default_state_file(src_research_hub)
+                dest_state = default_state_file(cfg.research_hub_dir)
+                result = import_session(
+                    src_session, src_state,
+                    session_dir, dest_state,
+                    overwrite=args.overwrite,
+                )
+                if not result.ok:
+                    print(f"[notebooklm login --import-from] FAILED: {result.error}", file=sys.stderr)
+                    return 1
+                mb = result.bytes_copied / (1024 * 1024)
+                print(
+                    f"[notebooklm login --import-from] copied logged-in session "
+                    f"({result.files_copied} files, {mb:.0f} MB) from {src_vault}"
+                )
+                print("Verify with: research-hub notebooklm bundle --cluster <slug>")
+                return 0
             if args.cdp:
                 return login_interactive_cdp(
                     session_dir,

--- a/src/research_hub/notebooklm/session_health.py
+++ b/src/research_hub/notebooklm/session_health.py
@@ -1,0 +1,154 @@
+"""NotebookLM session health checks + cross-vault session import.
+
+Why this exists
+---------------
+Two recurring login pain points:
+
+1. Google sessions go stale (typically weeks) and the next NLM operation
+   fails deep in the browser layer with a wall-of-text URL pointing at
+   accounts.google.com — user has to re-read the spew to realize "oh,
+   re-login needed". Pre-flight `is_session_logged_in()` lets callers
+   surface a 1-line actionable error BEFORE launching the browser.
+
+2. Each vault stores its own session profile under
+   `<vault>/.research_hub/nlm_sessions/`. After `research-hub init`
+   creates a new vault, NLM-related commands fail until the user
+   re-runs `notebooklm login` from scratch (~5 min including the Google
+   2FA dance) — even if another vault on the same machine is already
+   logged in. `import_session` lets the user copy a logged-in profile
+   from a sibling vault and skip the re-login.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+# Heuristic: a Playwright storage_state JSON < 100 bytes is either empty
+# or a placeholder. Real logged-in state files are typically 4 KB+ (a
+# handful of Google cookies serialize to that range).
+_MIN_STATE_FILE_BYTES = 100
+
+# Heuristic: a Chrome user-data dir without auth cookies has no Default/
+# subfolder OR a tiny Cookies file. A logged-in profile typically has
+# Default/Cookies > 5 KB (multiple google.com cookies).
+_MIN_COOKIES_BYTES = 5 * 1024
+
+
+@dataclass
+class SessionHealth:
+    session_dir: Path
+    state_file: Path
+    has_state_file: bool
+    state_file_bytes: int
+    has_cookies_db: bool
+    cookies_db_bytes: int
+
+    @property
+    def looks_logged_in(self) -> bool:
+        """Conservative: return True only when BOTH the state file and the
+        cookies DB look populated. False positives waste a browser launch
+        but don't corrupt anything; false negatives prompt a re-login the
+        user might not have needed but that's still safe.
+        """
+        state_ok = self.has_state_file and self.state_file_bytes >= _MIN_STATE_FILE_BYTES
+        cookies_ok = self.has_cookies_db and self.cookies_db_bytes >= _MIN_COOKIES_BYTES
+        return state_ok or cookies_ok  # OR: either signal is enough
+
+    def actionable_hint(self) -> str:
+        if self.looks_logged_in:
+            return ""
+        if not self.has_state_file and not self.has_cookies_db:
+            return (
+                "No NotebookLM session for this vault. Run "
+                "`research-hub notebooklm login` to sign in, or "
+                "`research-hub notebooklm login --import-from <other-vault-path>` "
+                "to copy a logged-in session from another vault."
+            )
+        return (
+            "NotebookLM session exists but looks empty/expired. Re-run "
+            "`research-hub notebooklm login` to refresh."
+        )
+
+
+def check_session_health(session_dir: Path, state_file: Path) -> SessionHealth:
+    """Cheap filesystem-only check — does NOT launch a browser."""
+    state_bytes = state_file.stat().st_size if state_file.exists() else 0
+    cookies_path = session_dir / "Default" / "Network" / "Cookies"
+    if not cookies_path.exists():
+        # Older Chromium versions store at Default/Cookies (without Network/)
+        cookies_path = session_dir / "Default" / "Cookies"
+    cookies_bytes = cookies_path.stat().st_size if cookies_path.exists() else 0
+    return SessionHealth(
+        session_dir=session_dir,
+        state_file=state_file,
+        has_state_file=state_file.exists(),
+        state_file_bytes=state_bytes,
+        has_cookies_db=cookies_path.exists(),
+        cookies_db_bytes=cookies_bytes,
+    )
+
+
+def is_session_logged_in(session_dir: Path, state_file: Path) -> bool:
+    """Convenience wrapper around `check_session_health(...).looks_logged_in`."""
+    return check_session_health(session_dir, state_file).looks_logged_in
+
+
+@dataclass
+class ImportResult:
+    ok: bool
+    files_copied: int = 0
+    bytes_copied: int = 0
+    error: str = ""
+
+
+def import_session(
+    source_session_dir: Path,
+    source_state_file: Path,
+    dest_session_dir: Path,
+    dest_state_file: Path,
+    *,
+    overwrite: bool = False,
+) -> ImportResult:
+    """Copy a logged-in NLM session profile from one vault to another.
+
+    Refuses to overwrite an existing logged-in dest unless `overwrite=True`
+    so the user doesn't accidentally clobber a working session.
+    """
+    if not source_session_dir.exists():
+        return ImportResult(ok=False, error=f"source session dir not found: {source_session_dir}")
+    src_health = check_session_health(source_session_dir, source_state_file)
+    if not src_health.looks_logged_in:
+        return ImportResult(
+            ok=False,
+            error=(
+                f"source session at {source_session_dir} does not look logged in "
+                f"(state={src_health.state_file_bytes}B, cookies={src_health.cookies_db_bytes}B). "
+                f"Log in there first via `research-hub notebooklm login`."
+            ),
+        )
+
+    if dest_session_dir.exists() and any(dest_session_dir.iterdir()):
+        dest_health = check_session_health(dest_session_dir, dest_state_file)
+        if dest_health.looks_logged_in and not overwrite:
+            return ImportResult(
+                ok=False,
+                error=(
+                    f"dest session at {dest_session_dir} already looks logged in. "
+                    f"Pass overwrite=True to replace it."
+                ),
+            )
+        # Wipe dest first so we don't merge two profiles
+        shutil.rmtree(dest_session_dir)
+
+    dest_session_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source_session_dir, dest_session_dir)
+
+    if source_state_file.exists():
+        dest_state_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_state_file, dest_state_file)
+
+    files = sum(1 for _ in dest_session_dir.rglob("*") if _.is_file())
+    total_bytes = sum(p.stat().st_size for p in dest_session_dir.rglob("*") if p.is_file())
+    return ImportResult(ok=True, files_copied=files, bytes_copied=total_bytes)

--- a/tests/test_v070_1_nlm_session_management.py
+++ b/tests/test_v070_1_nlm_session_management.py
@@ -1,0 +1,214 @@
+"""v0.70.1 — NLM session health check + cross-vault import.
+
+Two recurring user pain points this addresses:
+
+1. Google sessions go stale silently. The NEXT NLM operation fails deep
+   in the browser layer with a wall-of-text URL pointing at
+   accounts.google.com — user has to read the spew to realize "oh,
+   re-login". Pre-flight `is_session_logged_in()` surfaces a 1-line
+   actionable error BEFORE launching the browser.
+
+2. Each vault stores its own session profile. After `research-hub init`
+   creates a new vault, NLM commands fail until the user re-runs the
+   ~5-minute interactive login dance — even if a sibling vault on the
+   same machine is already logged in. `import_session` lets the user
+   copy the logged-in profile across vaults.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from research_hub.notebooklm.session_health import (
+    ImportResult,
+    SessionHealth,
+    check_session_health,
+    import_session,
+    is_session_logged_in,
+)
+
+
+def _make_logged_in_session(vault_root: Path) -> tuple[Path, Path]:
+    """Build a fixture that looks like a real logged-in NLM session:
+    state file > 100B + Default/Network/Cookies > 5KB."""
+    nlm_root = vault_root / ".research_hub" / "nlm_sessions"
+    session_dir = nlm_root / "default"
+    state_file = nlm_root / "state.json"
+    session_dir.mkdir(parents=True)
+    nlm_root.mkdir(exist_ok=True)
+    # Realistic Playwright storage_state shape
+    state_file.write_text(
+        json.dumps({
+            "cookies": [{"name": "SID", "value": "x" * 200, "domain": ".google.com"}] * 10,
+            "origins": [],
+        }),
+        encoding="utf-8",
+    )
+    cookies_path = session_dir / "Default" / "Network" / "Cookies"
+    cookies_path.parent.mkdir(parents=True)
+    cookies_path.write_bytes(b"\x00" * (10 * 1024))  # 10 KB binary
+    return session_dir, state_file
+
+
+def _make_empty_session(vault_root: Path) -> tuple[Path, Path]:
+    nlm_root = vault_root / ".research_hub" / "nlm_sessions"
+    session_dir = nlm_root / "default"
+    state_file = nlm_root / "state.json"
+    session_dir.mkdir(parents=True)
+    return session_dir, state_file
+
+
+# --- session health -----------------------------------------------------
+
+
+def test_check_session_health_reports_logged_in_when_state_file_and_cookies_present(tmp_path):
+    session_dir, state_file = _make_logged_in_session(tmp_path)
+    health = check_session_health(session_dir, state_file)
+    assert health.looks_logged_in is True
+    assert health.has_state_file
+    assert health.state_file_bytes > 100
+    assert health.has_cookies_db
+    assert health.cookies_db_bytes >= 5 * 1024
+
+
+def test_check_session_health_reports_not_logged_in_when_state_missing(tmp_path):
+    session_dir, state_file = _make_empty_session(tmp_path)
+    health = check_session_health(session_dir, state_file)
+    assert health.looks_logged_in is False
+    assert "No NotebookLM session" in health.actionable_hint()
+
+
+def test_check_session_health_distinguishes_expired_from_missing(tmp_path):
+    """A state file that exists but is tiny → 'session exists but looks
+    empty/expired' (different message from 'no session at all'). Helps the
+    user realize re-login is the right action vs. import."""
+    session_dir, state_file = _make_empty_session(tmp_path)
+    state_file.write_text("{}", encoding="utf-8")  # 2 bytes, below threshold
+    cookies = session_dir / "Default" / "Network" / "Cookies"
+    cookies.parent.mkdir(parents=True)
+    cookies.write_bytes(b"")  # 0 bytes
+
+    health = check_session_health(session_dir, state_file)
+    assert health.looks_logged_in is False
+    hint = health.actionable_hint()
+    assert "expired" in hint.lower() or "empty" in hint.lower()
+
+
+def test_is_session_logged_in_convenience_wrapper(tmp_path):
+    session_dir, state_file = _make_logged_in_session(tmp_path)
+    assert is_session_logged_in(session_dir, state_file) is True
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    assert is_session_logged_in(empty_dir, empty_dir / "state.json") is False
+
+
+def test_check_session_health_handles_legacy_cookies_path(tmp_path):
+    """Older Chromium stored cookies at Default/Cookies (no Network/).
+    The check should accept either layout."""
+    session_dir, state_file = _make_empty_session(tmp_path)
+    state_file.write_text("x" * 200, encoding="utf-8")
+    legacy_cookies = session_dir / "Default" / "Cookies"
+    legacy_cookies.parent.mkdir(parents=True)
+    legacy_cookies.write_bytes(b"\x00" * (10 * 1024))
+    health = check_session_health(session_dir, state_file)
+    assert health.looks_logged_in is True
+
+
+# --- import_session -----------------------------------------------------
+
+
+def test_import_session_copies_logged_in_profile_to_empty_dest(tmp_path):
+    src_vault = tmp_path / "old"
+    dest_vault = tmp_path / "new"
+    src_session, src_state = _make_logged_in_session(src_vault)
+    dest_session = dest_vault / ".research_hub" / "nlm_sessions" / "default"
+    dest_state = dest_vault / ".research_hub" / "nlm_sessions" / "state.json"
+
+    result = import_session(src_session, src_state, dest_session, dest_state)
+
+    assert result.ok is True
+    assert result.files_copied >= 1
+    assert result.bytes_copied > 5 * 1024
+    # Dest now looks logged in
+    assert is_session_logged_in(dest_session, dest_state) is True
+
+
+def test_import_session_refuses_to_overwrite_logged_in_dest_without_flag(tmp_path):
+    src_vault = tmp_path / "old"
+    dest_vault = tmp_path / "new"
+    src_session, src_state = _make_logged_in_session(src_vault)
+    dest_session, dest_state = _make_logged_in_session(dest_vault)
+
+    result = import_session(src_session, src_state, dest_session, dest_state)
+    assert result.ok is False
+    assert "already looks logged in" in result.error
+    assert "overwrite" in result.error
+
+
+def test_import_session_overwrites_when_flag_set(tmp_path):
+    src_vault = tmp_path / "old"
+    dest_vault = tmp_path / "new"
+    src_session, src_state = _make_logged_in_session(src_vault)
+    dest_session, dest_state = _make_logged_in_session(dest_vault)
+    # Marker file in src to verify it actually got copied over
+    (src_session / "MARKER").write_text("from-src", encoding="utf-8")
+
+    result = import_session(src_session, src_state, dest_session, dest_state, overwrite=True)
+    assert result.ok is True
+    assert (dest_session / "MARKER").read_text(encoding="utf-8") == "from-src"
+
+
+def test_import_session_refuses_when_source_is_not_logged_in(tmp_path):
+    """User asked to import from a vault that itself isn't logged in →
+    error explains why instead of silently copying junk."""
+    src_vault = tmp_path / "old"
+    dest_vault = tmp_path / "new"
+    src_session, src_state = _make_empty_session(src_vault)
+    dest_session = dest_vault / ".research_hub" / "nlm_sessions" / "default"
+    dest_state = dest_vault / ".research_hub" / "nlm_sessions" / "state.json"
+
+    result = import_session(src_session, src_state, dest_session, dest_state)
+    assert result.ok is False
+    assert "does not look logged in" in result.error
+
+
+def test_import_session_handles_missing_source_gracefully(tmp_path):
+    src_session = tmp_path / "nonexistent" / "session"
+    src_state = tmp_path / "nonexistent" / "state.json"
+    dest_session = tmp_path / "new" / "session"
+    dest_state = tmp_path / "new" / "state.json"
+    result = import_session(src_session, src_state, dest_session, dest_state)
+    assert result.ok is False
+    assert "not found" in result.error
+
+
+# --- pre-flight + CLI integration --------------------------------------
+
+
+def test_preflight_nlm_session_returns_exit_code_when_not_logged_in(tmp_path, capsys):
+    """The pre-flight helper used by bundle/upload/generate/download
+    should print a friendly error and return 1, not crash."""
+    from research_hub.cli import _preflight_nlm_session
+    from types import SimpleNamespace
+    cfg = SimpleNamespace(research_hub_dir=tmp_path / "vault" / ".research_hub")
+    cfg.research_hub_dir.mkdir(parents=True)
+    rc = _preflight_nlm_session(cfg, op_name="upload")
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "session check failed" in captured.err
+    assert "research-hub notebooklm login" in captured.err
+
+
+def test_preflight_nlm_session_returns_none_when_logged_in(tmp_path):
+    from research_hub.cli import _preflight_nlm_session
+    from types import SimpleNamespace
+    vault = tmp_path / "vault"
+    _make_logged_in_session(vault)
+    cfg = SimpleNamespace(research_hub_dir=vault / ".research_hub")
+    rc = _preflight_nlm_session(cfg, op_name="upload")
+    assert rc is None


### PR DESCRIPTION
## Summary

Two recurring NotebookLM login pain points addressed:

1. **Sessions go stale silently.** Google sessions expire after weeks. The next NLM op (bundle/upload/generate/download/ask) fails deep in the Playwright/Chrome layer with a wall-of-text URL pointing at accounts.google.com. User has to read the spew to realize "oh, re-login". → **Fix**: pre-flight `is_session_logged_in()` check surfaces a 1-line actionable error BEFORE the browser launches.

2. **Each vault needs its own login.** `research-hub init` creates a fresh vault with empty session profile. NLM commands fail until the user re-runs the ~5-min interactive login dance — even if a sibling vault on the same machine is already logged in. → **Fix**: `notebooklm login --import-from <other-vault>` flag copies the logged-in profile across vaults, skipping the browser dance.

## Verification (lived experience that prompted this PR)

In yesterday's E2E test of v0.70.0, ran `auto` against a fresh `~/knowledge-base-fresh/` vault. Got the wall-of-text Google sign-in URL on `nlm.upload`. Manually `cp -r 285MB` of session profile from old vault to new vault to recover. This PR turns that manual workaround into a one-line CLI flag.

## Changes

### `src/research_hub/notebooklm/session_health.py` (new)
- `SessionHealth` dataclass + `check_session_health()` — cheap filesystem check (state file size + Default/Network/Cookies size). Conservative thresholds (state ≥100B OR cookies ≥5KB).
- Distinct messages for "no session" vs "session expired" so user picks correct remedy.
- `import_session(src, dest, *, overwrite=False)` — refuses to clobber a logged-in dest without `overwrite`; refuses to copy from a not-logged-in source.

### `src/research_hub/cli.py`
- `notebooklm login --import-from <VAULT_PATH> [--overwrite]` — short-circuits Google sign-in by copying profile.
- `_preflight_nlm_session(cfg, op_name)` helper called from upload/download/generate/ask. Bundle is local-only; `--dry-run` upload also skipped.

### `tests/test_v070_1_nlm_session_management.py` (new — 12 tests)
- 5 session-health: detection, missing, expired-vs-missing, wrapper, legacy Cookies path
- 5 import_session: happy path, overwrite-protection, --overwrite, bad source, missing source
- 2 pre-flight integration: exit-code+message when not logged in, no-op when logged in

## Test plan

- [x] `pytest tests/test_v070_1_nlm_session_management.py -v` → **12 passed**
- [x] `pytest tests/ -q -k "not stress"` → **1958 passed**, 0 failed, 16 skipped, 2 xfailed

## Verification (manual, after merge)

```bash
# Fresh vault that has never logged in
research-hub notebooklm upload --cluster X
# OLD: 30s deep failure with Google URL spew
# NEW: 0.1s "session check failed: No NotebookLM session for this vault. Run `research-hub notebooklm login`..."

# Skip the 5-min interactive dance:
research-hub notebooklm login --import-from C:/Users/wenyu/knowledge-base
# Copies logged-in profile (~285 MB) and prints "Verify with: ... bundle ..."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)