### PR TITLE
feat(v0.71.1): bootstrap .obsidian/graph.json on init + auto cluster create

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.71.0"
+version = "0.71.1"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.71.0"
+__version__ = "0.71.1"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -25,6 +25,7 @@ from research_hub.notebooklm.upload import (
 from research_hub.pipeline import run_pipeline
 from research_hub.search import search_papers
 from research_hub.search.fallback import FIELD_PRESETS
+from research_hub.vault.graph_config import refresh_graph_from_vault
 
 
 _LLM_CLI_CANDIDATES = ("claude", "codex", "gemini")
@@ -198,6 +199,10 @@ def auto_pipeline(
             cluster = registry.create(query=topic, slug=slug, name=display)
             report.cluster_created = True
             _step_log(report, "cluster", True, 0.0, f"created: {slug}", print_progress)
+            try:
+                refresh_graph_from_vault(cfg)
+            except Exception as exc:
+                _step_log(report, "graph.refresh", False, 0.0, str(exc), print_progress)
             # v0.49.4: also auto-create + bind a Zotero collection so ingest
             # has somewhere to put papers without manual `clusters bind`.
             _ensure_zotero_collection(registry, cluster, slug, report, print_progress)

--- a/src/research_hub/init_wizard.py
+++ b/src/research_hub/init_wizard.py
@@ -11,6 +11,7 @@ import platformdirs
 
 from research_hub.security import chmod_sensitive
 from research_hub.security.secret_box import encrypt
+from research_hub.vault.graph_config import update_from_clusters_file
 
 
 def _check_first_run_readiness(vault: Path, *, persona: str, has_zotero: bool) -> list[tuple[str, str, str]]:
@@ -202,6 +203,12 @@ def run_init(
         (vault / subdir).mkdir(parents=True, exist_ok=True)
     chmod_sensitive(vault / ".research_hub", mode=0o700)
     print(f"  Vault root: {vault}")
+    clusters_file = vault / ".research_hub" / "clusters.yaml"
+    try:
+        graph_update = update_from_clusters_file(vault, clusters_file)
+        print(f"  [init] Wrote .obsidian/graph.json with {graph_update.color_groups_written} color groups")
+    except Exception as exc:
+        print(f"  [init] WARN could not write .obsidian/graph.json: {exc}", file=sys.stderr)
 
     if not no_zotero_persona and not zotero_key and interactive:
         print("\n  Zotero API key is needed to sync papers.")

--- a/src/research_hub/vault/graph_config.py
+++ b/src/research_hub/vault/graph_config.py
@@ -55,6 +55,7 @@ class GraphConfigUpdate:
     """Report for a graph.json update attempt."""
 
     updated: bool = False
+    created: bool = False
     color_groups_written: int = 0
     skipped_reason: str = ""
     cluster_slugs: list[str] = field(default_factory=list)
@@ -122,11 +123,29 @@ def _is_managed_query(query: object) -> bool:
     )
 
 
+def _is_obsidian_graph_path(graph_json_path: Path) -> bool:
+    return graph_json_path.name == "graph.json" and graph_json_path.parent.name == ".obsidian"
+
+
 def update_graph_json(graph_json_path: Path, cluster_slugs: list[str]) -> GraphConfigUpdate:
     """Update ``colorGroups`` in graph.json while preserving other settings."""
 
     if not graph_json_path.exists():
-        return GraphConfigUpdate(skipped_reason=f"No graph.json at {graph_json_path}")
+        if not _is_obsidian_graph_path(graph_json_path):
+            return GraphConfigUpdate(skipped_reason=f"No graph.json at {graph_json_path}")
+        ordered_slugs = list(cluster_slugs)
+        minimal = {"colorGroups": build_all_color_groups(ordered_slugs)}
+        graph_json_path.parent.mkdir(parents=True, exist_ok=True)
+        graph_json_path.write_text(
+            json.dumps(minimal, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return GraphConfigUpdate(
+            updated=True,
+            created=True,
+            color_groups_written=len(minimal["colorGroups"]),
+            cluster_slugs=ordered_slugs,
+        )
 
     try:
         existing = json.loads(graph_json_path.read_text(encoding="utf-8"))
@@ -137,8 +156,17 @@ def update_graph_json(graph_json_path: Path, cluster_slugs: list[str]) -> GraphC
         existing = {}
 
     ordered_slugs = list(cluster_slugs)
-    managed_groups = build_color_groups(ordered_slugs)
-    existing["colorGroups"] = managed_groups
+    if _is_obsidian_graph_path(graph_json_path):
+        managed_groups = build_all_color_groups(ordered_slugs)
+        preserved_groups = [
+            group
+            for group in (existing.get("colorGroups") or [])
+            if isinstance(group, dict) and not _is_managed_query(group.get("query"))
+        ]
+        existing["colorGroups"] = managed_groups + preserved_groups
+    else:
+        managed_groups = build_color_groups(ordered_slugs)
+        existing["colorGroups"] = managed_groups
     rendered = json.dumps(existing, ensure_ascii=False, indent=2) + "\n"
     current = graph_json_path.read_text(encoding="utf-8")
     if current != rendered:

--- a/tests/test_v071_1_graph_bootstrap.py
+++ b/tests/test_v071_1_graph_bootstrap.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research_hub.vault.graph_config import (
+    build_all_color_groups,
+    update_graph_json,
+)
+
+
+def test_update_graph_json_creates_file_when_missing(tmp_path: Path):
+    graph_path = tmp_path / ".obsidian" / "graph.json"
+
+    report = update_graph_json(graph_path, ["alpha", "beta"])
+
+    assert report.updated is True
+    assert report.created is True
+    assert graph_path.exists()
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    queries = [group["query"] for group in data["colorGroups"]]
+    assert "path:raw/alpha/" in queries
+    assert "path:raw/beta/" in queries
+    assert "tag:#label/seed" in queries
+    assert "tag:#label/archived" in queries
+    assert report.color_groups_written == len(data["colorGroups"])
+
+
+def test_update_graph_json_creates_parent_dir_when_missing(tmp_path: Path):
+    graph_path = tmp_path / "vault" / ".obsidian" / "graph.json"
+
+    report = update_graph_json(graph_path, ["alpha"])
+
+    assert report.created is True
+    assert graph_path.parent.is_dir()
+    assert graph_path.is_file()
+
+
+def test_update_graph_json_preserves_existing_file_behavior(tmp_path: Path):
+    graph_path = tmp_path / ".obsidian" / "graph.json"
+    graph_path.parent.mkdir(parents=True, exist_ok=True)
+    graph_path.write_text(
+        json.dumps(
+            {
+                "showTags": False,
+                "colorGroups": [
+                    {"query": "tag:#custom", "color": {"a": 1, "rgb": 123}},
+                    {"query": "path:raw/old/", "color": {"a": 1, "rgb": 456}},
+                    {"query": "tag:#label/seed", "color": {"a": 1, "rgb": 789}},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = update_graph_json(graph_path, ["alpha"])
+
+    assert report.updated is True
+    assert report.created is False
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    queries = [group["query"] for group in data["colorGroups"]]
+    assert "tag:#custom" in queries
+    assert "path:raw/old/" not in queries
+    assert queries.count("tag:#label/seed") == 1
+    assert report.color_groups_written == len(build_all_color_groups(["alpha"]))
+
+
+def test_init_wizard_bootstraps_graph_json(tmp_path: Path, monkeypatch, capsys):
+    from research_hub import init_wizard
+
+    vault = tmp_path / "vault"
+    config_dir = tmp_path / "config"
+    monkeypatch.setattr(
+        init_wizard.platformdirs,
+        "user_config_dir",
+        lambda *args, **kwargs: str(config_dir),
+    )
+    monkeypatch.setattr(
+        init_wizard,
+        "_check_first_run_readiness",
+        lambda vault, *, persona, has_zotero: [("chrome", "OK", "patchright can launch Chrome")],
+    )
+
+    assert init_wizard.run_init(vault_root=str(vault), non_interactive=True) == 0
+
+    graph_path = vault / ".obsidian" / "graph.json"
+    assert graph_path.exists()
+    data = json.loads(graph_path.read_text(encoding="utf-8"))
+    assert data["colorGroups"]
+    assert all(group["query"].startswith("tag:#label/") for group in data["colorGroups"])
+    assert "[init] Wrote .obsidian/graph.json" in capsys.readouterr().out
+
+
+def test_init_wizard_bootstrap_failure_does_not_abort_init(tmp_path: Path, monkeypatch, capsys):
+    from research_hub import init_wizard
+
+    vault = tmp_path / "vault"
+    config_dir = tmp_path / "config"
+    monkeypatch.setattr(
+        init_wizard.platformdirs,
+        "user_config_dir",
+        lambda *args, **kwargs: str(config_dir),
+    )
+    monkeypatch.setattr(
+        init_wizard,
+        "update_from_clusters_file",
+        lambda vault_root, clusters_file: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    monkeypatch.setattr(
+        init_wizard,
+        "_check_first_run_readiness",
+        lambda vault, *, persona, has_zotero: [("chrome", "OK", "patchright can launch Chrome")],
+    )
+
+    assert init_wizard.run_init(vault_root=str(vault), non_interactive=True) == 0
+
+    captured = capsys.readouterr()
+    assert "[init] WARN could not write .obsidian/graph.json: disk full" in captured.err


### PR DESCRIPTION
## Summary

The 2026-04-28 audit on the fresh vault (`~/knowledge-base-fresh/`) flagged that `update_graph_json` short-circuited when `.obsidian/graph.json` didn't exist:

```python
if not graph_json_path.exists():
    return GraphConfigUpdate(skipped_reason=f"No graph.json at {graph_json_path}")
```

Result: brand new vaults opened in Obsidian for the first time showed every paper in the same default-gray graph. No cluster colors. No label colors. The graph_config module had all the color-group machinery but only as an UPDATE to a pre-existing graph.json. The user had to manually add colorGroups themselves.

This release flips the short-circuit into a create-and-write path so a fresh vault gets a populated `graph.json` from day one, plus wires the bootstrap into both `init` and `auto` so users see colored clusters the moment Obsidian first renders the graph.

## Changes

### `src/research_hub/vault/graph_config.py`
- `update_graph_json` now creates the parent `.obsidian/` dir if missing and writes a minimal valid `graph.json` with **both** cluster path groups AND label tag groups (`build_all_color_groups`). Returns `GraphConfigUpdate(created=True, updated=True)` to distinguish from the existing-file update path.
- New `created: bool = False` field on `GraphConfigUpdate`.

### `src/research_hub/init_wizard.py`
- After creating the standard vault subdirs, call `update_from_clusters_file` to seed `graph.json`. Best-effort: write failures log a warning + continue (never abort init).

### `src/research_hub/auto.py`
- After cluster create + Zotero bind, call `refresh_graph_from_vault` so a brand-new cluster picks up its color group on the spot.

## Tests

5 new tests in `tests/test_v071_1_graph_bootstrap.py`:
- `update_graph_json` creates file when missing
- `update_graph_json` creates parent `.obsidian/` dir
- `update_graph_json` preserves existing user color groups
- `init_wizard` bootstraps `graph.json` on first run
- `init_wizard` bootstrap failure does NOT abort init (best-effort guard)

## Test plan

- [x] `pytest tests/test_v071_1_graph_bootstrap.py -v` → 5 passed
- [x] `pytest tests/test_graph_config_v027.py tests/test_init_wizard.py -q` → 19 passed (regression on related modules)
- [x] `pytest tests/ -q -k "not stress"` → **1972 passed, 0 failed**, 16 skipped, 2 xfailed (Windows 3.14, 14m57s)

## Process notes

- Drafted via `codex-delegate` skill (~5-min Codex run, 40 LOC + 5 tests). Claude reviewed the diff, ran tests, and shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)