### PR TITLE
feat(v0.74.0): drift prevention + per-batch sub-collection + 4 doctor checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## v0.74.0 (2026-05-02)
+
+Workflow drift prevention + per-batch sub-collection. Driven by audit
+of Wenyu's vault: 1148 Obsidian notes vs ~125 in cluster Zotero
+collections. Three holes patched, plus a new sub-collection axis so
+each ingest batch is discoverable in Zotero.
+
+### Added
+- `import-folder --with-zotero` flag opts into the Zotero write path.
+  Default behavior unchanged (Obsidian-only) but now requires
+  confirmation prompt unless `--yes` is also passed.
+- `import-folder --batch-label` and `auto`/`ingest --batch-label` for
+  explicit batch naming. Default auto-derives `<YYYYMMDD>-<query-slug>`
+  or `manual-<YYYYMMDD-HHMMSS>`.
+- Per-batch Zotero sub-collection: each ingest creates (or reuses)
+  `<cluster_collection>/<batch_label>` and items get
+  `collections=[parent, child]` plus a `batch:<label>` tag.
+- `clusters audit` CLI: run drift + collision + test-pattern checks,
+  exits 1 on any issue.
+- 4 new doctor checks: `cluster/zotero_drift`, `cluster/test_pattern`,
+  `cluster/collection_collision`, `manifest/orphan_cluster`.
+- Manifest entry gains `batch_label` field (back-compat: empty default).
+
+### Fixed
+- Silent `RESEARCH_HUB_NO_ZOTERO=1` bypass: now prints stderr banner at
+  pipeline entry and a one-line summary at exit.
+- `zotero_collection_key` collision was undetected. New doctor check
+  catches it; today flags the `WNV9SWVA` collision between
+  `llm-agents-software-engineering` and `llm-evaluation-harness`.
+
+### Tests
+- `tests/test_v074_drift_prevention.py` (9 tests)
+- `tests/test_v074_batch_collection.py` (7 tests)
+- pytest target: 2057+ collected
+
 ## v0.70.1 (2026-04-27)
 
 UX fix for two recurring NotebookLM session pain points: silent

--- a/docs/backfill_zotero.md
+++ b/docs/backfill_zotero.md
@@ -1,0 +1,48 @@
+# Zotero Backfill
+
+## When to run
+
+Run this after `doctor` or `research-hub clusters audit` reports Obsidian/Zotero drift for a cluster.
+
+## Prerequisites
+
+- `research-hub` v0.74+ with `pipeline.write_papers_to_zotero(...)`
+- A working Zotero API configuration
+- A vault with `.research_hub/clusters.yaml` and bound `zotero_collection_key` values
+
+## Step 1: Dry-run one cluster
+
+```bash
+python scripts/backfill_zotero.py --vault C:/Users/wenyu/knowledge-base --cluster survey --dry-run
+```
+
+## Step 2: Review the plan
+
+Inspect:
+
+- `<vault>/.research_hub/backfill/<cluster>/case_A_missing.json`
+- `<vault>/.research_hub/backfill/<cluster>/case_B_skip.json`
+- `<vault>/.research_hub/backfill/<cluster>/case_C_rebind.json`
+- `<vault>/.research_hub/backfill/<cluster>/case_D_recreate.json`
+- `<vault>/.research_hub/backfill/backfill_plan_<timestamp>.md`
+
+## Step 3: Apply one cluster
+
+```bash
+python scripts/backfill_zotero.py --vault C:/Users/wenyu/knowledge-base --cluster survey --apply
+```
+
+## Step 4: Apply the rest
+
+```bash
+python scripts/backfill_zotero.py --vault C:/Users/wenyu/knowledge-base --all --apply
+```
+
+## Recovery
+
+Before `--apply`, the script snapshots:
+
+- `<vault>/papers_input.json.bak-<timestamp>` when `papers_input.json` exists
+- `<vault>/.research_hub/clusters.yaml.bak-<timestamp>` when `clusters.yaml` exists
+
+If you need to revert, restore those backup files and review the per-cluster backfill JSON files plus `manifest.jsonl` entries with `action=backfill_<case>`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.73.0"
+version = "0.74.0"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/backfill_zotero.py
+++ b/scripts/backfill_zotero.py
@@ -1,0 +1,931 @@
+from __future__ import annotations
+
+import argparse
+import inspect
+import json
+import math
+import os
+import re
+import shutil
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from research_hub.clusters import Cluster, ClusterRegistry
+from research_hub.manifest import Manifest, new_entry
+from research_hub.zotero.client import ZoteroDualClient
+
+
+LEGACY_BATCH_LABEL = "legacy-pre-2026-04-11"
+CASE_LABELS = {
+    "A": "case_A_missing.json",
+    "B": "case_B_skip.json",
+    "C": "case_C_rebind.json",
+    "D": "case_D_recreate.json",
+}
+FRONTMATTER_BLOCK_RE = re.compile(r"^---\n(.*?)\n---(?=\n|$)", re.DOTALL)
+ZOTERO_KEY_LINE_RE = re.compile(
+    r"(?m)^(?P<prefix>\s*zotero-key:\s*)(?P<quote>['\"]?)(?P<value>[^\n'\"]*)(?P=quote)\s*$"
+)
+
+
+class BackfillArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise argparse.ArgumentError(None, message)
+
+
+@dataclass
+class BackfillEntry:
+    obsidian_path: str
+    title: str
+    doi: str
+    zotero_key_old: str
+    case: str
+    zotero_key_new: str = ""
+    applied_at: str = ""
+    applied_status: str = ""
+    error_message: str = ""
+    note_zotero_key: str = field(default="", repr=False)
+    target_zotero_key: str = field(default="", repr=False)
+    frontmatter: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def record_key(self) -> tuple[str, str, str]:
+        return (self.obsidian_path, self.case, self.zotero_key_old)
+
+    def to_record(self) -> dict[str, Any]:
+        payload = {
+            "obsidian_path": self.obsidian_path,
+            "title": self.title,
+            "doi": self.doi,
+            "zotero_key_old": self.zotero_key_old,
+            "zotero_key_new": self.zotero_key_new,
+            "case": self.case,
+            "applied_at": self.applied_at,
+            "applied_status": self.applied_status,
+        }
+        if self.error_message:
+            payload["error_message"] = self.error_message
+        return payload
+
+
+@dataclass
+class ClusterPlan:
+    cluster: Cluster
+    note_dir: Path
+    notes_scanned: int = 0
+    get_calls: int = 0
+    entries_by_case: dict[str, list[BackfillEntry]] = field(
+        default_factory=lambda: {case: [] for case in CASE_LABELS}
+    )
+
+    def counts(self) -> dict[str, int]:
+        return {case: len(self.entries_by_case[case]) for case in CASE_LABELS}
+
+    def planned_create_count(self) -> int:
+        return self.counts()["A"] + self.counts()["D"]
+
+
+class RateLimiter:
+    def __init__(self, rate_per_second: float) -> None:
+        if rate_per_second <= 0:
+            raise ValueError("rate_per_second must be > 0")
+        self.interval = 1.0 / rate_per_second
+        self._last_acquired: float | None = None
+
+    def acquire(self) -> None:
+        now = time.monotonic()
+        if self._last_acquired is not None:
+            elapsed = now - self._last_acquired
+            if elapsed < self.interval:
+                time.sleep(self.interval - elapsed)
+        self._last_acquired = time.monotonic()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def timestamp_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def normalize_doi(value: str) -> str:
+    text = str(value or "").strip().lower()
+    for prefix in ("https://doi.org/", "http://doi.org/", "doi:"):
+        if text.startswith(prefix):
+            text = text[len(prefix):]
+    return text.strip()
+
+
+def log_progress(message: str) -> None:
+    print(message, flush=True)
+
+
+def build_cfg(vault_root: Path) -> SimpleNamespace:
+    root = vault_root.expanduser()
+    return SimpleNamespace(
+        root=root,
+        raw=root / "raw",
+        research_hub_dir=root / ".research_hub",
+        clusters_file=root / ".research_hub" / "clusters.yaml",
+        manifest_path=root / ".research_hub" / "manifest.jsonl",
+    )
+
+
+def resolve_pipeline_api() -> tuple[Callable[..., tuple[list[dict], list[dict], list[dict]]], int]:
+    from research_hub import pipeline
+
+    helper = getattr(pipeline, "write_papers_to_zotero", None)
+    if helper is None:
+        raise RuntimeError(
+            "Prerequisite missing: research_hub.pipeline.write_papers_to_zotero(...) "
+            "does not exist yet. Merge v0.74.0-drift-prevention first."
+        )
+    signature = inspect.signature(helper)
+    for required_name in ("batch_coll", "batch_label"):
+        if required_name not in signature.parameters:
+            raise RuntimeError(
+                "Prerequisite missing: research_hub.pipeline.write_papers_to_zotero(...) "
+                f"must accept `{required_name}`. Merge v0.74.0-drift-prevention first."
+            )
+    batch_size = int(getattr(pipeline, "ZOTERO_BATCH_SIZE", 50) or 50)
+    return helper, batch_size
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = BackfillArgumentParser(
+        description="Audit and backfill legacy Obsidian/Zotero drift by cluster.",
+    )
+    parser.add_argument("--vault", required=True, help="Path to the vault root")
+    scope = parser.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--cluster", default=None, help="One cluster slug to process")
+    scope.add_argument("--all", dest="all_clusters", action="store_true", help="Process all clusters")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", dest="apply", action="store_false", help="Plan only (default)")
+    mode.add_argument("--apply", dest="apply", action="store_true", help="Execute the plan")
+    parser.set_defaults(apply=False)
+    parser.add_argument("--limit", type=int, default=0, help="Max notes to scan per cluster (0 = no limit)")
+    parser.add_argument("--rate-limit", type=float, default=4.0, help="Zotero write calls per second")
+    parser.add_argument("--force", action="store_true", help="Re-run entries already marked ok")
+    args = parser.parse_args(argv)
+    if args.limit < 0:
+        raise argparse.ArgumentError(None, "--limit must be >= 0")
+    if args.rate_limit <= 0:
+        raise argparse.ArgumentError(None, "--rate-limit must be > 0")
+    return args
+
+
+def parse_frontmatter(text: str) -> dict[str, Any]:
+    match = FRONTMATTER_BLOCK_RE.match(text)
+    if not match:
+        return {}
+    body = match.group(1)
+    try:
+        import yaml
+
+        loaded = yaml.safe_load(body) or {}
+        if isinstance(loaded, dict):
+            return loaded
+    except Exception:
+        pass
+
+    parsed: dict[str, Any] = {}
+    for line in body.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        token = value.strip()
+        if token.startswith("[") and token.endswith("]"):
+            inner = token[1:-1].strip()
+            parsed[key.strip()] = [
+                item.strip().strip('"').strip("'")
+                for item in inner.split(",")
+                if item.strip()
+            ]
+            continue
+        parsed[key.strip()] = token.strip('"').strip("'")
+    return parsed
+
+
+def read_note_frontmatter(note_path: Path) -> dict[str, Any]:
+    try:
+        return parse_frontmatter(note_path.read_text(encoding="utf-8", errors="ignore"))
+    except OSError:
+        return {}
+
+
+def extract_note_key(frontmatter: dict[str, Any]) -> str:
+    raw = frontmatter.get("zotero-key")
+    if raw in (None, ""):
+        raw = frontmatter.get("zotero_key")
+    return str(raw or "").strip().strip('"').strip("'")
+
+
+def note_title(frontmatter: dict[str, Any], note_path: Path) -> str:
+    title = str(frontmatter.get("title") or note_path.stem).strip()
+    return title or note_path.stem
+
+
+def not_found_error(exc: Exception) -> bool:
+    if getattr(exc, "status_code", None) == 404:
+        return True
+    return "404" in str(exc)
+
+
+def fetch_item(zot: Any, key: str) -> dict[str, Any]:
+    if hasattr(zot, "item"):
+        return zot.item(key)
+    if hasattr(zot, "get_item"):
+        return zot.get_item(key)
+    raise AttributeError("Zotero client has no item/get_item reader")
+
+
+def search_existing_key_by_doi(zot: Any, doi: str) -> str:
+    if not doi:
+        return ""
+    hits: Any = []
+    if hasattr(zot, "search_by_doi"):
+        hits = zot.search_by_doi(doi)
+    elif hasattr(zot, "search"):
+        hits = zot.search(doi, limit=10)
+    elif hasattr(zot, "items"):
+        hits = zot.items(q=doi, limit=10)
+    for hit in hits or []:
+        data = hit.get("data", {})
+        if normalize_doi(data.get("DOI", "")) == doi:
+            return str(hit.get("key") or data.get("key") or "").strip()
+    return ""
+
+
+def classify_note(
+    zot: Any,
+    cluster_slug: str,
+    cluster_coll: str,
+    note_path: Path,
+    frontmatter: dict[str, Any],
+) -> tuple[BackfillEntry, bool]:
+    del cluster_slug
+    zk = extract_note_key(frontmatter)
+    doi = normalize_doi(str(frontmatter.get("doi") or ""))
+    title = note_title(frontmatter, note_path)
+    used_get = False
+
+    if not zk:
+        dedup_key = search_existing_key_by_doi(zot, doi)
+        case = "C" if dedup_key else "A"
+        return (
+            BackfillEntry(
+                obsidian_path=str(note_path),
+                title=title,
+                doi=doi,
+                zotero_key_old=zk,
+                case=case,
+                note_zotero_key=zk,
+                target_zotero_key=dedup_key,
+                frontmatter=frontmatter,
+            ),
+            used_get,
+        )
+
+    try:
+        item = fetch_item(zot, zk)
+        used_get = True
+    except Exception as exc:
+        used_get = True
+        if not_found_error(exc):
+            dedup_key = search_existing_key_by_doi(zot, doi)
+            case = "C" if dedup_key else "D"
+            return (
+                BackfillEntry(
+                    obsidian_path=str(note_path),
+                    title=title,
+                    doi=doi,
+                    zotero_key_old=zk,
+                    case=case,
+                    note_zotero_key=zk,
+                    target_zotero_key=dedup_key,
+                    frontmatter=frontmatter,
+                ),
+                used_get,
+            )
+        raise
+
+    collections = list(item.get("data", {}).get("collections", []) or [])
+    case = "B" if cluster_coll in collections else "C"
+    return (
+        BackfillEntry(
+            obsidian_path=str(note_path),
+            title=title,
+            doi=doi,
+            zotero_key_old=zk,
+            case=case,
+            note_zotero_key=zk,
+            target_zotero_key=zk,
+            frontmatter=frontmatter,
+        ),
+        used_get,
+    )
+
+
+def cluster_note_dir(cfg: SimpleNamespace, cluster: Cluster) -> Path:
+    folder_name = cluster.obsidian_subfolder or cluster.slug
+    return cfg.raw / folder_name
+
+
+def load_existing_statuses(plan_dir: Path) -> dict[tuple[str, str, str], dict[str, Any]]:
+    status_map: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for filename in CASE_LABELS.values():
+        path = plan_dir / filename
+        if not path.exists():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(payload, list):
+            continue
+        for entry in payload:
+            if not isinstance(entry, dict):
+                continue
+            key = (
+                str(entry.get("obsidian_path", "")),
+                str(entry.get("case", "")),
+                str(entry.get("zotero_key_old", "")),
+            )
+            status_map[key] = entry
+    return status_map
+
+
+def merge_existing_status(entry: BackfillEntry, previous: dict[str, Any] | None) -> None:
+    if not previous:
+        return
+    entry.zotero_key_new = str(previous.get("zotero_key_new", "") or "")
+    entry.applied_at = str(previous.get("applied_at", "") or "")
+    entry.applied_status = str(previous.get("applied_status", "") or "")
+    entry.error_message = str(previous.get("error_message", "") or "")
+
+
+def write_cluster_plan_files(plan_dir: Path, entries_by_case: dict[str, list[BackfillEntry]]) -> None:
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    for case, filename in CASE_LABELS.items():
+        payload = [entry.to_record() for entry in entries_by_case.get(case, [])]
+        (plan_dir / filename).write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+
+def render_backup_line(source: Path, backup: Path | None) -> str:
+    if backup is not None:
+        return f"- Backup of `{source}` -> `{backup}`"
+    return f"- Backup of `{source}` -> `(source missing; no backup created)`"
+
+
+def select_clusters(registry: ClusterRegistry, args: argparse.Namespace) -> list[Cluster]:
+    if args.cluster:
+        cluster = registry.get(args.cluster)
+        if cluster is None:
+            raise ValueError(f"Unknown cluster slug: {args.cluster}")
+        return [cluster]
+    clusters = sorted(registry.list(), key=lambda item: item.slug)
+    if not clusters:
+        raise ValueError(f"No clusters found in {registry.path}")
+    return clusters
+
+
+def build_cluster_plan(
+    zot: Any,
+    cfg: SimpleNamespace,
+    cluster: Cluster,
+    *,
+    limit: int = 0,
+) -> ClusterPlan:
+    if not cluster.zotero_collection_key:
+        raise ValueError(f"Cluster '{cluster.slug}' has no zotero_collection_key")
+
+    note_dir = cluster_note_dir(cfg, cluster)
+    plan = ClusterPlan(cluster=cluster, note_dir=note_dir)
+    note_paths = sorted(note_dir.rglob("*.md")) if note_dir.exists() else []
+    if limit > 0:
+        note_paths = note_paths[:limit]
+    plan.notes_scanned = len(note_paths)
+
+    previous = load_existing_statuses(cfg.research_hub_dir / "backfill" / cluster.slug)
+    for note_path in note_paths:
+        frontmatter = read_note_frontmatter(note_path)
+        entry, used_get = classify_note(
+            zot,
+            cluster.slug,
+            str(cluster.zotero_collection_key or ""),
+            note_path,
+            frontmatter,
+        )
+        if used_get:
+            plan.get_calls += 1
+        merge_existing_status(entry, previous.get(entry.record_key()))
+        plan.entries_by_case[entry.case].append(entry)
+
+    return plan
+
+
+def summary_row(plan: ClusterPlan, batch_size: int) -> tuple[str, int, int, int, int, int, int]:
+    counts = plan.counts()
+    est_writes = counts["C"] + math.ceil((counts["A"] + counts["D"]) / batch_size) if (counts["A"] + counts["D"]) else counts["C"]
+    return (
+        plan.cluster.slug,
+        plan.notes_scanned,
+        counts["A"],
+        counts["B"],
+        counts["C"],
+        counts["D"],
+        est_writes,
+    )
+
+
+def write_summary(
+    cfg: SimpleNamespace,
+    plans: list[ClusterPlan],
+    *,
+    batch_size: int,
+    rate_limit: float,
+    papers_backup: Path | None,
+    clusters_backup: Path | None,
+) -> Path:
+    out_dir = cfg.research_hub_dir / "backfill"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"backfill_plan_{timestamp_slug()}.md"
+
+    rows = [summary_row(plan, batch_size) for plan in plans]
+    total_scanned = sum(row[1] for row in rows)
+    total_a = sum(row[2] for row in rows)
+    total_b = sum(row[3] for row in rows)
+    total_c = sum(row[4] for row in rows)
+    total_d = sum(row[5] for row in rows)
+    total_est_writes = sum(row[6] for row in rows)
+    total_get_calls = sum(plan.get_calls for plan in plans)
+    create_calls = sum(
+        math.ceil(plan.planned_create_count() / batch_size)
+        for plan in plans
+        if plan.planned_create_count()
+    )
+    update_calls = total_c
+    get_minutes = total_get_calls / 10.0 / 60.0
+    create_minutes = create_calls / rate_limit / 60.0
+    update_minutes = update_calls / rate_limit / 60.0
+    total_minutes = get_minutes + create_minutes + update_minutes
+
+    lines = [
+        f"# Backfill plan - generated {utc_now()}",
+        "",
+        "| Cluster | Notes scanned | A (missing) | B (skip) | C (rebind) | D (recreate) | Est. Zotero writes |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in rows:
+        lines.append(
+            f"| {row[0]} | {row[1]} | {row[2]} | {row[3]} | {row[4]} | {row[5]} | {row[6]} |"
+        )
+    lines.extend(
+        [
+            f"| **TOTAL** | **{total_scanned}** | **{total_a}** | **{total_b}** | **{total_c}** | **{total_d}** | **{total_est_writes}** |",
+            "",
+            "### Wall-clock estimate",
+            f"- HTTP GETs (B/C/D classification): ~10/s = {get_minutes:.2f} min",
+            f"- Zotero create_items writes (A/D): rate-limited to {rate_limit:g}/s = {create_minutes:.2f} min",
+            f"- Zotero update_items writes (C): rate-limited to {rate_limit:g}/s = {update_minutes:.2f} min",
+            f"- Total: {total_minutes:.2f} min",
+            "",
+            "### Safety",
+            render_backup_line(cfg.root / "papers_input.json", papers_backup),
+            render_backup_line(cfg.clusters_file, clusters_backup),
+            f"- All writes append to `{cfg.manifest_path}` with action=backfill_<case>",
+        ]
+    )
+
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return out_path
+
+
+def copy_backup(source: Path) -> Path | None:
+    if not source.exists():
+        return None
+    backup = source.with_name(f"{source.name}.bak-{timestamp_slug()}")
+    shutil.copy2(source, backup)
+    return backup
+
+
+def parse_year(value: Any) -> int | str:
+    raw = str(value or "").strip()
+    match = re.search(r"\d{4}", raw)
+    if match:
+        return int(match.group(0))
+    return 2025
+
+
+def parse_authors_from_fm(frontmatter: dict[str, Any]) -> list[dict[str, str]]:
+    raw = frontmatter.get("authors", "")
+    if isinstance(raw, list):
+        names = [str(item).strip() for item in raw if str(item).strip()]
+    else:
+        text = str(raw or "").strip()
+        if not text:
+            return [{"creatorType": "author", "name": "Unknown"}]
+        names = [part.strip() for part in text.split(";") if part.strip()]
+        if len(names) == 1 and " and " in text.lower():
+            names = [part.strip() for part in re.split(r"\band\b", text, flags=re.IGNORECASE) if part.strip()]
+
+    creators: list[dict[str, str]] = []
+    organization_tokens = {
+        "agency",
+        "association",
+        "bureau",
+        "center",
+        "centre",
+        "college",
+        "committee",
+        "corporation",
+        "department",
+        "institute",
+        "ministry",
+        "office",
+        "organization",
+        "society",
+        "university",
+    }
+    for name in names:
+        if "," in name:
+            last, first = [part.strip() for part in name.split(",", 1)]
+            creators.append(
+                {
+                    "creatorType": "author",
+                    "firstName": first,
+                    "lastName": last,
+                }
+            )
+            continue
+        lowered = name.lower()
+        if any(token in lowered for token in organization_tokens):
+            creators.append({"creatorType": "author", "name": name})
+            continue
+        parts = name.split()
+        if len(parts) >= 2:
+            creators.append(
+                {
+                    "creatorType": "author",
+                    "firstName": " ".join(parts[:-1]),
+                    "lastName": parts[-1],
+                }
+            )
+        else:
+            creators.append({"creatorType": "author", "name": name})
+    return creators or [{"creatorType": "author", "name": "Unknown"}]
+
+
+def build_paper(entry: BackfillEntry, cluster_slug: str) -> dict[str, Any]:
+    frontmatter = entry.frontmatter or read_note_frontmatter(Path(entry.obsidian_path))
+    note_path = Path(entry.obsidian_path)
+    return {
+        "title": entry.title,
+        "doi": entry.doi,
+        "authors": parse_authors_from_fm(frontmatter),
+        "year": parse_year(frontmatter.get("year")),
+        "abstract": str(frontmatter.get("abstract") or "(legacy backfill)"),
+        "journal": str(frontmatter.get("journal") or "(unknown venue)"),
+        "slug": str(frontmatter.get("slug") or note_path.stem),
+        "sub_category": cluster_slug,
+        "tags": [],
+        "url": str(frontmatter.get("url") or ""),
+        "volume": str(frontmatter.get("volume") or ""),
+        "issue": str(frontmatter.get("issue") or ""),
+        "pages": str(frontmatter.get("pages") or ""),
+    }
+
+
+def rewrite_note_zotero_key(note_path: Path, new_key: str) -> bool:
+    text = note_path.read_text(encoding="utf-8", errors="ignore")
+    match = FRONTMATTER_BLOCK_RE.match(text)
+    if not match:
+        new_text = f"---\nzotero-key: {new_key}\n---\n" + text.lstrip("\n")
+    else:
+        block = match.group(0)
+        if ZOTERO_KEY_LINE_RE.search(block):
+            def _replace(line_match: re.Match[str]) -> str:
+                quote = line_match.group("quote")
+                if quote:
+                    return f"{line_match.group('prefix')}{quote}{new_key}{quote}"
+                return f"{line_match.group('prefix')}{new_key}"
+
+            new_block = ZOTERO_KEY_LINE_RE.sub(_replace, block, count=1)
+        else:
+            insert_at = block.rfind("\n---")
+            new_block = block[:insert_at] + f"\nzotero-key: {new_key}" + block[insert_at:]
+        new_text = new_block + text[len(block):]
+    if new_text == text:
+        return False
+    note_path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def append_manifest_entry(
+    manifest: Manifest,
+    cluster_slug: str,
+    case: str,
+    entry: BackfillEntry,
+    zotero_key: str,
+    *,
+    error: str = "",
+) -> None:
+    manifest.append(
+        new_entry(
+            cluster=cluster_slug,
+            query="backfill",
+            action=f"backfill_{case}",
+            doi=entry.doi,
+            title=entry.title,
+            zotero_key=zotero_key,
+            obsidian_path=entry.obsidian_path,
+            batch_label=LEGACY_BATCH_LABEL,
+            error=error,
+        )
+    )
+
+
+def mark_entry(
+    entry: BackfillEntry,
+    *,
+    status: str,
+    zotero_key_new: str = "",
+    error_message: str = "",
+) -> None:
+    entry.applied_at = utc_now()
+    entry.applied_status = status
+    if zotero_key_new:
+        entry.zotero_key_new = zotero_key_new
+    if error_message:
+        entry.error_message = error_message
+
+
+def update_item_collections(zot: Any, item_key: str, cluster_coll: str) -> str:
+    item = fetch_item(zot, item_key)
+    data = item.get("data", {})
+    collections = list(data.get("collections", []) or [])
+    if cluster_coll not in collections:
+        collections.append(cluster_coll)
+    data["collections"] = collections
+    try:
+        zot.update_item(data)
+    except TypeError:
+        zot.update_item(item_key, {"collections": collections})
+    return item_key
+
+
+def apply_case_c_entries(
+    zot: Any,
+    manifest: Manifest,
+    plan: ClusterPlan,
+    rate_limiter: RateLimiter,
+    *,
+    force: bool = False,
+) -> int:
+    failures = 0
+    cluster_coll = str(plan.cluster.zotero_collection_key or "")
+    for entry in plan.entries_by_case["C"]:
+        if entry.applied_status == "ok" and not force:
+            continue
+        target_key = entry.target_zotero_key or entry.zotero_key_old
+        if not target_key:
+            mark_entry(entry, status="failed", error_message="missing target Zotero key for case C")
+            append_manifest_entry(
+                manifest,
+                plan.cluster.slug,
+                entry.case,
+                entry,
+                "",
+                error="missing target Zotero key for case C",
+            )
+            failures += 1
+            continue
+        try:
+            rate_limiter.acquire()
+            update_item_collections(zot, target_key, cluster_coll)
+            if entry.note_zotero_key != target_key:
+                rewrite_note_zotero_key(Path(entry.obsidian_path), target_key)
+            mark_entry(entry, status="ok", zotero_key_new=target_key)
+            append_manifest_entry(manifest, plan.cluster.slug, entry.case, entry, target_key)
+        except Exception as exc:
+            failures += 1
+            mark_entry(entry, status="failed", error_message=str(exc))
+            append_manifest_entry(
+                manifest,
+                plan.cluster.slug,
+                entry.case,
+                entry,
+                target_key,
+                error=str(exc),
+            )
+    return failures
+
+
+def apply_create_entries(
+    zot: Any,
+    manifest: Manifest,
+    plan: ClusterPlan,
+    rate_limiter: RateLimiter,
+    *,
+    write_papers_to_zotero: Callable[..., tuple[list[dict], list[dict], list[dict]]],
+    batch_size: int,
+    case: str,
+    force: bool = False,
+) -> int:
+    failures = 0
+    pending = [
+        entry
+        for entry in plan.entries_by_case[case]
+        if force or entry.applied_status != "ok"
+    ]
+    if not pending:
+        return 0
+
+    for start in range(0, len(pending), batch_size):
+        batch_entries = pending[start : start + batch_size]
+        papers = [build_paper(entry, plan.cluster.slug) for entry in batch_entries]
+        try:
+            rate_limiter.acquire()
+            write_papers_to_zotero(
+                zot,
+                papers,
+                plan.cluster.slug,
+                str(plan.cluster.zotero_collection_key or ""),
+                batch_coll=None,
+                batch_label=LEGACY_BATCH_LABEL,
+                zotero_batch_size=batch_size,
+                log=log_progress,
+            )
+        except Exception as exc:
+            for entry in batch_entries:
+                failures += 1
+                mark_entry(entry, status="failed", error_message=str(exc))
+                append_manifest_entry(
+                    manifest,
+                    plan.cluster.slug,
+                    entry.case,
+                    entry,
+                    "",
+                    error=str(exc),
+                )
+            continue
+
+        for entry, paper in zip(batch_entries, papers):
+            created_key = str(paper.get("zotero_key") or "").strip()
+            if not created_key:
+                failures += 1
+                message = f"write_papers_to_zotero returned no zotero_key for {entry.title}"
+                mark_entry(entry, status="failed", error_message=message)
+                append_manifest_entry(
+                    manifest,
+                    plan.cluster.slug,
+                    entry.case,
+                    entry,
+                    "",
+                    error=message,
+                )
+                continue
+            rewrite_note_zotero_key(Path(entry.obsidian_path), created_key)
+            mark_entry(entry, status="ok", zotero_key_new=created_key)
+            append_manifest_entry(
+                manifest,
+                plan.cluster.slug,
+                entry.case,
+                entry,
+                created_key,
+            )
+    return failures
+
+
+def apply_cluster_plan(
+    zot: Any,
+    manifest: Manifest,
+    plan: ClusterPlan,
+    *,
+    write_papers_to_zotero: Callable[..., tuple[list[dict], list[dict], list[dict]]],
+    batch_size: int,
+    rate_limiter: RateLimiter,
+    force: bool = False,
+) -> int:
+    failures = 0
+    failures += apply_create_entries(
+        zot,
+        manifest,
+        plan,
+        rate_limiter,
+        write_papers_to_zotero=write_papers_to_zotero,
+        batch_size=batch_size,
+        case="A",
+        force=force,
+    )
+    failures += apply_case_c_entries(
+        zot,
+        manifest,
+        plan,
+        rate_limiter,
+        force=force,
+    )
+    failures += apply_create_entries(
+        zot,
+        manifest,
+        plan,
+        rate_limiter,
+        write_papers_to_zotero=write_papers_to_zotero,
+        batch_size=batch_size,
+        case="D",
+        force=force,
+    )
+    return failures
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+    except argparse.ArgumentError as exc:
+        print(f"usage error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        write_papers_to_zotero, batch_size = resolve_pipeline_api()
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    cfg = build_cfg(Path(args.vault))
+    registry = ClusterRegistry(cfg.clusters_file)
+    try:
+        clusters = select_clusters(registry, args)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    cfg.research_hub_dir.mkdir(parents=True, exist_ok=True)
+    zot = getattr(ZoteroDualClient(), "web")
+    plans: list[ClusterPlan] = []
+    try:
+        for cluster in clusters:
+            plan = build_cluster_plan(
+                zot,
+                cfg,
+                cluster,
+                limit=args.limit,
+            )
+            write_cluster_plan_files(cfg.research_hub_dir / "backfill" / cluster.slug, plan.entries_by_case)
+            plans.append(plan)
+    except Exception as exc:
+        print(f"ERROR: backfill planning failed: {exc}", file=sys.stderr)
+        return 1
+
+    papers_backup = copy_backup(cfg.root / "papers_input.json") if args.apply else None
+    clusters_backup = copy_backup(cfg.clusters_file) if args.apply else None
+    summary_path = write_summary(
+        cfg,
+        plans,
+        batch_size=batch_size,
+        rate_limit=args.rate_limit,
+        papers_backup=papers_backup,
+        clusters_backup=clusters_backup,
+    )
+    log_progress(f"Plan summary written to {summary_path}")
+
+    if not args.apply:
+        return 0
+
+    manifest = Manifest(cfg.manifest_path)
+    rate_limiter = RateLimiter(args.rate_limit)
+    failures = 0
+    for plan in plans:
+        log_progress(f"[apply] {plan.cluster.slug}: A={len(plan.entries_by_case['A'])} C={len(plan.entries_by_case['C'])} D={len(plan.entries_by_case['D'])}")
+        failures += apply_cluster_plan(
+            zot,
+            manifest,
+            plan,
+            write_papers_to_zotero=write_papers_to_zotero,
+            batch_size=batch_size,
+            rate_limiter=rate_limiter,
+            force=args.force,
+        )
+        write_cluster_plan_files(cfg.research_hub_dir / "backfill" / plan.cluster.slug, plan.entries_by_case)
+    return 1 if failures else 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return run(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.73.0"
+__version__ = "0.74.0"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -208,6 +208,74 @@ def _clusters_show(slug: str) -> int:
     return 0
 
 
+def _clusters_audit(cluster_slug: str | None = None) -> int:
+    from research_hub.doctor import (
+        check_cluster_collection_collision,
+        check_cluster_test_pattern,
+        check_cluster_zotero_drift,
+        check_manifest_orphan_cluster,
+    )
+    from research_hub.vault.sync import compute_sync_status
+
+    cfg = get_config()
+    registry = ClusterRegistry(cfg.clusters_file)
+    clusters = registry.list()
+    if cluster_slug is not None:
+        cluster = registry.get(cluster_slug)
+        if cluster is None:
+            raise ValueError(f"Cluster not found: {cluster_slug}")
+        clusters = [cluster]
+
+    drift_results = check_cluster_zotero_drift(cfg)
+    test_result = check_cluster_test_pattern(cfg)
+    collision_result = check_cluster_collection_collision(cfg)
+    orphan_result = check_manifest_orphan_cluster(cfg)
+
+    drifted = {
+        line.strip().split(":", 1)[0]
+        for result in drift_results
+        for line in result.details.splitlines()
+        if line.strip()
+    }
+    test_slugs = {line.strip() for line in test_result.details.splitlines() if line.strip()}
+    collision_slugs: set[str] = set()
+    for line in collision_result.details.splitlines():
+        if "[" not in line or "]" not in line:
+            continue
+        inside = line.split("[", 1)[1].rsplit("]", 1)[0]
+        collision_slugs.update(slug.strip() for slug in inside.split(",") if slug.strip())
+
+    drift_available = not any(result.status == "INFO" for result in drift_results)
+    zot = _load_zotero_if_configured() if drift_available else None
+    bad = False
+    print(f"{'cluster':40} {'obsidian':>8} {'zotero':>8} {'in_both':>8} {'drift':>8} {'test?':>6} {'collision?':>11}")
+    for cluster in clusters:
+        if drift_available and zot is not None:
+            status = compute_sync_status(cluster, zot, cfg.raw)
+            drift = status.obsidian_count - status.in_both
+            obsidian_cell = str(status.obsidian_count)
+            zotero_cell = str(status.zotero_count)
+            in_both_cell = str(status.in_both)
+            drift_cell = f"!{drift}" if cluster.slug in drifted else str(drift)
+        else:
+            obsidian_cell = "n/a"
+            zotero_cell = "n/a"
+            in_both_cell = "n/a"
+            drift_cell = "n/a"
+        test_mark = "!" if cluster.slug in test_slugs else "-"
+        collision_mark = "!" if cluster.slug in collision_slugs else "-"
+        print(f"{cluster.slug:40} {obsidian_cell:>8} {zotero_cell:>8} {in_both_cell:>8} {drift_cell:>8} {test_mark:>6} {collision_mark:>11}")
+        bad = bad or cluster.slug in drifted or test_mark == "!" or collision_mark == "!"
+
+    if orphan_result.status != "OK":
+        print()
+        print(f"[{orphan_result.status}] {orphan_result.name}: {orphan_result.message}")
+        if orphan_result.details:
+            print(orphan_result.details)
+
+    return 1 if bad else 0
+
+
 def _clusters_new(query: str, name: str | None, slug: str | None) -> int:
     cfg = get_config()
     registry = ClusterRegistry(cfg.clusters_file)
@@ -765,6 +833,9 @@ def _import_folder_command(args) -> int:
         use_graphify=args.use_graphify,
         graphify_graph=Path(args.graphify_graph) if args.graphify_graph else None,
         dry_run=args.dry_run,
+        with_zotero=args.with_zotero,
+        yes=args.yes,
+        batch_label=args.batch_label,
     )
     print(f"\nImport summary ({'DRY RUN' if args.dry_run else 'WRITTEN'}):")
     print(f"  imported:  {report.imported_count}")
@@ -2292,6 +2363,7 @@ def _auto(
     append: bool = False,
     force: bool = False,
     show: bool = True,
+    batch_label: str | None = None,
 ) -> int:
     from research_hub.auto import auto_pipeline
 
@@ -2304,22 +2376,32 @@ def _auto(
             print("       Re-run with --append (add more) or --force (overwrite).")
             return 2
 
-    report = auto_pipeline(
-        topic,
-        cluster_slug=cluster_slug,
-        cluster_name=cluster_name,
-        max_papers=max_papers,
-        field=field,
-        do_nlm=do_nlm,
-        do_crystals=do_crystals,
-        do_cluster_overview=do_cluster_overview,
-        do_fit_check=do_fit_check,
-        fit_check_threshold=fit_check_threshold,
-        zotero_batch_size=zotero_batch_size,
-        llm_cli=llm_cli,
-        dry_run=dry_run,
-        print_progress=True,
-    )
+    previous_batch_label = os.environ.get("RESEARCH_HUB_BATCH_LABEL")
+    if batch_label is not None:
+        os.environ["RESEARCH_HUB_BATCH_LABEL"] = batch_label
+    try:
+        report = auto_pipeline(
+            topic,
+            cluster_slug=cluster_slug,
+            cluster_name=cluster_name,
+            max_papers=max_papers,
+            field=field,
+            do_nlm=do_nlm,
+            do_crystals=do_crystals,
+            do_cluster_overview=do_cluster_overview,
+            do_fit_check=do_fit_check,
+            fit_check_threshold=fit_check_threshold,
+            zotero_batch_size=zotero_batch_size,
+            llm_cli=llm_cli,
+            dry_run=dry_run,
+            print_progress=True,
+        )
+    finally:
+        if batch_label is not None:
+            if previous_batch_label is None:
+                os.environ.pop("RESEARCH_HUB_BATCH_LABEL", None)
+            else:
+                os.environ["RESEARCH_HUB_BATCH_LABEL"] = previous_batch_label
     if not report.ok:
         print(f"  [ERR] {report.error}")
         return 1
@@ -2649,6 +2731,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Bypass non-empty cluster guard",
     )
+    auto_parser.add_argument(
+        "--batch-label",
+        default=None,
+        help="Optional explicit batch label for the ingest sub-collection",
+    )
 
     plan_parser = subparsers.add_parser(
         "plan",
@@ -2686,6 +2773,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=3,
         help="Minimum score (0-5) to keep a paper when --fit-check is on",
     )
+    ingest_parser.add_argument(
+        "--batch-label",
+        default=None,
+        help="Optional explicit batch label for the ingest sub-collection",
+    )
 
     import_folder_parser = subparsers.add_parser(
         "import-folder",
@@ -2722,6 +2814,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--dry-run",
         action="store_true",
         help="Show what would be imported without writing notes",
+    )
+    import_folder_parser.add_argument(
+        "--with-zotero",
+        action="store_true",
+        default=False,
+        help="Also write imported files into the cluster Zotero collection",
+    )
+    import_folder_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the Obsidian-only confirmation prompt",
+    )
+    import_folder_parser.add_argument(
+        "--batch-label",
+        default=None,
+        help="Optional label for the manifest and Zotero batch sub-collection",
     )
 
     for parser_with_verify in (run_parser, ingest_parser):
@@ -2827,6 +2935,15 @@ def build_parser() -> argparse.ArgumentParser:
     clusters_subparsers.add_parser(
         "scaffold-missing",
         help="Find clusters with no hub/<slug>/ scaffold and create it. Idempotent.",
+    )
+    audit_parser = clusters_subparsers.add_parser(
+        "audit",
+        help="Run drift + collision + test-pattern checks (subset of doctor)",
+    )
+    audit_parser.add_argument(
+        "--cluster",
+        default=None,
+        help="Audit only this cluster slug (default: all)",
     )
 
     # v0.67: Phase 2 of the Codex skills brief - shell entry point for the
@@ -3731,6 +3848,7 @@ def main(argv: list[str] | None = None) -> int:
             fit_check=getattr(args, "fit_check", False),
             fit_check_threshold=getattr(args, "fit_check_threshold", 3),
             no_fit_check_auto_labels=getattr(args, "no_fit_check_auto_labels", False),
+            batch_label=getattr(args, "batch_label", None),
         )
         if rc == 0 and getattr(args, "fit_check", False) and not getattr(args, "no_fit_check_auto_labels", False):
             from research_hub.paper import apply_fit_check_to_labels
@@ -3910,6 +4028,7 @@ def main(argv: list[str] | None = None) -> int:
             append=args.append,
             force=args.force,
             show=args.show,
+            batch_label=args.batch_label,
         )
     if args.command == "ingest":
         rc = run_pipeline(
@@ -3921,6 +4040,7 @@ def main(argv: list[str] | None = None) -> int:
             fit_check=args.fit_check,
             fit_check_threshold=args.fit_check_threshold,
             no_fit_check_auto_labels=args.no_fit_check_auto_labels,
+            batch_label=args.batch_label,
         )
         if rc == 0 and args.fit_check and not args.no_fit_check_auto_labels:
             from research_hub.paper import apply_fit_check_to_labels
@@ -4065,6 +4185,8 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         if args.clusters_command == "scaffold-missing":
             return _clusters_scaffold_missing()
+        if args.clusters_command == "audit":
+            return _clusters_audit(args.cluster)
     if args.command == "topic":
         from research_hub.topic import (
             SubtopicProposal,

--- a/src/research_hub/doctor.py
+++ b/src/research_hub/doctor.py
@@ -330,6 +330,147 @@ def check_quote_orphan(cfg) -> CheckResult:
     return CheckResult("quote/orphan", "OK", f"All {quote_count} quotes reference live papers")
 
 
+def check_cluster_zotero_drift(cfg) -> list[CheckResult]:
+    """WARN when Obsidian count drifts materially above in-both count."""
+    from research_hub.clusters import ClusterRegistry
+    from research_hub.vault.sync import compute_sync_status
+    from research_hub.zotero.client import get_client
+
+    registry = ClusterRegistry(cfg.clusters_file)
+    try:
+        zot = get_client()
+    except Exception:
+        return [
+            CheckResult(
+                "cluster/zotero_drift",
+                "INFO",
+                "Zotero client unavailable; drift check skipped",
+            )
+        ]
+
+    drifted: list[str] = []
+    try:
+        for cluster in registry.list():
+            status = compute_sync_status(cluster, zot, cfg.raw)
+            drift = status.obsidian_count - status.in_both
+            threshold = max(5, status.obsidian_count // 20)
+            if drift > threshold:
+                drifted.append(
+                    f"{cluster.slug}: {drift} obsidian-only papers "
+                    f"(obsidian={status.obsidian_count}, in_both={status.in_both})"
+                )
+    except Exception as exc:
+        return [
+            CheckResult(
+                "cluster/zotero_drift",
+                "INFO",
+                f"Zotero drift check skipped: {exc}",
+            )
+        ]
+
+    if drifted:
+        return [
+            CheckResult(
+                "cluster/zotero_drift",
+                "WARN",
+                f"{len(drifted)} cluster(s) have Zotero drift > 5% threshold",
+                remedy="Run: python scripts/backfill_zotero.py --dry-run --cluster <slug>",
+                details="\n  ".join(drifted[:10]),
+            )
+        ]
+    return [
+        CheckResult(
+            "cluster/zotero_drift",
+            "OK",
+            "All clusters have Obsidian/Zotero counts within 5% drift",
+        )
+    ]
+
+
+def check_cluster_test_pattern(cfg) -> CheckResult:
+    """WARN on cluster slugs that look like test or scratch data."""
+    import fnmatch
+
+    from research_hub.clusters import ClusterRegistry
+
+    patterns = ["*-test", "*-scratch", "*-sandbox", "fresh-user-*", "*-smoke", "*-tmp"]
+    registry = ClusterRegistry(cfg.clusters_file)
+    matches: list[str] = []
+    for cluster in registry.list():
+        for pattern in patterns:
+            if fnmatch.fnmatch(cluster.slug, pattern):
+                matches.append(cluster.slug)
+                break
+
+    if matches:
+        return CheckResult(
+            "cluster/test_pattern",
+            "WARN",
+            f"{len(matches)} cluster(s) match a test/scratch slug pattern",
+            remedy="Delete with: python -m research_hub clusters delete <slug> --apply --force",
+            details="\n  ".join(matches),
+        )
+    return CheckResult("cluster/test_pattern", "OK", "No test-pattern clusters found")
+
+
+def check_cluster_collection_collision(cfg) -> CheckResult:
+    """WARN when multiple clusters share the same Zotero collection key."""
+    from research_hub.clusters import ClusterRegistry
+
+    registry = ClusterRegistry(cfg.clusters_file)
+    by_key: dict[str, list[str]] = {}
+    for cluster in registry.list():
+        key = (cluster.zotero_collection_key or "").strip()
+        if key:
+            by_key.setdefault(key, []).append(cluster.slug)
+
+    collisions = [(key, slugs) for key, slugs in by_key.items() if len(slugs) > 1]
+    if collisions:
+        details = "\n  ".join(
+            f"{key} -> [{', '.join(sorted(slugs))}]" for key, slugs in collisions
+        )
+        return CheckResult(
+            "cluster/collection_collision",
+            "WARN",
+            f"{len(collisions)} Zotero collection key(s) bound to >1 cluster",
+            remedy="Run: python -m research_hub clusters bind <slug> --zotero <new-key>",
+            details=details,
+        )
+    return CheckResult(
+        "cluster/collection_collision",
+        "OK",
+        "All cluster zotero_collection_key values are unique",
+    )
+
+
+def check_manifest_orphan_cluster(cfg) -> CheckResult:
+    """INFO on manifest entries that reference deleted clusters."""
+    from research_hub.clusters import ClusterRegistry
+    from research_hub.manifest import Manifest
+
+    registry = ClusterRegistry(cfg.clusters_file)
+    valid = {cluster.slug for cluster in registry.list()}
+    manifest_path = cfg.research_hub_dir / "manifest.jsonl"
+    if not manifest_path.exists():
+        return CheckResult("manifest/orphan_cluster", "OK", "no manifest yet")
+
+    seen: dict[str, int] = {}
+    for entry in Manifest(manifest_path).read_all():
+        if entry.cluster and entry.cluster not in valid:
+            seen[entry.cluster] = seen.get(entry.cluster, 0) + 1
+
+    if seen:
+        details = "\n  ".join(f"{slug}: {count} entries" for slug, count in sorted(seen.items()))
+        return CheckResult(
+            "manifest/orphan_cluster",
+            "INFO",
+            f"{len(seen)} cluster slug(s) in manifest are no longer in clusters.yaml",
+            remedy="Audit trail only. Manual prune of manifest if desired.",
+            details=details,
+        )
+    return CheckResult("manifest/orphan_cluster", "OK", "All manifest cluster references resolve")
+
+
 def check_defuddle_cli() -> CheckResult:
     """Report whether the optional defuddle CLI is available."""
     try:
@@ -834,12 +975,19 @@ def run_doctor(*, strict: bool = False) -> list[CheckResult]:
             results.append(check_nlm_chrome_orphans())
         except Exception as exc:
             results.append(CheckResult("nlm_chrome_orphans", "WARN", f"Could not check: {exc}"))
+        try:
+            results.extend(check_cluster_zotero_drift(cfg))
+        except Exception as exc:
+            results.append(CheckResult("cluster/zotero_drift", "WARN", f"check failed: {exc}"))
         for check in (
             check_cluster_missing_dir,
             check_cluster_orphan_papers,
             check_cluster_empty,
             check_cluster_cross_tagged,
             check_quote_orphan,
+            check_cluster_test_pattern,
+            check_cluster_collection_collision,
+            check_manifest_orphan_cluster,
         ):
             try:
                 results.append(check(cfg))

--- a/src/research_hub/importer.py
+++ b/src/research_hub/importer.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
+import sys
 import warnings
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +16,7 @@ import yaml
 
 from research_hub.clusters import ClusterRegistry, slugify
 from research_hub.dedup import DedupHit, DedupIndex
+from research_hub.manifest import Manifest, new_entry
 from research_hub.security import atomic_write_text, safe_join, validate_slug
 
 logger = logging.getLogger(__name__)
@@ -374,8 +377,25 @@ def import_folder(
     use_graphify: bool = False,
     graphify_graph: Path | None = None,
     dry_run: bool = False,
+    with_zotero: bool = False,
+    yes: bool = False,
+    batch_label: str | None = None,
 ) -> ImportReport:
     cluster_slug = validate_slug(cluster_slug, field="cluster_slug")
+    if not with_zotero and not dry_run:
+        msg = (
+            "WARNING: import-folder writes Obsidian only.\n"
+            f"  Cluster '{cluster_slug}' Zotero collection will NOT receive these files.\n"
+            "  To also write Zotero, re-run with --with-zotero (requires Zotero API set up).\n"
+        )
+        print(msg, file=sys.stderr)
+        if not yes and getattr(sys.stdin, "isatty", lambda: False)():
+            try:
+                response = input("Continue with Obsidian-only? [y/N]: ").strip().lower()
+            except EOFError:
+                response = ""
+            if response not in {"y", "yes"}:
+                raise SystemExit("aborted by user")
     folder_path = Path(folder).expanduser().resolve()
     if not folder_path.is_dir():
         raise ValueError(f"folder not found: {folder_path}")
@@ -386,11 +406,13 @@ def import_folder(
     _maybe_create_cluster(cfg, cluster_slug, dry_run=dry_run)
     dedup_path = cfg.research_hub_dir / "dedup_index.json"
     dedup = _load_dedup(dedup_path)
+    manifest = Manifest(cfg.research_hub_dir / "manifest.jsonl")
     cluster_raw_dir = safe_join(cfg.raw, cluster_slug)
     if not dry_run:
         cluster_raw_dir.mkdir(parents=True, exist_ok=True)
 
     report = ImportReport(folder=folder_path, cluster_slug=cluster_slug, dry_run=dry_run)
+    imported_records: list[dict[str, Any]] = []
 
     if use_graphify and not graphify_graph:
         warnings.warn(
@@ -455,12 +477,87 @@ def import_folder(
                     obsidian_path=str(note_path),
                 )
             ]
+            imported_records.append(
+                {
+                    "entry": entry,
+                    "title": title,
+                    "content_hash": content_hash,
+                    "note_path": note_path,
+                    "text": text,
+                }
+            )
 
         entry.status = "imported"
         report.entries.append(entry)
 
     if not dry_run and report.imported_count > 0:
         dedup.save(dedup_path)
+        manifest_query = batch_label or "import-folder"
+        manifest_batch_label = batch_label or ""
+        zotero_keys = [""] * len(imported_records)
+        if with_zotero and imported_records:
+            from research_hub.pipeline import (
+                _ensure_batch_subcollection,
+                resolve_batch_label,
+                write_papers_to_zotero,
+            )
+            from research_hub.zotero.client import get_client
+
+            zot = get_client()
+            cluster = ClusterRegistry(cfg.clusters_file).get(cluster_slug)
+            cluster_coll = cluster.zotero_collection_key if cluster else None
+            zotero_batch_label = resolve_batch_label(None, batch_label)
+            batch_coll = ""
+            if cluster_coll:
+                batch_coll = _ensure_batch_subcollection(
+                    zot,
+                    cluster_coll=cluster_coll,
+                    batch_label=zotero_batch_label,
+                    log=logger.info,
+                )
+            import_papers = [
+                {
+                    "title": record["title"],
+                    "doi": _hash_key(record["content_hash"]),
+                    "authors": [],
+                    "year": datetime.now(timezone.utc).year,
+                    "abstract": "",
+                    "journal": "(local file)",
+                    "slug": record["entry"].slug,
+                    "sub_category": cluster_slug,
+                    "summary": str(record["text"])[:500],
+                    "key_findings": [],
+                    "methodology": "",
+                    "relevance": "",
+                    "url": "",
+                }
+                for record in imported_records
+            ]
+            _zr, _papers_for_notes, errors = write_papers_to_zotero(
+                zot,
+                import_papers,
+                cluster_slug,
+                cluster_coll,
+                batch_coll=batch_coll or None,
+                batch_label=zotero_batch_label if cluster_coll else "",
+                log=logger.info,
+            )
+            if errors:
+                logger.warning("import-folder Zotero write had %d error(s)", len(errors))
+            zotero_keys = [paper.get("zotero_key", "") for paper in import_papers]
+            manifest_batch_label = zotero_batch_label
+        for record, zotero_key in zip(imported_records, zotero_keys):
+            manifest.append(
+                new_entry(
+                    cluster=cluster_slug,
+                    query=manifest_query,
+                    action="import-folder-with-zotero" if with_zotero else "import-folder",
+                    title=record["title"],
+                    zotero_key=zotero_key,
+                    obsidian_path=str(record["note_path"]),
+                    batch_label=manifest_batch_label,
+                )
+            )
 
     if graphify_graph and not dry_run:
         _apply_graphify_assignments(report, Path(graphify_graph))

--- a/src/research_hub/manifest.py
+++ b/src/research_hub/manifest.py
@@ -21,6 +21,7 @@ class ManifestEntry:
     zotero_key: str = ""
     obsidian_path: str = ""
     error: str = ""
+    batch_label: str = ""
 
 
 class Manifest:

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -325,7 +325,18 @@ def _ensure_batch_subcollection(
             return _collection_field(collection, "key")
 
     try:
-        result = zot.create_collection(batch_label, parent_key=cluster_coll)
+        # get_client() returns raw pyzotero.Zotero (which has
+        # create_collections(payload_list)), but ZoteroDualClient wraps it
+        # as create_collection(name, parent_key=...). Probe for both.
+        if hasattr(zot, "create_collections"):
+            result = zot.create_collections(
+                [{"name": batch_label, "parentCollection": cluster_coll}]
+            )
+        elif hasattr(zot, "create_collection"):
+            result = zot.create_collection(batch_label, parent_key=cluster_coll)
+        else:
+            log(f"[warn] zot has no create_collection(s) method")
+            return ""
         key = _extract_created_collection_key(result)
         if key:
             return key

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -5,8 +5,11 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 import traceback
+from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 
 from research_hub.clusters import ClusterRegistry
@@ -27,7 +30,7 @@ logger = logging.getLogger(__name__)
 ZOTERO_BATCH_SIZE = 50
 
 
-def _compose_hub_tags(pp: dict, cluster_slug: str | None) -> list[str]:
+def _compose_hub_tags(pp: dict, cluster_slug: str | None, batch_label: str = "") -> list[str]:
     """Compose research-hub namespace tags from a paper dict + cluster slug.
 
     Always includes 'research-hub'. Adds 'cluster/<slug>', 'type/<doc_type>',
@@ -48,6 +51,8 @@ def _compose_hub_tags(pp: dict, cluster_slug: str | None) -> list[str]:
     backend = pp.get("source") or pp.get("found_in")
     if backend:
         hub_tags.append(f"src/{backend}")
+    if batch_label:
+        hub_tags.append(f"batch:{batch_label}")
     existing = pp.get("tags") or []
     return list(dict.fromkeys(existing + hub_tags))
 
@@ -56,6 +61,26 @@ def _slugify(text: str) -> str:
     from research_hub.clusters import slugify
 
     return slugify(text)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utc_today_yyyymmdd() -> str:
+    return _utc_now().strftime("%Y%m%d")
+
+
+def _utc_now_yyyymmdd_hhmmss() -> str:
+    return _utc_now().strftime("%Y%m%d-%H%M%S")
+
+
+def resolve_batch_label(query: str | None, batch_label: str | None) -> str:
+    if batch_label is not None:
+        return str(batch_label).strip()
+    if query:
+        return f"{_utc_today_yyyymmdd()}-{_slugify(query)[:30]}".strip("-")
+    return f"manual-{_utc_now_yyyymmdd_hhmmss()}"
 
 
 def _build_note_html(pp: dict) -> str:
@@ -234,6 +259,140 @@ def _flush_batch(
         zr.append({"title": paper["title"], "status": "FAILED", "key": ""})
 
 
+def _collection_field(collection: dict, field: str) -> str:
+    if not isinstance(collection, dict):
+        return ""
+    data = collection.get("data", {})
+    if isinstance(data, dict) and data.get(field):
+        return str(data.get(field) or "")
+    return str(collection.get(field, "") or "")
+
+
+def _list_subcollections(zot, *, cluster_coll: str) -> list[dict]:
+    web = getattr(zot, "web", None) or zot
+    collections_sub = getattr(web, "collections_sub", None)
+    if callable(collections_sub):
+        try:
+            return list(collections_sub(cluster_coll) or [])
+        except Exception:
+            pass
+
+    collections = getattr(web, "collections", None)
+    if not callable(collections):
+        return []
+    try:
+        all_collections = collections() or []
+    except Exception:
+        return []
+    return [
+        coll
+        for coll in all_collections
+        if _collection_field(coll, "parentCollection") == cluster_coll
+    ]
+
+
+def _extract_created_collection_key(result) -> str:
+    successful = (result or {}).get("successful", {}) if isinstance(result, dict) else {}
+    first = next(iter(successful.values()), None) if successful else None
+    return (first or {}).get("key") or (first or {}).get("data", {}).get("key") or ""
+
+
+def _next_batch_label(zot, *, cluster_coll: str, batch_label: str) -> str:
+    existing_names = {
+        _collection_field(collection, "name")
+        for collection in _list_subcollections(zot, cluster_coll=cluster_coll)
+    }
+    if batch_label not in existing_names:
+        return batch_label
+    suffix = 2
+    while f"{batch_label}-{suffix}" in existing_names:
+        suffix += 1
+    return f"{batch_label}-{suffix}"
+
+
+def _ensure_batch_subcollection(
+    zot,
+    *,
+    cluster_coll: str,
+    batch_label: str,
+    log: Callable[[str], None],
+) -> str:
+    if not cluster_coll or not batch_label:
+        return ""
+
+    for collection in _list_subcollections(zot, cluster_coll=cluster_coll):
+        if _collection_field(collection, "name") == batch_label:
+            return _collection_field(collection, "key")
+
+    try:
+        result = zot.create_collection(batch_label, parent_key=cluster_coll)
+        key = _extract_created_collection_key(result)
+        if key:
+            return key
+        log(f"[warn] batch sub-collection create returned no key for {batch_label!r}: {result}")
+    except Exception as exc:
+        log(f"[warn] could not create batch sub-collection {batch_label!r}: {exc}")
+    return ""
+
+
+def write_papers_to_zotero(
+    zot,
+    papers: list[dict],
+    cluster_slug: str | None,
+    cluster_coll: str | None,
+    batch_coll: str | None = None,
+    batch_label: str = "",
+    *,
+    zotero_batch_size: int = ZOTERO_BATCH_SIZE,
+    log: Callable[[str], None] = print,
+) -> tuple[list[dict], list[dict], list[dict]]:
+    """Build Zotero item templates and flush them in batches."""
+    zr: list[dict] = []
+    papers_for_notes: list[dict] = []
+    errors: list[dict] = []
+    batch_templates: list[dict] = []
+    batch_papers: list[dict] = []
+    target_collection = (cluster_coll or "").strip()
+
+    for pp in papers:
+        template = zot.item_template("journalArticle")
+        template["title"] = pp["title"]
+        template["creators"] = pp["authors"]
+        template["date"] = pp["year"]
+        template["DOI"] = pp["doi"]
+        template["url"] = pp.get("url", "")
+        template["publicationTitle"] = pp.get("journal", "")
+        template["volume"] = pp.get("volume", "")
+        template["issue"] = pp.get("issue", "")
+        template["pages"] = pp.get("pages", "")
+        template["abstractNote"] = pp["abstract"]
+        template["tags"] = [
+            {"tag": tag}
+            for tag in _compose_hub_tags(pp, cluster_slug, batch_label=batch_label)
+        ]
+        collections = [target_collection] if target_collection else []
+        if batch_coll and batch_coll not in collections:
+            collections.append(batch_coll)
+        template["collections"] = collections
+        if len(collections) == 1:
+            log(f"  Routing to collection: {collections[0]} (cluster={cluster_slug or 'none'})")
+        else:
+            route = ", ".join(collections) if collections else "<none>"
+            log(f"  Routing to collection(s): {route} (cluster={cluster_slug or 'none'})")
+        batch_templates.append(template)
+        batch_papers.append(pp)
+        if len(batch_templates) >= zotero_batch_size:
+            _flush_batch(zot, batch_templates, batch_papers, zr, errors, log, papers_for_notes)
+            batch_templates = []
+            batch_papers = []
+            time.sleep(1)
+
+    if batch_templates:
+        _flush_batch(zot, batch_templates, batch_papers, zr, errors, log, papers_for_notes)
+
+    return zr, papers_for_notes, errors
+
+
 def append_cluster_query_to_existing(
     note_path: Path,
     query: str,
@@ -405,6 +564,7 @@ def run_pipeline(
     fit_check_threshold: int = 3,
     no_fit_check_auto_labels: bool = False,
     zotero_batch_size: int = ZOTERO_BATCH_SIZE,
+    batch_label: str | None = None,
 ) -> int:
     del no_fit_check_auto_labels
     cfg = get_config()
@@ -439,6 +599,12 @@ def run_pipeline(
     if query is None and cluster_slug is not None:
         if cluster_obj is not None and cluster_obj.first_query:
             query = cluster_obj.first_query
+    requested_batch_label = batch_label
+    if requested_batch_label is None:
+        env_batch_label = str(os.environ.get("RESEARCH_HUB_BATCH_LABEL", "") or "").strip()
+        requested_batch_label = env_batch_label or None
+    resolved_batch_label = resolve_batch_label(query, requested_batch_label)
+    explicit_batch_label = requested_batch_label is not None
     manifest = Manifest(cfg.research_hub_dir / "manifest.jsonl")
     dedup_path = cfg.research_hub_dir / "dedup_index.json"
     fit_rejected_by_doi, fit_rejected_by_title = _load_fit_check_rejections(cfg, cluster_slug)
@@ -535,33 +701,63 @@ def run_pipeline(
                             action="new",
                             doi=paper.get("doi", ""),
                             title=paper.get("title", ""),
+                            batch_label=resolved_batch_label,
                         )
                     )
             p(f"DRY RUN: would process {len(papers)} papers. Config OK. Exiting.")
             return 0
 
+        cluster_coll = cluster_obj.zotero_collection_key if cluster_obj else None
+        batch_coll = ""
+        zotero_batch_label = ""
         if no_zotero:
             zot = None
             dedup = _load_or_build_dedup(cfg, None, dry_run=False)
-            p("RESEARCH_HUB_NO_ZOTERO=1 — skipping Zotero, using Obsidian-only mode")
+            p("RESEARCH_HUB_NO_ZOTERO=1 - skipping Zotero, using Obsidian-only mode")
+            if cluster_slug:
+                print(
+                    "\n".join(
+                        [
+                            "=" * 60,
+                            "WARNING: Zotero writes DISABLED (RESEARCH_HUB_NO_ZOTERO=1)",
+                            f"This run will write Obsidian notes only. Cluster '{cluster_slug}'",
+                            "Zotero collection will NOT receive these papers. Unset the",
+                            "env var to re-enable Zotero writes.",
+                            "=" * 60,
+                        ]
+                    ),
+                    file=sys.stderr,
+                )
         else:
             zot = get_client()
             dedup = _load_or_build_dedup(cfg, zot, dry_run=False)
             p("Zotero client ready")
+            if cluster_slug and cluster_coll:
+                if not explicit_batch_label:
+                    resolved_batch_label = _next_batch_label(
+                        zot,
+                        cluster_coll=cluster_coll,
+                        batch_label=resolved_batch_label,
+                    )
+                batch_coll = _ensure_batch_subcollection(
+                    zot,
+                    cluster_coll=cluster_coll,
+                    batch_label=resolved_batch_label,
+                    log=p,
+                )
+                zotero_batch_label = resolved_batch_label
 
-        zr = []
-        obr = []
-        dr = []
-        errors = []
-        papers_for_notes = []
-        batch_templates: list[dict] = []
-        batch_papers: list[dict] = []
+        zr: list[dict] = []
+        obr: list[dict] = []
+        dr: list[dict] = []
+        errors: list[dict] = []
+        papers_for_notes: list[dict] = []
+        pending_zotero_papers: list[dict] = []
+        target_collection_key = cluster_coll or collection_key
 
         for i, pp in enumerate(papers):
             p(f"\n--- Paper {i+1}: {pp['title'][:60]}...")
             query_text = _query_for_paper(pp, query)
-            cluster_obj = clusters.get(cluster_slug) if cluster_slug else None
-            cluster_coll = cluster_obj.zotero_collection_key if cluster_obj else None
             if pp.get("year_drift_warning"):
                 p(
                     f"  [warn] year-drift: {pp['slug']} "
@@ -582,6 +778,7 @@ def run_pipeline(
                             doi=pp.get("doi", ""),
                             title=pp.get("title", ""),
                             error="below fit-check threshold",
+                            batch_label=resolved_batch_label,
                         )
                     )
                     zr.append({"title": pp["title"], "status": "SKIPPED_FIT_CHECK", "key": ""})
@@ -620,6 +817,7 @@ def run_pipeline(
                                 title=pp["title"],
                                 zotero_key=obsidian_hit.zotero_key or "",
                                 obsidian_path=obsidian_hit.obsidian_path,
+                                batch_label=resolved_batch_label,
                             )
                         )
                         p("  SKIPPED dup in Obsidian")
@@ -645,7 +843,13 @@ def run_pipeline(
                                     for tag in existing_item.get("data", {}).get("tags", [])
                                     if "tag" in tag
                                 }
-                                hub_tags = set(_compose_hub_tags(pp, cluster_slug))
+                                hub_tags = set(
+                                    _compose_hub_tags(
+                                        pp,
+                                        cluster_slug,
+                                        batch_label=zotero_batch_label,
+                                    )
+                                )
                                 new_tags = hub_tags - existing_tags
                                 if new_tags:
                                     existing_data = existing_item["data"]
@@ -671,6 +875,7 @@ def run_pipeline(
                                 doi=pp["doi"],
                                 title=pp["title"],
                                 zotero_key=zotero_hit.zotero_key or "",
+                                batch_label=resolved_batch_label,
                             )
                         )
                         p("  SKIPPED dup in Zotero")
@@ -707,33 +912,20 @@ def run_pipeline(
                 time.sleep(0.1)
                 continue
 
-            t = zot.item_template("journalArticle")
-            t["title"] = pp["title"]
-            t["creators"] = pp["authors"]
-            t["date"] = pp["year"]
-            t["DOI"] = pp["doi"]
-            t["url"] = pp.get("url", "")
-            t["publicationTitle"] = pp.get("journal", "")
-            t["volume"] = pp.get("volume", "")
-            t["issue"] = pp.get("issue", "")
-            t["pages"] = pp.get("pages", "")
-            t["abstractNote"] = pp["abstract"]
-            t["tags"] = [{"tag": x} for x in _compose_hub_tags(pp, cluster_slug)]
-            t["collections"] = [cluster_coll or collection_key]
-            p(
-                f"  Routing to collection: {cluster_coll or collection_key} "
-                f"(cluster={cluster_slug or 'none'})"
-            )
-            batch_templates.append(t)
-            batch_papers.append(pp)
-            if len(batch_templates) >= zotero_batch_size:
-                _flush_batch(zot, batch_templates, batch_papers, zr, errors, p, papers_for_notes)
-                batch_templates = []
-                batch_papers = []
-                time.sleep(1)
+            pending_zotero_papers.append(pp)
 
-        if batch_templates:
-            _flush_batch(zot, batch_templates, batch_papers, zr, errors, p, papers_for_notes)
+        if not no_zotero and pending_zotero_papers:
+            zr, papers_for_notes, zotero_errors = write_papers_to_zotero(
+                zot,
+                pending_zotero_papers,
+                cluster_slug,
+                target_collection_key,
+                batch_coll=batch_coll or None,
+                batch_label=zotero_batch_label,
+                zotero_batch_size=zotero_batch_size,
+                log=p,
+            )
+            errors.extend(zotero_errors)
 
         p("\n=== DOI VALIDATION ===")
         verify_cache = VerifyCache(cfg.research_hub_dir / "verify_cache.json") if verify else None
@@ -832,6 +1024,7 @@ def run_pipeline(
                         title=pp["title"],
                         zotero_key=zotero_key,
                         obsidian_path=str(file_path),
+                        batch_label=resolved_batch_label,
                     )
                 )
             except Exception as exc:
@@ -847,6 +1040,7 @@ def run_pipeline(
                         zotero_key=zotero_key,
                         obsidian_path=str(file_path),
                         error=str(exc),
+                        batch_label=resolved_batch_label,
                     )
                 )
                 errors.append(
@@ -929,6 +1123,8 @@ def run_pipeline(
 
     if cluster_obj is not None:
         _refresh_cluster_base(cfg, cluster_obj)
+    if no_zotero and cluster_slug and not dry_run:
+        print(f"[no-zotero] wrote {oc} obsidian notes; 0 zotero items", file=sys.stderr)
     return 0
 
 

--- a/src/research_hub/vault/sync.py
+++ b/src/research_hub/vault/sync.py
@@ -65,10 +65,26 @@ class ClusterSyncStatus:
 
 
 def list_cluster_notes(cluster_slug: str, raw_dir: Path) -> list[Path]:
-    """Find all Obsidian notes whose YAML topic_cluster matches a slug."""
+    """Find all Obsidian notes whose YAML topic_cluster matches a slug.
+
+    Skips soft-deleted notes living under raw/_deleted_*/ — they retain
+    their topic_cluster frontmatter so they can be restored, but should
+    not inflate sync/drift counts.
+    """
     if not raw_dir.exists():
         return []
-    return [md for md in sorted(raw_dir.rglob("*.md")) if _note_topic_cluster(md) == cluster_slug]
+    results: list[Path] = []
+    for md in sorted(raw_dir.rglob("*.md")):
+        # Skip anything under a top-level _deleted_* directory.
+        try:
+            rel_first = md.relative_to(raw_dir).parts[0]
+        except (ValueError, IndexError):
+            rel_first = ""
+        if rel_first.startswith("_deleted_"):
+            continue
+        if _note_topic_cluster(md) == cluster_slug:
+            results.append(md)
+    return results
 
 
 def list_zotero_collection_items(zot, collection_key: str) -> list[dict]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,8 @@ _ZOTERO_WRITE_TEST_MODULES = frozenset({
     "test_v073_parallel_search",
     "test_v073_batched_zotero",
     "test_v073_parallel_summarize",
+    "test_v074_drift_prevention",
+    "test_v074_batch_collection",
 })
 
 

--- a/tests/test_v074_backfill.py
+++ b/tests/test_v074_backfill.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts import backfill_zotero as bz
+
+
+class NotFoundError(Exception):
+    status_code = 404
+
+
+class FakeZotero:
+    def __init__(self, *, items_by_key=None, search_hits=None):
+        self.items_by_key = items_by_key or {}
+        self.search_hits = search_hits or {}
+        self.updated: list[dict] = []
+        self.created: list[dict] = []
+
+    def item(self, key):
+        payload = self.items_by_key.get(key)
+        if isinstance(payload, Exception):
+            raise payload
+        if payload is None:
+            raise NotFoundError(f"404 item not found: {key}")
+        return payload
+
+    def items(self, q=None, limit=10):
+        del limit
+        return list(self.search_hits.get(q, []))
+
+    def update_item(self, data):
+        copied = json.loads(json.dumps(data))
+        self.updated.append(copied)
+        key = copied.get("key", "")
+        if key and key in self.items_by_key and isinstance(self.items_by_key[key], dict):
+            self.items_by_key[key]["data"] = copied
+        return {"successful": {"0": {"key": key}}}
+
+    def item_template(self, item_type):
+        return {"itemType": item_type}
+
+    def create_items(self, items):
+        copied = json.loads(json.dumps(items))
+        self.created.extend(copied)
+        return {
+            "successful": {
+                str(idx): {"key": f"NEW{idx + 1}"}
+                for idx, _item in enumerate(copied)
+            }
+        }
+
+
+def _seed_vault(tmp_path: Path, *, slug: str = "survey", cluster_coll: str = "CLUSTER1") -> Path:
+    vault = tmp_path / "vault"
+    (vault / "raw" / slug).mkdir(parents=True, exist_ok=True)
+    research_hub_dir = vault / ".research_hub"
+    research_hub_dir.mkdir(parents=True, exist_ok=True)
+    (research_hub_dir / "clusters.yaml").write_text(
+        json.dumps(
+            {
+                "clusters": {
+                    slug: {
+                        "name": slug.title(),
+                        "zotero_collection_key": cluster_coll,
+                        "obsidian_subfolder": slug,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return vault
+
+
+def _write_note(vault: Path, slug: str, name: str, frontmatter: str) -> Path:
+    path = vault / "raw" / slug / name
+    path.write_text(f"---\n{frontmatter.rstrip()}\n---\n\n# Body\n", encoding="utf-8")
+    return path
+
+
+def _patch_zot(monkeypatch, zot: FakeZotero) -> None:
+    monkeypatch.setattr(bz, "ZoteroDualClient", lambda: SimpleNamespace(web=zot))
+
+
+def _patch_pipeline(monkeypatch, helper=None, batch_size: int = 50) -> None:
+    if helper is None:
+        helper = lambda *args, **kwargs: ([], [], [])
+    monkeypatch.setattr(bz, "resolve_pipeline_api", lambda: (helper, batch_size))
+
+
+def _plan_files(vault: Path, slug: str) -> list[Path]:
+    plan_dir = vault / ".research_hub" / "backfill" / slug
+    return [
+        plan_dir / "case_A_missing.json",
+        plan_dir / "case_B_skip.json",
+        plan_dir / "case_C_rebind.json",
+        plan_dir / "case_D_recreate.json",
+    ]
+
+
+def test_classify_case_B_already_in_collection(tmp_path):
+    vault = _seed_vault(tmp_path)
+    note = _write_note(vault, "survey", "paper.md", 'title: "Paper"\ndoi: "10.1/a"\nzotero-key: "K1"')
+    zot = FakeZotero(items_by_key={"K1": {"key": "K1", "data": {"collections": ["CLUSTER1"]}}})
+
+    entry, used_get = bz.classify_note(
+        zot,
+        "survey",
+        "CLUSTER1",
+        note,
+        bz.read_note_frontmatter(note),
+    )
+
+    assert used_get is True
+    assert entry.case == "B"
+
+
+def test_classify_case_C_item_exists_other_collection(tmp_path):
+    vault = _seed_vault(tmp_path)
+    note = _write_note(vault, "survey", "paper.md", 'title: "Paper"\ndoi: "10.1/a"\nzotero-key: "K2"')
+    zot = FakeZotero(items_by_key={"K2": {"key": "K2", "data": {"collections": ["OTHER"]}}})
+
+    entry, _ = bz.classify_note(zot, "survey", "CLUSTER1", note, bz.read_note_frontmatter(note))
+
+    assert entry.case == "C"
+    assert entry.target_zotero_key == "K2"
+
+
+def test_classify_case_D_item_404(tmp_path):
+    vault = _seed_vault(tmp_path)
+    note = _write_note(vault, "survey", "paper.md", 'title: "Paper"\ndoi: "10.1/a"\nzotero-key: "K3"')
+    zot = FakeZotero(items_by_key={"K3": NotFoundError("404 gone")})
+
+    entry, _ = bz.classify_note(zot, "survey", "CLUSTER1", note, bz.read_note_frontmatter(note))
+
+    assert entry.case == "D"
+
+
+def test_classify_case_A_no_zotero_key(tmp_path):
+    vault = _seed_vault(tmp_path)
+    note = _write_note(vault, "survey", "paper.md", 'title: "Paper"\ndoi: "10.1/a"')
+    zot = FakeZotero()
+
+    entry, used_get = bz.classify_note(zot, "survey", "CLUSTER1", note, bz.read_note_frontmatter(note))
+
+    assert used_get is False
+    assert entry.case == "A"
+
+
+def test_classify_doi_dedup_downgrades_A_to_C(tmp_path):
+    vault = _seed_vault(tmp_path)
+    note = _write_note(vault, "survey", "paper.md", 'title: "Paper"\ndoi: "10.1/a"')
+    zot = FakeZotero(
+        search_hits={
+            "10.1/a": [
+                {"key": "EXIST1", "data": {"key": "EXIST1", "DOI": "10.1/a"}},
+            ]
+        }
+    )
+
+    entry, _ = bz.classify_note(zot, "survey", "CLUSTER1", note, bz.read_note_frontmatter(note))
+
+    assert entry.case == "C"
+    assert entry.target_zotero_key == "EXIST1"
+
+
+def test_dry_run_writes_plan_files_no_zotero_writes(tmp_path, monkeypatch):
+    vault = _seed_vault(tmp_path)
+    _write_note(vault, "survey", "missing.md", 'title: "Missing"\ndoi: "10.1/a"')
+    _write_note(vault, "survey", "bound.md", 'title: "Bound"\ndoi: "10.1/b"\nzotero-key: "K1"')
+    zot = FakeZotero(items_by_key={"K1": {"key": "K1", "data": {"collections": ["CLUSTER1"]}}})
+    _patch_zot(monkeypatch, zot)
+    _patch_pipeline(monkeypatch)
+
+    assert bz.main(["--vault", str(vault), "--cluster", "survey", "--dry-run"]) == 0
+
+    for path in _plan_files(vault, "survey"):
+        assert path.exists(), path
+    assert zot.updated == []
+    assert zot.created == []
+
+
+def test_apply_case_C_calls_update_item_with_collections_appended(tmp_path, monkeypatch):
+    vault = _seed_vault(tmp_path)
+    _write_note(vault, "survey", "paper.md", 'title: "Paper"\ndoi: "10.1/a"\nzotero-key: "K2"')
+    zot = FakeZotero(items_by_key={"K2": {"key": "K2", "data": {"key": "K2", "collections": ["OTHER"]}}})
+    _patch_zot(monkeypatch, zot)
+    _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(bz.time, "sleep", lambda seconds: None)
+
+    assert bz.main(["--vault", str(vault), "--cluster", "survey", "--apply"]) == 0
+
+    assert len(zot.updated) == 1
+    assert set(zot.updated[0]["collections"]) == {"OTHER", "CLUSTER1"}
+    manifest_lines = (vault / ".research_hub" / "manifest.jsonl").read_text(encoding="utf-8").splitlines()
+    assert any(json.loads(line)["action"] == "backfill_C" for line in manifest_lines)
+
+
+def test_apply_case_D_calls_write_papers_to_zotero_and_updates_md(tmp_path, monkeypatch):
+    vault = _seed_vault(tmp_path)
+    note = _write_note(
+        vault,
+        "survey",
+        "paper.md",
+        'title: "Paper"\nauthors: "Jane Doe"\nyear: "2024"\ndoi: "10.1/a"\nzotero-key: "K3"',
+    )
+    zot = FakeZotero(items_by_key={"K3": NotFoundError("404 gone")})
+    _patch_zot(monkeypatch, zot)
+    calls: list[list[dict]] = []
+
+    def fake_write(_zot, papers, *_args, **_kwargs):
+        calls.append(json.loads(json.dumps(papers)))
+        papers[0]["zotero_key"] = "NEW1"
+        return ([{"title": papers[0]["title"], "status": "CREATED", "key": "NEW1"}], [], [])
+
+    _patch_pipeline(monkeypatch, helper=fake_write)
+    monkeypatch.setattr(bz.time, "sleep", lambda seconds: None)
+
+    assert bz.main(["--vault", str(vault), "--cluster", "survey", "--apply"]) == 0
+
+    assert len(calls) == 1
+    assert "zotero-key: \"NEW1\"" in note.read_text(encoding="utf-8")
+    manifest_lines = (vault / ".research_hub" / "manifest.jsonl").read_text(encoding="utf-8").splitlines()
+    assert any(json.loads(line)["action"] == "backfill_D" for line in manifest_lines)
+
+
+def test_rate_limit_enforced(tmp_path, monkeypatch):
+    vault = _seed_vault(tmp_path)
+    items = {}
+    for idx in range(5):
+        key = f"K{idx}"
+        items[key] = {"key": key, "data": {"key": key, "collections": ["OTHER"]}}
+        _write_note(
+            vault,
+            "survey",
+            f"paper-{idx}.md",
+            f'title: "Paper {idx}"\ndoi: "10.1/{idx}"\nzotero-key: "{key}"',
+        )
+    zot = FakeZotero(items_by_key=items)
+    _patch_zot(monkeypatch, zot)
+    _patch_pipeline(monkeypatch)
+
+    start = time.monotonic()
+    assert bz.main(
+        [
+            "--vault",
+            str(vault),
+            "--cluster",
+            "survey",
+            "--apply",
+            "--rate-limit",
+            "2",
+        ]
+    ) == 0
+    elapsed = time.monotonic() - start
+
+    assert len(zot.updated) == 5
+    assert elapsed >= 2.0
+
+
+def test_idempotent_skips_already_applied(tmp_path, monkeypatch):
+    vault = _seed_vault(tmp_path)
+    _write_note(vault, "survey", "paper.md", 'title: "Paper"\ndoi: "10.1/a"\nzotero-key: "K2"')
+    zot = FakeZotero(items_by_key={"K2": {"key": "K2", "data": {"key": "K2", "collections": ["OTHER"]}}})
+    _patch_zot(monkeypatch, zot)
+    _patch_pipeline(monkeypatch)
+    monkeypatch.setattr(bz.time, "sleep", lambda seconds: None)
+
+    assert bz.main(["--vault", str(vault), "--cluster", "survey", "--apply"]) == 0
+    assert bz.main(["--vault", str(vault), "--cluster", "survey", "--apply"]) == 0
+
+    assert len(zot.updated) == 1

--- a/tests/test_v074_batch_collection.py
+++ b/tests/test_v074_batch_collection.py
@@ -34,6 +34,9 @@ def _make_zotero(existing_subcollections=None):
     zot = MagicMock()
     zot.web = MagicMock()
     zot.web.collections_sub.return_value = list(existing_subcollections or [])
+    # _list_subcollections in pipeline.py iterates zot.collections() filtered
+    # by parentCollection; mirror that so existing subcollections get found.
+    zot.collections.return_value = list(existing_subcollections or [])
     zot.item_template.side_effect = lambda item_type: {"itemType": item_type}
 
     def _create_items(items):
@@ -45,7 +48,9 @@ def _make_zotero(existing_subcollections=None):
         }
 
     zot.create_items.side_effect = _create_items
-    zot.create_collection.return_value = {"successful": {"0": {"key": "BATCH123"}}}
+    # pyzotero.Zotero exposes create_collections(payload_list); the pipeline
+    # probes for it first via hasattr.
+    zot.create_collections.return_value = {"successful": {"0": {"key": "BATCH123"}}}
     return zot
 
 
@@ -63,7 +68,9 @@ def test_pipeline_creates_subcollection_per_batch_label(tmp_path, monkeypatch):
             verify=False,
             batch_label="2026-05-02-society",
         ) == 0
-        zot.create_collection.assert_called_once_with("2026-05-02-society", parent_key="CLUSTER123")
+        zot.create_collections.assert_called_once_with(
+            [{"name": "2026-05-02-society", "parentCollection": "CLUSTER123"}]
+        )
         template = zot.create_items.call_args_list[0].args[0][0]
         assert template["collections"] == ["CLUSTER123", "BATCH123"]
     finally:
@@ -86,7 +93,7 @@ def test_pipeline_reuses_existing_subcollection(tmp_path, monkeypatch):
             verify=False,
             batch_label="2026-05-02-society",
         ) == 0
-        zot.create_collection.assert_not_called()
+        zot.create_collections.assert_not_called()
         template = zot.create_items.call_args_list[0].args[0][0]
         assert template["collections"] == ["CLUSTER123", "BATCH123"]
     finally:
@@ -150,8 +157,8 @@ def test_pipeline_default_batch_label_from_query(tmp_path, monkeypatch):
             query="post-flood",
             verify=False,
         ) == 0
-        label = zot.create_collection.call_args.args[0]
-        assert re.match(r"^\d{8}-post-flood", label)
+        payload = zot.create_collections.call_args.args[0][0]
+        assert re.match(r"^\d{8}-post-flood", payload["name"])
     finally:
         hub_config._config = None
         hub_config._config_path = None
@@ -170,8 +177,8 @@ def test_pipeline_default_batch_label_manual(tmp_path, monkeypatch):
             query=None,
             verify=False,
         ) == 0
-        label = zot.create_collection.call_args.args[0]
-        assert re.match(r"^manual-\d{8}-\d{6}$", label)
+        payload = zot.create_collections.call_args.args[0][0]
+        assert re.match(r"^manual-\d{8}-\d{6}$", payload["name"])
     finally:
         hub_config._config = None
         hub_config._config_path = None
@@ -188,25 +195,27 @@ def test_same_day_same_query_appends_suffix(tmp_path, monkeypatch):
     zot.item_template.side_effect = lambda item_type: {"itemType": item_type}
     zot.create_items.side_effect = lambda items: {"successful": {"0": {"key": "Z0"}}}
 
-    def _collections_sub(_parent):
+    def _existing_payload(_parent=None):
         return [
             {"key": key, "data": {"name": name, "parentCollection": "CLUSTER123"}}
             for key, name in existing
         ]
 
-    def _create_collection(name, parent_key=None):
+    def _create_collections(payload_list):
+        name = payload_list[0]["name"]
         key = f"B{len(existing) + 1}"
         existing.append((key, name))
         return {"successful": {"0": {"key": key}}}
 
-    zot.web.collections_sub.side_effect = _collections_sub
-    zot.create_collection.side_effect = _create_collection
+    zot.web.collections_sub.side_effect = _existing_payload
+    zot.collections.side_effect = _existing_payload
+    zot.create_collections.side_effect = _create_collections
     monkeypatch.setattr(pipeline, "get_client", lambda: zot)
 
     try:
         assert pipeline.run_pipeline(dry_run=False, cluster_slug="agents", query="same query", verify=False) == 0
         assert pipeline.run_pipeline(dry_run=False, cluster_slug="agents", query="same query", verify=False) == 0
-        labels = [call.args[0] for call in zot.create_collection.call_args_list]
+        labels = [call.args[0][0]["name"] for call in zot.create_collections.call_args_list]
         assert labels == ["20260502-same-query", "20260502-same-query-2"]
     finally:
         hub_config._config = None

--- a/tests/test_v074_batch_collection.py
+++ b/tests/test_v074_batch_collection.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from research_hub.clusters import ClusterRegistry
+from research_hub.manifest import Manifest
+from tests.test_pipeline import _configure, _paper
+
+
+def _prepare_cfg(monkeypatch, tmp_path, *, cluster_query: str = "agents"):
+    from research_hub import config as hub_config
+    from research_hub import pipeline
+
+    cfg = _configure(monkeypatch, tmp_path, default_collection="ABCD1234")
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query=cluster_query, name="Agents", slug="agents")
+    registry.bind("agents", zotero_collection_key="CLUSTER123")
+    monkeypatch.setattr(pipeline, "check_duplicate", lambda zot, title, doi="", **kwargs: False)
+    monkeypatch.setattr(pipeline, "add_note", lambda zot, key, content: True)
+    monkeypatch.setattr(pipeline.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(pipeline, "update_cluster_links", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline, "_refresh_cluster_base", lambda *args, **kwargs: None)
+    return cfg, pipeline, hub_config
+
+
+def _write_papers(cfg, *papers):
+    (cfg.root / "papers_input.json").write_text(json.dumps(list(papers)), encoding="utf-8")
+
+
+def _make_zotero(existing_subcollections=None):
+    zot = MagicMock()
+    zot.web = MagicMock()
+    zot.web.collections_sub.return_value = list(existing_subcollections or [])
+    zot.item_template.side_effect = lambda item_type: {"itemType": item_type}
+
+    def _create_items(items):
+        return {
+            "successful": {
+                str(idx): {"key": f"Z{idx}"}
+                for idx, _item in enumerate(items)
+            }
+        }
+
+    zot.create_items.side_effect = _create_items
+    zot.create_collection.return_value = {"successful": {"0": {"key": "BATCH123"}}}
+    return zot
+
+
+def test_pipeline_creates_subcollection_per_batch_label(tmp_path, monkeypatch):
+    cfg, pipeline, hub_config = _prepare_cfg(monkeypatch, tmp_path)
+    _write_papers(cfg, _paper("Paper One", "paper-one", "10.1000/one"))
+    zot = _make_zotero()
+    monkeypatch.setattr(pipeline, "get_client", lambda: zot)
+
+    try:
+        assert pipeline.run_pipeline(
+            dry_run=False,
+            cluster_slug="agents",
+            query="society",
+            verify=False,
+            batch_label="2026-05-02-society",
+        ) == 0
+        zot.create_collection.assert_called_once_with("2026-05-02-society", parent_key="CLUSTER123")
+        template = zot.create_items.call_args_list[0].args[0][0]
+        assert template["collections"] == ["CLUSTER123", "BATCH123"]
+    finally:
+        hub_config._config = None
+        hub_config._config_path = None
+
+
+def test_pipeline_reuses_existing_subcollection(tmp_path, monkeypatch):
+    cfg, pipeline, hub_config = _prepare_cfg(monkeypatch, tmp_path)
+    _write_papers(cfg, _paper("Paper One", "paper-one", "10.1000/one"))
+    existing = [{"key": "BATCH123", "data": {"name": "2026-05-02-society", "parentCollection": "CLUSTER123"}}]
+    zot = _make_zotero(existing_subcollections=existing)
+    monkeypatch.setattr(pipeline, "get_client", lambda: zot)
+
+    try:
+        assert pipeline.run_pipeline(
+            dry_run=False,
+            cluster_slug="agents",
+            query="society",
+            verify=False,
+            batch_label="2026-05-02-society",
+        ) == 0
+        zot.create_collection.assert_not_called()
+        template = zot.create_items.call_args_list[0].args[0][0]
+        assert template["collections"] == ["CLUSTER123", "BATCH123"]
+    finally:
+        hub_config._config = None
+        hub_config._config_path = None
+
+
+def test_pipeline_batch_tag_appended(tmp_path, monkeypatch):
+    cfg, pipeline, hub_config = _prepare_cfg(monkeypatch, tmp_path)
+    _write_papers(cfg, _paper("Paper One", "paper-one", "10.1000/one"))
+    zot = _make_zotero()
+    monkeypatch.setattr(pipeline, "get_client", lambda: zot)
+
+    try:
+        assert pipeline.run_pipeline(
+            dry_run=False,
+            cluster_slug="agents",
+            query="society",
+            verify=False,
+            batch_label="2026-05-02-society",
+        ) == 0
+        template = zot.create_items.call_args_list[0].args[0][0]
+        tags = {tag["tag"] for tag in template["tags"]}
+        assert "batch:2026-05-02-society" in tags
+    finally:
+        hub_config._config = None
+        hub_config._config_path = None
+
+
+def test_pipeline_skips_subcollection_when_no_zotero(tmp_path, monkeypatch):
+    cfg, pipeline, hub_config = _prepare_cfg(monkeypatch, tmp_path)
+    _write_papers(cfg, _paper("Paper One", "paper-one", "10.1000/one"))
+    monkeypatch.setenv("RESEARCH_HUB_NO_ZOTERO", "1")
+    monkeypatch.setattr(pipeline, "get_client", lambda: (_ for _ in ()).throw(AssertionError("no client")))
+
+    try:
+        assert pipeline.run_pipeline(
+            dry_run=False,
+            cluster_slug="agents",
+            query="society",
+            verify=False,
+            batch_label="manual-batch",
+        ) == 0
+        entries = Manifest(cfg.research_hub_dir / "manifest.jsonl").read_all()
+        assert entries[-1].batch_label == "manual-batch"
+    finally:
+        hub_config._config = None
+        hub_config._config_path = None
+
+
+def test_pipeline_default_batch_label_from_query(tmp_path, monkeypatch):
+    cfg, pipeline, hub_config = _prepare_cfg(monkeypatch, tmp_path)
+    _write_papers(cfg, _paper("Paper One", "paper-one", "10.1000/one"))
+    zot = _make_zotero()
+    monkeypatch.setattr(pipeline, "get_client", lambda: zot)
+
+    try:
+        assert pipeline.run_pipeline(
+            dry_run=False,
+            cluster_slug="agents",
+            query="post-flood",
+            verify=False,
+        ) == 0
+        label = zot.create_collection.call_args.args[0]
+        assert re.match(r"^\d{8}-post-flood", label)
+    finally:
+        hub_config._config = None
+        hub_config._config_path = None
+
+
+def test_pipeline_default_batch_label_manual(tmp_path, monkeypatch):
+    cfg, pipeline, hub_config = _prepare_cfg(monkeypatch, tmp_path, cluster_query="")
+    _write_papers(cfg, _paper("Paper One", "paper-one", "10.1000/one"))
+    zot = _make_zotero()
+    monkeypatch.setattr(pipeline, "get_client", lambda: zot)
+
+    try:
+        assert pipeline.run_pipeline(
+            dry_run=False,
+            cluster_slug="agents",
+            query=None,
+            verify=False,
+        ) == 0
+        label = zot.create_collection.call_args.args[0]
+        assert re.match(r"^manual-\d{8}-\d{6}$", label)
+    finally:
+        hub_config._config = None
+        hub_config._config_path = None
+
+
+def test_same_day_same_query_appends_suffix(tmp_path, monkeypatch):
+    cfg, pipeline, hub_config = _prepare_cfg(monkeypatch, tmp_path)
+    _write_papers(cfg, _paper("Paper One", "paper-one", "10.1000/one"))
+    fixed_now = datetime(2026, 5, 2, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(pipeline, "_utc_now", lambda: fixed_now)
+    existing: list[tuple[str, str]] = []
+    zot = MagicMock()
+    zot.web = MagicMock()
+    zot.item_template.side_effect = lambda item_type: {"itemType": item_type}
+    zot.create_items.side_effect = lambda items: {"successful": {"0": {"key": "Z0"}}}
+
+    def _collections_sub(_parent):
+        return [
+            {"key": key, "data": {"name": name, "parentCollection": "CLUSTER123"}}
+            for key, name in existing
+        ]
+
+    def _create_collection(name, parent_key=None):
+        key = f"B{len(existing) + 1}"
+        existing.append((key, name))
+        return {"successful": {"0": {"key": key}}}
+
+    zot.web.collections_sub.side_effect = _collections_sub
+    zot.create_collection.side_effect = _create_collection
+    monkeypatch.setattr(pipeline, "get_client", lambda: zot)
+
+    try:
+        assert pipeline.run_pipeline(dry_run=False, cluster_slug="agents", query="same query", verify=False) == 0
+        assert pipeline.run_pipeline(dry_run=False, cluster_slug="agents", query="same query", verify=False) == 0
+        labels = [call.args[0] for call in zot.create_collection.call_args_list]
+        assert labels == ["20260502-same-query", "20260502-same-query-2"]
+    finally:
+        hub_config._config = None
+        hub_config._config_path = None

--- a/tests/test_v074_drift_prevention.py
+++ b/tests/test_v074_drift_prevention.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from research_hub.clusters import ClusterRegistry
+from research_hub.doctor import CheckResult
+from research_hub.manifest import Manifest, new_entry
+from research_hub.vault.sync import ClusterSyncStatus
+from tests.test_pipeline import _configure, _paper
+
+
+def _make_cfg(tmp_path: Path):
+    root = tmp_path / "vault"
+    raw = root / "raw"
+    research_hub_dir = root / ".research_hub"
+    raw.mkdir(parents=True)
+    research_hub_dir.mkdir(parents=True)
+    return SimpleNamespace(
+        root=root,
+        raw=raw,
+        research_hub_dir=research_hub_dir,
+        clusters_file=research_hub_dir / "clusters.yaml",
+    )
+
+
+def test_doctor_zotero_drift_warns_on_drifted_cluster(tmp_path, monkeypatch):
+    from research_hub import doctor
+    from research_hub.vault import sync as vault_sync
+
+    cfg = _make_cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(query="agents", name="Agents", slug="agents")
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: object())
+    monkeypatch.setattr(
+        vault_sync,
+        "compute_sync_status",
+        lambda cluster, zot, raw: ClusterSyncStatus(
+            cluster_slug=cluster.slug,
+            obsidian_count=50,
+            zotero_count=5,
+            in_both=4,
+        ),
+    )
+
+    result = doctor.check_cluster_zotero_drift(cfg)[0]
+    assert result.status == "WARN"
+    assert "agents" in result.details
+
+
+def test_doctor_zotero_drift_ok_within_threshold(tmp_path, monkeypatch):
+    from research_hub import doctor
+    from research_hub.vault import sync as vault_sync
+
+    cfg = _make_cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(query="agents", name="Agents", slug="agents")
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: object())
+    monkeypatch.setattr(
+        vault_sync,
+        "compute_sync_status",
+        lambda cluster, zot, raw: ClusterSyncStatus(
+            cluster_slug=cluster.slug,
+            obsidian_count=100,
+            zotero_count=100,
+            in_both=99,
+        ),
+    )
+
+    result = doctor.check_cluster_zotero_drift(cfg)[0]
+    assert result.status == "OK"
+
+
+def test_doctor_test_pattern_warns_on_matching_slugs(tmp_path):
+    from research_hub import doctor
+
+    cfg = _make_cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="foo-test", name="Foo", slug="foo-test")
+    registry.create(query="bar-scratch", name="Bar", slug="bar-scratch")
+    registry.create(query="fresh-user-x", name="Fresh", slug="fresh-user-x")
+    registry.create(query="real-cluster", name="Real", slug="real-cluster")
+
+    result = doctor.check_cluster_test_pattern(cfg)
+    assert result.status == "WARN"
+    assert "foo-test" in result.details
+    assert "bar-scratch" in result.details
+    assert "fresh-user-x" in result.details
+    assert "real-cluster" not in result.details
+
+
+def test_doctor_collection_collision_warns_on_shared_key(tmp_path):
+    from research_hub import doctor
+
+    cfg = _make_cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="alpha", name="Alpha", slug="alpha")
+    registry.create(query="beta", name="Beta", slug="beta")
+    registry.bind("alpha", zotero_collection_key="ABC123")
+    registry.bind("beta", zotero_collection_key="ABC123")
+
+    result = doctor.check_cluster_collection_collision(cfg)
+    assert result.status == "WARN"
+    assert "alpha" in result.details
+    assert "beta" in result.details
+
+
+def test_doctor_collection_collision_ok_when_unique(tmp_path):
+    from research_hub import doctor
+
+    cfg = _make_cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="alpha", name="Alpha", slug="alpha")
+    registry.create(query="beta", name="Beta", slug="beta")
+    registry.bind("alpha", zotero_collection_key="ABC123")
+    registry.bind("beta", zotero_collection_key="XYZ999")
+
+    result = doctor.check_cluster_collection_collision(cfg)
+    assert result.status == "OK"
+
+
+def test_doctor_manifest_orphan_cluster_info(tmp_path):
+    from research_hub import doctor
+
+    cfg = _make_cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(query="live", name="Live", slug="live")
+    manifest = Manifest(cfg.research_hub_dir / "manifest.jsonl")
+    manifest.append(new_entry(cluster="gone-cluster", query="q", action="new", title="Gone"))
+
+    result = doctor.check_manifest_orphan_cluster(cfg)
+    assert result.status == "INFO"
+    assert "gone-cluster" in result.details
+
+
+def test_import_folder_warns_without_with_zotero(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    vault_root = tmp_path / "vault"
+    source_dir = tmp_path / "docs"
+    source_dir.mkdir()
+    (source_dir / "note.md").write_text("# Imported\n\nBody", encoding="utf-8")
+    vault_root.mkdir()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "knowledge_base": {
+                    "root": str(vault_root),
+                    "raw": str(vault_root / "raw"),
+                    "hub": str(vault_root / "hub"),
+                    "projects": str(vault_root / "projects"),
+                    "logs": str(vault_root / "logs"),
+                    "obsidian_graph": str(vault_root / ".obsidian" / "graph.json"),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+    env["RESEARCH_HUB_ROOT"] = str(vault_root)
+    env["RESEARCH_HUB_ALLOW_EXTERNAL_ROOT"] = "1"
+    env["RESEARCH_HUB_CONFIG"] = str(config_path)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "research_hub",
+            "import-folder",
+            str(source_dir),
+            "--cluster",
+            "agents",
+            "--yes",
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0
+    assert "WARNING: import-folder writes Obsidian only" in proc.stderr
+
+
+def test_pipeline_no_zotero_banner_appears(tmp_path, monkeypatch, capsys):
+    from research_hub import config as hub_config
+    from research_hub import pipeline
+
+    cfg = _configure(monkeypatch, tmp_path, default_collection="ABCD1234")
+    ClusterRegistry(cfg.clusters_file).create(query="agents", name="Agents", slug="agents")
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps([_paper("Paper One", "paper-one", "10.1000/one")]),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("RESEARCH_HUB_NO_ZOTERO", "1")
+    monkeypatch.setattr(pipeline, "update_cluster_links", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline, "_refresh_cluster_base", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline.time, "sleep", lambda seconds: None)
+
+    try:
+        assert pipeline.run_pipeline(dry_run=False, cluster_slug="agents", verify=False) == 0
+        err = capsys.readouterr().err
+        assert "WARNING: Zotero writes DISABLED" in err
+        assert "[no-zotero] wrote 1 obsidian notes; 0 zotero items" in err
+    finally:
+        hub_config._config = None
+        hub_config._config_path = None
+
+
+def test_clusters_audit_exits_1_on_drift(tmp_path, monkeypatch):
+    from research_hub import cli
+
+    cfg = _make_cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(query="audit", name="Audit", slug="audit")
+    monkeypatch.setattr(cli, "get_config", lambda: cfg, raising=False)
+    monkeypatch.setattr(cli, "_load_zotero_if_configured", lambda: object())
+    monkeypatch.setattr(
+        "research_hub.doctor.check_cluster_test_pattern",
+        lambda cfg: CheckResult("cluster/test_pattern", "OK", "No test-pattern clusters found"),
+    )
+    monkeypatch.setattr(
+        "research_hub.doctor.check_cluster_collection_collision",
+        lambda cfg: CheckResult("cluster/collection_collision", "OK", "All unique"),
+    )
+    monkeypatch.setattr(
+        "research_hub.doctor.check_manifest_orphan_cluster",
+        lambda cfg: CheckResult("manifest/orphan_cluster", "OK", "All manifest cluster references resolve"),
+    )
+    monkeypatch.setattr(
+        "research_hub.vault.sync.compute_sync_status",
+        lambda cluster, zot, raw: ClusterSyncStatus(
+            cluster_slug=cluster.slug,
+            obsidian_count=10,
+            zotero_count=5,
+            in_both=4,
+        ),
+    )
+    monkeypatch.setattr(
+        "research_hub.doctor.check_cluster_zotero_drift",
+        lambda cfg: [
+            CheckResult(
+                "cluster/zotero_drift",
+                "WARN",
+                "1 cluster(s) have Zotero drift > 5% threshold",
+                details="audit: 6 obsidian-only papers (obsidian=10, in_both=4)",
+            )
+        ],
+    )
+    assert cli.main(["clusters", "audit"]) == 1
+
+    monkeypatch.setattr(
+        "research_hub.vault.sync.compute_sync_status",
+        lambda cluster, zot, raw: ClusterSyncStatus(
+            cluster_slug=cluster.slug,
+            obsidian_count=10,
+            zotero_count=10,
+            in_both=10,
+        ),
+    )
+    monkeypatch.setattr(
+        "research_hub.doctor.check_cluster_zotero_drift",
+        lambda cfg: [CheckResult("cluster/zotero_drift", "OK", "All clusters have Obsidian/Zotero counts within 5% drift")],
+    )
+    assert cli.main(["clusters", "audit"]) == 0


### PR DESCRIPTION
## Summary
First in a 4-PR drift-prevention stack. Fixes the workflow holes that let the maintainer's vault drift to **1023 obsidian-only papers** vs ~125 in cluster Zotero collections.

## Why
Before v0.74:
- `import-folder` silently wrote Obsidian-only (no Zotero, no warning, no audit)
- `RESEARCH_HUB_NO_ZOTERO=1` env-var was silently honored — no banner
- No drift surfaced to the user; doctor's `frontmatter_completeness` reported 1077 legacy gaps as INFO
- Each ingest into a cluster dumped into one parent collection — no way to see "what was added in this batch"

## Changes
- `import-folder --with-zotero` opt-in (default Obsidian-only with stderr WARNING + interactive prompt; `--yes` for non-interactive)
- Per-batch Zotero **sub-collection** `<cluster>/<YYYYMMDD-query-slug>` + `batch:<label>` tag — every ingest now navigable in the Zotero sidebar
- 4 new doctor checks: `cluster/zotero_drift`, `cluster/test_pattern`, `cluster/collection_collision`, `manifest/orphan_cluster`
- `clusters audit` CLI — one-table view of drift / collision / test-pattern / orphan, exits 1 on any issue
- `pipeline.write_papers_to_zotero()` extracted as a reusable helper (Part 1.2 refactor + hotfix to use pyzotero's `create_collections` API)
- `vault/sync.list_cluster_notes()` skips `raw/_deleted_*/` so soft-deleted notes don't inflate sync counts
- `ManifestEntry.batch_label` field (back-compat: empty default)
- 16 new tests in `tests/test_v074_drift_prevention.py` + `tests/test_v074_batch_collection.py`

## Test plan
- [ ] `python -m pytest tests/test_v074_drift_prevention.py tests/test_v074_batch_collection.py -v` → 16 green
- [ ] `python -m pytest -q` → no regression (was 2032 baseline, still 2032+)
- [ ] `python -m research_hub clusters audit` on a vault with drift → exits 1 with table
- [ ] `python -m research_hub import-folder ./pdfs --cluster x` → prompts confirmation; `--yes` skips; `--with-zotero` does both writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)