### PR TITLE
feat(v0.72.0): abstract recovery + year drift detector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.71.2"
+version = "0.72.0"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.71.2"
+__version__ = "0.72.0"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/discover.py
+++ b/src/research_hub/discover.py
@@ -26,6 +26,13 @@ _DEFAULT_PER_BACKEND_LIMIT_FACTOR = 3
 _DEFAULT_PER_BACKEND_LIMIT_FLOOR = 40
 
 
+def _search_result_to_candidate(result) -> dict:
+    entry = asdict(result)
+    entry["abstract_source"] = result.abstract_source
+    entry["metadata_year"] = result.metadata_year
+    return entry
+
+
 @dataclass
 class QueryVariation:
     query: str
@@ -204,7 +211,7 @@ def apply_variations(
     out: list[dict] = []
     for result in merged:
         matched = list(result.found_in)
-        entry = asdict(result)
+        entry = _search_result_to_candidate(result)
         entry["confidence"] = min(
             1.0,
             base_confidence_by_key.get(result.dedup_key, float(result.confidence))
@@ -357,7 +364,7 @@ def _resolve_seed_dois(
         for doi, result in zip(to_fetch, resolved):
             if result is None:
                 continue
-            entry = asdict(result)
+            entry = _search_result_to_candidate(result)
             entry["confidence"] = 1.0
             entry["_discover_meta"] = {
                 "matched_variations": [],
@@ -529,7 +536,7 @@ def discover_new(
         rank_by=rank_by,
         per_backend_limit=per_backend_limit,
     )
-    candidates = [asdict(result) for result in results]
+    candidates = [_search_result_to_candidate(result) for result in results]
 
     for candidate in candidates:
         candidate["_discover_meta"] = {
@@ -584,7 +591,7 @@ def discover_new(
                         )
                         break
                 continue
-            entry = asdict(result)
+            entry = _search_result_to_candidate(result)
             entry["_discover_meta"] = {
                 "matched_variations": [],
                 "source_tags": ["citation-graph"],
@@ -831,7 +838,9 @@ def _to_papers_input(candidates: list[dict], cluster_slug: str | None) -> list[d
             "doi": doi,
             "authors": _authors_to_creators(names),
             "year": candidate.get("year") or 0,
+            "metadata_year": candidate.get("metadata_year"),
             "abstract": abstract_text or "(no abstract)",
+            "abstract_source": candidate.get("abstract_source") or "",
             "journal": candidate.get("venue") or "preprint",
             "slug": slug,
             "sub_category": cluster_slug or "",
@@ -852,5 +861,11 @@ def _to_papers_input(candidates: list[dict], cluster_slug: str | None) -> list[d
             entry["arxiv_id"] = arxiv_id
         if backend_source:
             entry["source"] = backend_source
+        ingest_year = candidate.get("year") or 0
+        metadata_year = candidate.get("metadata_year")
+        if metadata_year and ingest_year and metadata_year != ingest_year:
+            entry["year_drift_warning"] = (
+                f"ingest_year={ingest_year} differs from doi_lookup_year={metadata_year}"
+            )
         papers.append(entry)
     return papers

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -479,6 +479,11 @@ def run_pipeline(
             query_text = _query_for_paper(pp, query)
             cluster_obj = clusters.get(cluster_slug) if cluster_slug else None
             cluster_coll = cluster_obj.zotero_collection_key if cluster_obj else None
+            if pp.get("year_drift_warning"):
+                p(
+                    f"  [warn] year-drift: {pp['slug']} "
+                    f"ingest={pp.get('year')} doi-lookup={pp.get('metadata_year')}"
+                )
             if fit_check:
                 doi_key = str(pp.get("doi", "") or "").strip().lower()
                 title_key = str(pp.get("title", "") or "").strip().lower()

--- a/src/research_hub/search/abstract_recovery.py
+++ b/src/research_hub/search/abstract_recovery.py
@@ -1,0 +1,64 @@
+"""Best-effort abstract recovery from DOI metadata services."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from urllib.parse import quote
+
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+_USER_AGENT = "research-hub/0.72.0 (https://github.com/WenyuChiou/research-hub)"
+_UNPAYWALL_EMAIL = "research-hub@anthropic.com"
+
+
+@dataclass
+class RecoveredAbstract:
+    text: str
+    source: str
+    oa_url: str = ""
+
+
+def recover_abstract(doi: str, *, timeout: int = 10) -> RecoveredAbstract:
+    """Try Crossref first, then Unpaywall, to recover missing abstracts."""
+    if not doi:
+        return RecoveredAbstract(text="", source="")
+
+    try:
+        from research_hub.search.crossref import _extract_crossref_abstract
+
+        response = requests.get(
+            f"https://api.crossref.org/works/{quote(doi.strip(), safe='')}",
+            timeout=timeout,
+            headers={"User-Agent": _USER_AGENT},
+        )
+        if response.status_code == 200:
+            work = (response.json().get("message") or {})
+            abstract = _extract_crossref_abstract(work)
+            if abstract:
+                logger.info("abstract recovery: doi=%s source=crossref", doi)
+                return RecoveredAbstract(text=abstract, source="crossref")
+    except Exception as exc:
+        logger.debug("Crossref abstract recovery failed for %s: %s", doi, exc)
+
+    try:
+        response = requests.get(
+            f"https://api.unpaywall.org/v2/{quote(doi.strip(), safe='')}",
+            params={"email": _UNPAYWALL_EMAIL},
+            timeout=timeout,
+            headers={"User-Agent": _USER_AGENT},
+        )
+        if response.status_code == 200:
+            data = response.json() or {}
+            best_oa = (data.get("best_oa_location") or {})
+            oa_url = best_oa.get("url", "") or ""
+            if oa_url:
+                logger.info("abstract recovery: doi=%s source=unpaywall oa_url=%s", doi, oa_url)
+                return RecoveredAbstract(text="", source="unpaywall", oa_url=oa_url)
+    except Exception as exc:
+        logger.debug("Unpaywall lookup failed for %s: %s", doi, exc)
+
+    return RecoveredAbstract(text="", source="")

--- a/src/research_hub/search/base.py
+++ b/src/research_hub/search/base.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Protocol
 
 
-@dataclass
+@dataclass(init=False)
 class SearchResult:
     """Normalized search result from any backend."""
 
@@ -33,6 +33,52 @@ class SearchResult:
     volume: str = ""
     issue: str = ""
     pages: str = ""
+
+    def __init__(
+        self,
+        title: str,
+        doi: str = "",
+        arxiv_id: str = "",
+        abstract: str = "",
+        abstract_source: str = "",
+        year: int | None = None,
+        metadata_year: int | None = None,
+        authors: list[str] | None = None,
+        venue: str = "",
+        url: str = "",
+        citation_count: int = 0,
+        pdf_url: str = "",
+        source: str = "",
+        confidence: float = 0.5,
+        found_in: list[str] | None = None,
+        doc_type: str = "",
+        categories: list[str] | None = None,
+        publication_types: list[str] | None = None,
+        volume: str = "",
+        issue: str = "",
+        pages: str = "",
+    ) -> None:
+        self.title = title
+        self.doi = doi
+        self.arxiv_id = arxiv_id
+        self.abstract = abstract
+        self.abstract_source = abstract_source or ""
+        self.year = year
+        self.metadata_year = metadata_year
+        self.authors = list(authors or [])
+        self.venue = venue
+        self.url = url
+        self.citation_count = citation_count
+        self.pdf_url = pdf_url
+        self.source = source
+        self.confidence = confidence
+        self.found_in = list(found_in or [])
+        self.doc_type = doc_type
+        self.categories = list(categories or [])
+        self.publication_types = list(publication_types or [])
+        self.volume = volume
+        self.issue = issue
+        self.pages = pages
 
     @classmethod
     def from_s2_json(cls, item: dict) -> "SearchResult":

--- a/src/research_hub/search/crossref.py
+++ b/src/research_hub/search/crossref.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 from urllib.parse import quote
 
@@ -16,6 +17,15 @@ logger = logging.getLogger(__name__)
 CROSSREF_BASE = "https://api.crossref.org/works"
 _USER_AGENT = "research-hub/0.16.0 (mailto:research-hub@example.invalid)"
 _DEFAULT_TIMEOUT = 20
+_JATS_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _extract_crossref_abstract(work: dict) -> str:
+    raw = work.get("abstract", "")
+    if not raw:
+        return ""
+    text = _JATS_TAG_RE.sub("", raw)
+    return " ".join(text.split())
 
 
 class CrossrefBackend:
@@ -123,11 +133,14 @@ class CrossrefBackend:
         # v0.68.5: Crossref returns `page` as a single string already in the
         # canonical "first-last" form (e.g. "123-145"). volume / issue may be
         # missing for some doc types; fall back to "" rather than None.
+        abstract = _extract_crossref_abstract(work)
         return SearchResult(
             title=title,
             doi=doi,
-            abstract="",
+            abstract=abstract,
+            abstract_source=self.name if abstract else "",
             year=year,
+            metadata_year=year,
             authors=authors,
             venue=venue,
             url=f"https://doi.org/{work.get('DOI', '')}",

--- a/src/research_hub/search/enrich.py
+++ b/src/research_hub/search/enrich.py
@@ -6,6 +6,7 @@ import logging
 import re
 from collections.abc import Sequence
 
+from research_hub.search.abstract_recovery import recover_abstract
 from research_hub.search.arxiv_backend import ArxivBackend
 from research_hub.search.base import SearchResult
 from research_hub.search.openalex import OpenAlexBackend
@@ -70,6 +71,8 @@ def enrich_candidates(
                     logger.debug("enrich %s via %s failed: %s", cand, name, exc)
                     continue
                 if result is not None:
+                    if result.abstract and not result.abstract_source:
+                        result.abstract_source = result.source
                     resolved = result
                     break
         else:
@@ -83,8 +86,20 @@ def enrich_candidates(
                     continue
                 best = max(hits, key=lambda h: _ratio(h.title.lower(), cand.lower()))
                 if _ratio(best.title.lower(), cand.lower()) >= 60:
+                    if best.abstract and not best.abstract_source:
+                        best.abstract_source = best.source
                     resolved = best
                     break
+
+        if resolved is not None and not resolved.abstract and resolved.doi:
+            try:
+                recovered = recover_abstract(resolved.doi)
+            except Exception as exc:
+                logger.debug("abstract recovery failed for %s: %s", resolved.doi, exc)
+            else:
+                if recovered.text:
+                    resolved.abstract = recovered.text
+                    resolved.abstract_source = recovered.source
 
         out.append(resolved)
     return out

--- a/src/research_hub/search/openalex.py
+++ b/src/research_hub/search/openalex.py
@@ -33,6 +33,27 @@ def _reconstruct_abstract(inv_index: dict[str, list[int]] | None) -> str:
     return " ".join(word for _, word in positions)
 
 
+def _extract_metadata_year(work: dict) -> int | None:
+    publication_year = work.get("publication_year")
+    biblio = work.get("biblio") or {}
+    issued_date = biblio.get("issued_date")
+    if isinstance(issued_date, str):
+        match = re.match(r"(\d{4})", issued_date.strip())
+        if match:
+            metadata_year = int(match.group(1))
+            if publication_year is not None and metadata_year != publication_year:
+                return metadata_year
+    elif isinstance(issued_date, dict):
+        year_value = issued_date.get("year")
+        if isinstance(year_value, int) and publication_year is not None and year_value != publication_year:
+            return year_value
+    elif isinstance(issued_date, (list, tuple)) and issued_date:
+        year_value = issued_date[0]
+        if isinstance(year_value, int) and publication_year is not None and year_value != publication_year:
+            return year_value
+    return None
+
+
 class OpenAlexBackend:
     """OpenAlex REST backend with polite throttling."""
 
@@ -102,13 +123,16 @@ class OpenAlexBackend:
             pages = f"{first_page}-{last_page}"
         else:
             pages = first_page or last_page
+        abstract = _reconstruct_abstract(work.get("abstract_inverted_index"))
 
         return SearchResult(
             title=work.get("title") or "",
             doi=doi,
             arxiv_id=arxiv_id,
-            abstract=_reconstruct_abstract(work.get("abstract_inverted_index")),
+            abstract=abstract,
+            abstract_source=self.name if abstract else "",
             year=work.get("publication_year"),
+            metadata_year=_extract_metadata_year(work),
             authors=[
                 authorship.get("author", {}).get("display_name", "")
                 for authorship in authorships

--- a/tests/test_v072_search_quality.py
+++ b/tests/test_v072_search_quality.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import requests
+
+from research_hub.discover import _to_papers_input
+from research_hub.search.abstract_recovery import RecoveredAbstract, recover_abstract
+from research_hub.search.base import SearchResult
+from research_hub.search.crossref import _extract_crossref_abstract
+from research_hub.search.enrich import enrich_candidates
+
+
+def test_extract_crossref_abstract_strips_jats_tags():
+    work = {"abstract": "<jats:p>Hello <jats:i>world</jats:i></jats:p>"}
+    assert _extract_crossref_abstract(work) == "Hello world"
+
+
+def test_extract_crossref_abstract_returns_empty_when_missing():
+    assert _extract_crossref_abstract({}) == ""
+
+
+def test_recover_abstract_uses_crossref_first(monkeypatch):
+    crossref_response = MagicMock()
+    crossref_response.status_code = 200
+    crossref_response.json.return_value = {
+        "message": {"abstract": "<jats:p>Recovered abstract</jats:p>"}
+    }
+
+    def fake_get(url, **kwargs):
+        assert kwargs["timeout"] == 10
+        assert "crossref" in url
+        return crossref_response
+
+    monkeypatch.setattr("research_hub.search.abstract_recovery.requests.get", fake_get)
+
+    recovered = recover_abstract("10.1/example")
+    assert recovered.source == "crossref"
+    assert recovered.text == "Recovered abstract"
+    assert recovered.oa_url == ""
+
+
+def test_recover_abstract_falls_back_to_unpaywall_oa_url_when_crossref_empty(monkeypatch):
+    crossref_response = MagicMock()
+    crossref_response.status_code = 200
+    crossref_response.json.return_value = {"message": {}}
+
+    unpaywall_response = MagicMock()
+    unpaywall_response.status_code = 200
+    unpaywall_response.json.return_value = {
+        "best_oa_location": {"url": "https://example.org/paper.pdf"}
+    }
+
+    responses = [crossref_response, unpaywall_response]
+
+    def fake_get(url, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr("research_hub.search.abstract_recovery.requests.get", fake_get)
+
+    recovered = recover_abstract("10.1/example")
+    assert recovered.source == "unpaywall"
+    assert recovered.text == ""
+    assert recovered.oa_url == "https://example.org/paper.pdf"
+
+
+def test_recover_abstract_returns_empty_when_both_fail(monkeypatch):
+    not_found = MagicMock()
+    not_found.status_code = 404
+    not_found.json.return_value = {}
+    responses = [not_found, not_found]
+
+    def fake_get(url, **kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr("research_hub.search.abstract_recovery.requests.get", fake_get)
+
+    recovered = recover_abstract("10.1/example")
+    assert recovered == RecoveredAbstract(text="", source="", oa_url="")
+
+
+def test_recover_abstract_handles_network_timeout_gracefully(monkeypatch):
+    def fake_get(url, **kwargs):
+        raise requests.exceptions.Timeout("boom")
+
+    monkeypatch.setattr("research_hub.search.abstract_recovery.requests.get", fake_get)
+
+    recovered = recover_abstract("10.1/example")
+    assert recovered == RecoveredAbstract(text="", source="", oa_url="")
+
+
+def test_enrich_candidates_recovers_missing_abstract_for_doi_results(monkeypatch):
+    result = SearchResult(
+        title="Test Paper",
+        doi="10.1234/x",
+        abstract="",
+        source="openalex",
+    )
+
+    class FakeBackend:
+        def get_paper(self, identifier):
+            return result
+
+    monkeypatch.setattr("research_hub.search.enrich.OpenAlexBackend", lambda: FakeBackend())
+    monkeypatch.setattr("research_hub.search.enrich.recover_abstract", lambda doi: RecoveredAbstract(text="Filled abstract", source="crossref"))
+
+    enriched = enrich_candidates(["10.1234/x"], backends=("openalex",))
+    assert enriched[0] is not None
+    assert enriched[0].abstract == "Filled abstract"
+    assert enriched[0].abstract_source == "crossref"
+
+
+def test_to_papers_input_emits_year_drift_warning_when_years_differ():
+    papers = _to_papers_input(
+        [
+            {
+                "title": "Title",
+                "authors": ["Jane Doe"],
+                "year": 2026,
+                "metadata_year": 2025,
+                "doi": "10.1/x",
+                "abstract": "Abstract",
+                "venue": "Venue",
+            }
+        ],
+        "cluster-a",
+    )
+    assert papers[0]["year_drift_warning"] == "ingest_year=2026 differs from doi_lookup_year=2025"
+
+
+def test_to_papers_input_no_year_drift_warning_when_years_match():
+    papers = _to_papers_input(
+        [
+            {
+                "title": "Title",
+                "authors": ["Jane Doe"],
+                "year": 2025,
+                "metadata_year": 2025,
+                "doi": "10.1/x",
+                "abstract": "Abstract",
+                "venue": "Venue",
+            }
+        ],
+        "cluster-a",
+    )
+    assert "year_drift_warning" not in papers[0]
+
+
+def test_searchresult_dataclass_has_metadata_year_and_abstract_source():
+    result = SearchResult(title="Title", metadata_year=2025, abstract_source="openalex")
+    assert result.metadata_year == 2025
+    assert result.abstract_source == "openalex"


### PR DESCRIPTION
## Summary

Two search-quality gaps surfaced by the 2026-04-28 audit on the `llm-based-agent-flood` cluster:

1. **Hassouna 2026** (`10.1016/j.inffus.2025.103865`) is a real Elsevier paper but OpenAlex doesn't expose its abstract (paywalled). Result: ingested with `Abstract: (no abstract)` and v0.69.0 summarize correctly emitted `[abstract too thin to extract findings]`. The Crossref API actually has the abstract for newer Elsevier/Wiley DOIs (returned as JATS XML); we just weren't reading it.

2. **Year drift** between ingest year and DOI metadata year (Hassouna vault frontmatter said 2026, OpenAlex said 2025). Easy to miss when citing.

## Changes

### `src/research_hub/search/abstract_recovery.py` (NEW)
- `recover_abstract(doi) → RecoveredAbstract(text, source, oa_url)`
- Tries Crossref first (often has abstract for Elsevier/Wiley/Springer), falls back to Unpaywall to surface OA URL when no abstract is available.
- Time-bounded (10s default per backend), graceful on network failures.

### `src/research_hub/search/crossref.py`
- Extract abstract from JATS XML wrapper (`<jats:p>...</jats:p>` → text). New `_extract_crossref_abstract` helper.
- `_parse_work` now populates `abstract` and `abstract_source`.

### `src/research_hub/search/enrich.py`
- In `enrich_candidates`, when result has no abstract AND has a DOI, call `recover_abstract()` to fill. Best-effort.

### `src/research_hub/search/base.py`
- `SearchResult` gains `abstract_source: str` (provenance) and `metadata_year: int | None` (DOI metadata year, separate from ingest year).

### `src/research_hub/search/openalex.py`
- Surface `metadata_year` when `biblio.issued_date` differs from `publication_year` (in-press / formal-publish split).

### `src/research_hub/discover.py`
- `_to_papers_input` emits `year_drift_warning` field when ingest year ≠ metadata_year.

### `src/research_hub/pipeline.py`
- When `pp[\"year_drift_warning\"]` is set, prints `[warn] year-drift: <slug> ...` to log. Doesn't block ingest.

## Test plan

- [x] `pytest tests/test_v072_search_quality.py -v` → 10 passed
- [x] `pytest tests/test_v068_5_metadata_completeness.py tests/test_discover.py -q` → all passed (regression on related)
- [x] `pytest tests/ -q -k \"not stress\"` → **1988 passed, 0 failed**, 16 skipped, 2 xfailed (Windows 3.14, 14m08s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)