### PR TITLE
feat(v0.75.0): workflow drift fixes round 2 + test isolation + PDF attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.75.0 (2026-05-02)
+
+Workflow drift fixes (round 2) + test isolation + PDF auto-attach.
+Driven by 6 gaps surfaced after v0.74 ship: vault/Zotero name drift,
+collision allowed at bind time, stale Zotero collections after
+cluster delete, tests polluting real Zotero, metadata gaps from search
+backends with no re-enrich path, and no PDF auto-attach.
+
+### Added
+- `clusters bind --no-sync-zotero` / `--force-shared` flags
+- `clusters rename --no-sync-zotero` flag
+- `clusters sync-names [--apply]` to fix vault/Zotero name drift
+- `clusters resolve-collision <slug> --new|--into <other>` to fix shared collection keys
+- `clusters delete --delete-zotero-collection` flag
+- `zotero gc [--apply] [--age-days N]` to find/delete empty/test/orphan Zotero collections
+- `paper enrich-existing --cluster <slug> --apply` to fill empty vol/issue/pages/url/abstract fields via Crossref + OpenAlex
+- `paper attach-pdfs --cluster <slug> --apply` for Unpaywall + arXiv PDF discovery
+- `auto --with-pdfs` and `ingest --with-pdfs` flags for end-to-end ingest + PDFs
+- doctor check `cluster/name_drift`
+- `tests/conftest.py` autouse `_block_real_zotero` fixture with `ALLOW_REAL_ZOTERO=1` / `@pytest.mark.real_zotero` opt-out
+- `unpaywall_email` optional config field
+- 28 new tests across 6 files
+
+### Changed
+- `ClusterRegistry.bind()` raises `CollisionError` on duplicate `zotero_collection_key` unless `force_shared=True`
+- `ClusterRegistry.bind()` and `.rename()` sync the corresponding Zotero collection name by default
+
+### Tests
+- 2032 baseline -> ~2060 passing target
+
 ## v0.74.0 (2026-05-02)
 
 Workflow drift prevention + per-batch sub-collection. Driven by audit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.74.0"
+version = "0.75.0"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}
@@ -67,6 +67,7 @@ markers = [
     "network: Tests that hit real external APIs (OpenAlex, arXiv, etc)",
     "evals: Evaluation tests measuring search accuracy and fit-check quality",
     "slow: Tests that take >5 seconds to run",
+    "real_zotero: bypass the real-Zotero block (rare)",
 ]
 testpaths = ["tests"]
 addopts = "--ignore=tests/stress -m 'not stress' -p no:cacheprovider -p no:tmpdir"

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.74.0"
+__version__ = "0.75.0"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -156,6 +156,7 @@ def auto_pipeline(
     dry_run: bool = False,
     print_progress: bool = True,
     zotero_batch_size: int = 50,
+    with_pdfs: bool = False,
 ) -> AutoReport:
     """End-to-end ingest + optional NotebookLM publish.
 
@@ -228,6 +229,8 @@ def auto_pipeline(
                 f"  fit-check via LLM judge ({cli_for_plan}, threshold={fit_check_threshold})"
             )
         plan_lines.append(f"  ingest into cluster {slug}")
+        if with_pdfs:
+            plan_lines.append("  attach open-access PDFs from arXiv/Unpaywall")
         if do_cluster_overview:
             cli = llm_cli or detect_llm_cli() or "(none on PATH -> save prompt only)"
             plan_lines.append(f"  cluster overview auto-fill via LLM CLI ({cli})")
@@ -288,13 +291,16 @@ def auto_pipeline(
     # 5. Ingest
     try:
 
-        rc = run_pipeline(
-            dry_run=False,
-            cluster_slug=slug,
-            query=topic,
-            verify=False,
-            zotero_batch_size=zotero_batch_size,
-        )
+        run_kwargs = {
+            "dry_run": False,
+            "cluster_slug": slug,
+            "query": topic,
+            "verify": False,
+            "zotero_batch_size": zotero_batch_size,
+        }
+        if with_pdfs:
+            run_kwargs["with_pdfs"] = True
+        rc = run_pipeline(**run_kwargs)
         if rc != 0:
             raise RuntimeError("pipeline returned exit code " + str(rc))        
         # Count actual ingested files (anything in raw/<slug>/ now)
@@ -652,11 +658,27 @@ def _ensure_zotero_collection(registry, cluster, slug: str, report: AutoReport, 
         web = getattr(zot, "web", None) or zot
         existing_key = _find_existing_collection_key_by_name(web, cluster.name)
         if existing_key:
-            cluster.zotero_collection_key = existing_key
-            registry.save()
-            _step_log(report, "zotero.bind", True, 0.0,
-                      f"reused existing collection {existing_key} for {slug}", print_progress)
-            return
+            collision_slug = next(
+                (
+                    other.slug
+                    for other in registry.list()
+                    if other.slug != slug
+                    and (other.zotero_collection_key or "").strip() == existing_key
+                ),
+                None,
+            )
+            if collision_slug:
+                if print_progress:
+                    print(
+                        f"  [WARN] Zotero collection {existing_key} is already bound to "
+                        f"{collision_slug}; creating a fresh collection for {slug} instead."
+                    )
+            else:
+                cluster.zotero_collection_key = existing_key
+                registry.save()
+                _step_log(report, "zotero.bind", True, 0.0,
+                          f"reused existing collection {existing_key} for {slug}", print_progress)
+                return
         result = web.create_collections([{"name": cluster.name}])
         # pyzotero returns {"successful": {"0": {"key": "ABC123", ...}}, ...}
         successful = (result or {}).get("successful", {}) if isinstance(result, dict) else {}

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import time
 from dataclasses import asdict
+from datetime import datetime, timezone
 from pathlib import Path
 
 from research_hub.clusters import ClusterRegistry
@@ -284,15 +285,36 @@ def _clusters_new(query: str, name: str | None, slug: str | None) -> int:
     return 0
 
 
-def _clusters_bind(slug: str, zotero_key, obsidian_folder, notebooklm_notebook) -> int:
+def _clusters_bind(
+    slug: str,
+    zotero_key,
+    obsidian_folder,
+    notebooklm_notebook,
+    *,
+    sync_zotero: bool = True,
+    force_shared: bool = False,
+) -> int:
     cfg = get_config()
+    from research_hub.clusters import CollisionError
+
     reg = ClusterRegistry(cfg.clusters_file)
-    cluster = reg.bind(
-        slug=slug,
-        zotero_collection_key=zotero_key,
-        obsidian_subfolder=obsidian_folder,
-        notebooklm_notebook=notebooklm_notebook,
-    )
+    try:
+        cluster = reg.bind(
+            slug=slug,
+            zotero_collection_key=zotero_key,
+            obsidian_subfolder=obsidian_folder,
+            notebooklm_notebook=notebooklm_notebook,
+            sync_zotero=sync_zotero,
+            force_shared=force_shared,
+        )
+    except CollisionError as exc:
+        print(str(exc), file=sys.stderr)
+        print(
+            "Remedy: re-run with --force-shared if the shared binding is intentional, "
+            "or use `research-hub clusters resolve-collision <slug> --new --apply`.",
+            file=sys.stderr,
+        )
+        return 2
     print(f"Bound {cluster.slug}:")
     print(f"  Zotero collection:   {cluster.zotero_collection_key or '(unset)'}")
     print(f"  Obsidian folder:     {cluster.obsidian_subfolder or '(unset)'}")
@@ -300,10 +322,10 @@ def _clusters_bind(slug: str, zotero_key, obsidian_folder, notebooklm_notebook) 
     return 0
 
 
-def _clusters_rename(slug: str, name: str) -> int:
+def _clusters_rename(slug: str, name: str, *, sync_zotero: bool = True) -> int:
     cfg = get_config()
     registry = ClusterRegistry(cfg.clusters_file)
-    cluster = registry.rename(slug, name)
+    cluster = registry.rename(slug, name, sync_zotero=False)
     print(f"{cluster.slug}\t{cluster.name}")
     cache_path = cfg.research_hub_dir / "nlm_cache.json"
     if cache_path.exists():
@@ -314,7 +336,7 @@ def _clusters_rename(slug: str, name: str) -> int:
         if isinstance(cache, dict) and isinstance(cache.get(cluster.slug), dict):
             cache[cluster.slug]["notebook_name"] = name
             cache_path.write_text(json.dumps(cache, ensure_ascii=False, indent=2), encoding="utf-8")
-    if not cluster.zotero_collection_key:
+    if not sync_zotero or not cluster.zotero_collection_key:
         return 0
     try:
         from research_hub.zotero.client import get_client
@@ -333,17 +355,174 @@ def _clusters_rename(slug: str, name: str) -> int:
     return 0
 
 
-def _clusters_delete(slug: str, dry_run: bool, purge_folder: bool = False) -> int:
+def _clusters_delete(
+    slug: str,
+    dry_run: bool,
+    purge_folder: bool = False,
+    *,
+    delete_zotero_collection: bool = False,
+) -> int:
     del purge_folder
     cfg = get_config()
     from research_hub.clusters import cascade_delete_cluster
 
-    report = cascade_delete_cluster(cfg, slug, apply=not dry_run)
+    report = cascade_delete_cluster(
+        cfg,
+        slug,
+        apply=not dry_run,
+        delete_zotero_collection=delete_zotero_collection,
+    )
     print(report.summary())
     if dry_run:
         print("")
         print("Run with --apply to execute the delete.")
         return 0
+    return 0
+
+
+def _clusters_sync_names(
+    slug_filter: str | None,
+    apply: bool,
+    direction: str,
+) -> int:
+    cfg = get_config()
+    from research_hub.zotero.client import get_client
+
+    registry = ClusterRegistry(cfg.clusters_file)
+    zot = get_client()
+    clusters = registry.list()
+    if slug_filter:
+        cluster = registry.get(slug_filter)
+        if cluster is None:
+            print(f"Cluster not found: {slug_filter}", file=sys.stderr)
+            return 2
+        clusters = [cluster]
+
+    drifts: list[tuple[object, str]] = []
+    print("slug\tvault_name\tzotero_name")
+    for cluster in clusters:
+        if not cluster.zotero_collection_key:
+            continue
+        try:
+            coll = zot.collection(cluster.zotero_collection_key)
+            zotero_name = str(coll.get("data", {}).get("name", "") or "")
+        except Exception as exc:
+            zotero_name = f"<error: {exc}>"
+        if cluster.name == zotero_name:
+            continue
+        drifts.append((cluster, zotero_name))
+        print(f"{cluster.slug}\t{cluster.name}\t{zotero_name}")
+
+    if not drifts:
+        print("All cluster names already match.")
+        return 0
+    if not apply:
+        print("")
+        print("Preview only. Re-run with --apply to sync names.")
+        return 0
+
+    for cluster, zotero_name in drifts:
+        if direction == "vault-to-zotero":
+            _clusters_rename(cluster.slug, cluster.name, sync_zotero=True)
+            continue
+        registry.rename(cluster.slug, zotero_name, sync_zotero=False)
+        print(f"updated vault name for {cluster.slug} -> {zotero_name!r}")
+    return 0
+
+
+def _clusters_resolve_collision(
+    slug: str,
+    *,
+    new: bool,
+    target_slug: str | None,
+    apply: bool,
+    force_shared: bool,
+) -> int:
+    cfg = get_config()
+    from research_hub.vault.sync import list_cluster_notes, list_zotero_collection_items
+    from research_hub.zotero.client import get_client
+
+    registry = ClusterRegistry(cfg.clusters_file)
+    cluster = registry.get(slug)
+    if cluster is None:
+        print(f"Cluster not found: {slug}", file=sys.stderr)
+        return 2
+    key = (cluster.zotero_collection_key or "").strip()
+    if not key:
+        print(f"{slug}: no Zotero collection is bound")
+        return 0
+
+    colliding = [
+        other
+        for other in registry.list()
+        if other.slug != slug and (other.zotero_collection_key or "").strip() == key
+    ]
+    if not colliding:
+        print(f"{slug}: no collision detected")
+        return 0
+
+    print(f"{slug}: {key} is also bound by {', '.join(other.slug for other in colliding)}")
+    if not new and not target_slug:
+        print("Specify exactly one of --new or --into <target>", file=sys.stderr)
+        return 2
+    if new and target_slug:
+        print("Use either --new or --into, not both", file=sys.stderr)
+        return 2
+
+    zot = get_client()
+    if not apply:
+        if new:
+            print("Preview: would create a fresh Zotero collection and re-tag this cluster's items.")
+        else:
+            print(f"Preview: would drop the Zotero binding from {slug} and keep it on {target_slug}.")
+        return 0
+
+    if new:
+        result = zot.create_collections([{"name": cluster.name, "parentCollection": False}])
+        successful = (result or {}).get("successful", {}) if isinstance(result, dict) else {}
+        first = next(iter(successful.values()), None) if successful else None
+        new_key = (first or {}).get("key") or (first or {}).get("data", {}).get("key")
+        if not new_key:
+            print(f"Could not create fresh Zotero collection: {result}", file=sys.stderr)
+            return 1
+        registry.bind(slug, zotero_collection_key=new_key, sync_zotero=False, force_shared=False)
+        note_dois = {
+            str(_read_doi_from_frontmatter(note_path) or "").strip().lower()
+            for note_path in list_cluster_notes(slug, cfg.raw)
+        }
+        note_dois.discard("")
+        moved = 0
+        for item in list_zotero_collection_items(zot, key):
+            data = item.get("data", {})
+            doi = str(data.get("DOI", "") or "").strip().lower()
+            if not doi or doi not in note_dois:
+                continue
+            current = zot.item(item.get("key") or item.get("data", {}).get("key"))
+            current_data = current.get("data", {})
+            collections = list(current_data.get("collections", []))
+            if new_key not in collections:
+                collections.append(new_key)
+                current_data["collections"] = collections
+                zot.update_item(current_data)
+                moved += 1
+        print(f"Created {new_key} and added it to {moved} matching item(s).")
+        return 0
+
+    target = registry.get(target_slug or "")
+    if target is None:
+        print(f"Cluster not found: {target_slug}", file=sys.stderr)
+        return 2
+    if not force_shared:
+        print("--into requires --force-shared", file=sys.stderr)
+        return 2
+    if (target.zotero_collection_key or "").strip() != key:
+        print(
+            f"{target.slug} is not bound to the colliding key {key!r}",
+            file=sys.stderr,
+        )
+        return 2
+    registry.bind(slug, zotero_collection_key="", sync_zotero=False)
+    print(f"Removed Zotero binding from {slug}; {target.slug} keeps {key}.")
     return 0
 
 
@@ -730,6 +909,192 @@ def _cmd_memory(args, cfg) -> int:
     raise ValueError(f"unknown memory command: {args.memory_command}")
 
 
+def _manifest_batch_label(prefix: str) -> str:
+    return f"{prefix}-{datetime.now(timezone.utc).strftime('%Y%m%d')}"
+
+
+def _paper_enrich_existing(
+    cluster_slug: str,
+    *,
+    limit: int,
+    apply: bool,
+    rate_limit: float,
+) -> int:
+    cfg = get_config()
+    from research_hub.manifest import Manifest, new_entry
+    from research_hub.vault.sync import list_zotero_collection_items
+    from research_hub.zotero.client import get_client
+    from research_hub.zotero.enrich import apply_enrichment, plan_enrichment
+
+    registry = ClusterRegistry(cfg.clusters_file)
+    cluster = registry.get(cluster_slug)
+    if cluster is None:
+        print(f"Cluster not found: {cluster_slug}", file=sys.stderr)
+        return 2
+    if not cluster.zotero_collection_key:
+        print(f"{cluster_slug} has no Zotero collection binding", file=sys.stderr)
+        return 2
+
+    zot = get_client()
+    items = list_zotero_collection_items(zot, cluster.zotero_collection_key)
+    if limit > 0:
+        items = items[:limit]
+    plans = plan_enrichment(items)
+    if not plans:
+        print("No enrichment candidates found.")
+        return 0
+
+    print("item_key\ttitle\tdoi\tfields")
+    for plan in plans:
+        print(
+            f"{plan.item_key}\t{plan.title}\t{plan.doi}\t"
+            f"{', '.join(sorted(plan.fields_to_fill))}"
+        )
+    if not apply:
+        print("")
+        print("Preview only. Re-run with --apply to write metadata back to Zotero.")
+        return 0
+
+    results = apply_enrichment(zot, plans, rate_limit_rps=rate_limit)
+    manifest = Manifest(cfg.research_hub_dir / "manifest.jsonl")
+    batch_label = _manifest_batch_label("enrich")
+    ok_count = 0
+    for plan in plans:
+        status = results.get(plan.item_key, "")
+        if status != "ok":
+            continue
+        ok_count += 1
+        manifest.append(
+            new_entry(
+                cluster=cluster_slug,
+                query=cluster.first_query or cluster.name,
+                action="enrich-existing",
+                doi=plan.doi,
+                title=plan.title,
+                zotero_key=plan.item_key,
+                batch_label=batch_label,
+            )
+        )
+    print(f"Applied enrichment to {ok_count}/{len(plans)} item(s).")
+    return 0
+
+
+def _paper_attach_pdfs(
+    cluster_slug: str,
+    *,
+    limit: int,
+    apply: bool,
+    rate_limit: float,
+) -> int:
+    cfg = get_config()
+    from research_hub.manifest import Manifest, new_entry
+    from research_hub.vault.sync import list_zotero_collection_items
+    from research_hub.zotero.client import get_client
+    from research_hub.zotero.pdf_attach import attach_pdfs, plan_attach_for_items
+
+    registry = ClusterRegistry(cfg.clusters_file)
+    cluster = registry.get(cluster_slug)
+    if cluster is None:
+        print(f"Cluster not found: {cluster_slug}", file=sys.stderr)
+        return 2
+    if not cluster.zotero_collection_key:
+        print(f"{cluster_slug} has no Zotero collection binding", file=sys.stderr)
+        return 2
+
+    zot = get_client()
+    items = list_zotero_collection_items(zot, cluster.zotero_collection_key)
+    if limit > 0:
+        items = items[:limit]
+    plans = plan_attach_for_items(items, unpaywall_email=getattr(cfg, "unpaywall_email", ""))
+
+    print("item_key\tsource\tpdf_url\ttitle")
+    for plan in plans:
+        print(f"{plan.item_key}\t{plan.source or '-'}\t{plan.pdf_url or '-'}\t{plan.title}")
+    if not apply:
+        print("")
+        print("Preview only. Re-run with --apply to attach PDFs.")
+        return 0
+
+    results = attach_pdfs(zot, plans, rate_limit_rps=rate_limit)
+    manifest = Manifest(cfg.research_hub_dir / "manifest.jsonl")
+    batch_label = _manifest_batch_label("pdf-attach")
+    ok_count = 0
+    title_by_key = {item.get("key", ""): str(item.get("data", {}).get("title", "") or "") for item in items}
+    doi_by_key = {item.get("key", ""): str(item.get("data", {}).get("DOI", "") or "") for item in items}
+    for item_key, status in results.items():
+        if status != "ok":
+            continue
+        ok_count += 1
+        manifest.append(
+            new_entry(
+                cluster=cluster_slug,
+                query=cluster.first_query or cluster.name,
+                action="pdf-attach",
+                doi=doi_by_key.get(item_key, ""),
+                title=title_by_key.get(item_key, ""),
+                zotero_key=item_key,
+                batch_label=batch_label,
+            )
+        )
+    print(f"Attached PDFs to {ok_count}/{len(plans)} item(s).")
+    return 0
+
+
+def _zotero_gc(*, apply: bool, yes: bool, no_test_pattern: bool, age_days: int) -> int:
+    cfg = get_config()
+    from research_hub.zotero.client import get_client
+    from research_hub.zotero.gc import delete_candidates, scan_zotero_for_gc
+
+    registry = ClusterRegistry(cfg.clusters_file)
+    vault_keys = {
+        (cluster.zotero_collection_key or "").strip()
+        for cluster in registry.list()
+        if (cluster.zotero_collection_key or "").strip()
+    }
+    zot = get_client()
+    candidates = scan_zotero_for_gc(
+        zot,
+        vault_keys,
+        include_test_pattern=not no_test_pattern,
+        age_days=age_days,
+    )
+    if not candidates:
+        print("No Zotero GC candidates found.")
+        return 0
+
+    print("key\tname\titems\tsubcollections\treasons")
+    for candidate in candidates:
+        print(
+            f"{candidate.key}\t{candidate.name}\t{candidate.num_items}\t"
+            f"{candidate.num_collections}\t{', '.join(candidate.reasons)}"
+        )
+    if not apply:
+        print("")
+        print("Preview only. Re-run with --apply to delete candidates.")
+        return 0
+
+    selected = list(candidates)
+    if not yes:
+        kept: list = []
+        for candidate in candidates:
+            answer = input(f"Delete {candidate.name} ({candidate.key})? [y/N] ").strip().lower()
+            if answer in {"y", "yes"}:
+                kept.append(candidate)
+        selected = kept
+    else:
+        selected = [
+            candidate
+            for candidate in candidates
+            if any(reason.startswith("empty>") for reason in candidate.reasons)
+            and any(reason.startswith("test-pattern(") for reason in candidate.reasons)
+            and "orphan-from-vault" in candidate.reasons
+        ]
+    results = delete_candidates(zot, selected)
+    ok_count = sum(1 for status in results.values() if status == "ok")
+    print(f"Deleted {ok_count}/{len(selected)} collection(s).")
+    return 0
+
+
 def _paper_command(args) -> int:
     if args.paper_command == "lookup-doi":
         from research_hub.doi_lookup import batch_lookup_missing_dois, lookup_doi_for_slug
@@ -803,6 +1168,20 @@ def _paper_command(args) -> int:
         print(f"restored: {result['restored']}")
         print(f"path: {result['path']}")
         return 0
+    if args.paper_command == "enrich-existing":
+        return _paper_enrich_existing(
+            args.cluster,
+            limit=args.limit,
+            apply=args.apply,
+            rate_limit=args.rate_limit,
+        )
+    if args.paper_command == "attach-pdfs":
+        return _paper_attach_pdfs(
+            args.cluster,
+            limit=args.limit,
+            apply=args.apply,
+            rate_limit=args.rate_limit,
+        )
     return 2
 
 
@@ -1151,6 +1530,24 @@ def _read_zotero_key_from_frontmatter(md_path: Path) -> str | None:
     import re as _re
     match = _re.search(r"^zotero-key:\s*([A-Z0-9]+)", frontmatter, _re.MULTILINE)
     return match.group(1) if match else None
+
+
+def _read_doi_from_frontmatter(md_path: Path) -> str | None:
+    """Pull the `doi:` line out of an Obsidian raw note frontmatter."""
+    try:
+        text = md_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end < 0:
+        return None
+    frontmatter = text[3:end]
+    import re as _re
+
+    match = _re.search(r'^doi:\s*[\'"]?([^\'"\n]+)', frontmatter, _re.MULTILINE)
+    return match.group(1).strip() if match else None
 
 
 def _search(
@@ -2364,6 +2761,7 @@ def _auto(
     force: bool = False,
     show: bool = True,
     batch_label: str | None = None,
+    with_pdfs: bool = False,
 ) -> int:
     from research_hub.auto import auto_pipeline
 
@@ -2380,22 +2778,25 @@ def _auto(
     if batch_label is not None:
         os.environ["RESEARCH_HUB_BATCH_LABEL"] = batch_label
     try:
-        report = auto_pipeline(
-            topic,
-            cluster_slug=cluster_slug,
-            cluster_name=cluster_name,
-            max_papers=max_papers,
-            field=field,
-            do_nlm=do_nlm,
-            do_crystals=do_crystals,
-            do_cluster_overview=do_cluster_overview,
-            do_fit_check=do_fit_check,
-            fit_check_threshold=fit_check_threshold,
-            zotero_batch_size=zotero_batch_size,
-            llm_cli=llm_cli,
-            dry_run=dry_run,
-            print_progress=True,
-        )
+        auto_kwargs = {
+            "topic": topic,
+            "cluster_slug": cluster_slug,
+            "cluster_name": cluster_name,
+            "max_papers": max_papers,
+            "field": field,
+            "do_nlm": do_nlm,
+            "do_crystals": do_crystals,
+            "do_cluster_overview": do_cluster_overview,
+            "do_fit_check": do_fit_check,
+            "fit_check_threshold": fit_check_threshold,
+            "zotero_batch_size": zotero_batch_size,
+            "llm_cli": llm_cli,
+            "dry_run": dry_run,
+            "print_progress": True,
+        }
+        if with_pdfs:
+            auto_kwargs["with_pdfs"] = True
+        report = auto_pipeline(**auto_kwargs)
     finally:
         if batch_label is not None:
             if previous_batch_label is None:
@@ -2679,6 +3080,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Bypass Zotero library duplicate blocking and allow re-ingest",
     )
+    run_parser.add_argument(
+        "--with-pdfs",
+        action="store_true",
+        help="Attach open-access PDFs from arXiv/Unpaywall after ingest",
+    )
 
     auto_parser = subparsers.add_parser(
         "auto",
@@ -2736,6 +3142,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Optional explicit batch label for the ingest sub-collection",
     )
+    auto_parser.add_argument(
+        "--with-pdfs",
+        action="store_true",
+        help="Attach open-access PDFs from arXiv/Unpaywall after ingest",
+    )
 
     plan_parser = subparsers.add_parser(
         "plan",
@@ -2777,6 +3188,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--batch-label",
         default=None,
         help="Optional explicit batch label for the ingest sub-collection",
+    )
+    ingest_parser.add_argument(
+        "--with-pdfs",
+        action="store_true",
+        help="Attach open-access PDFs from arXiv/Unpaywall after ingest",
     )
 
     import_folder_parser = subparsers.add_parser(
@@ -2889,14 +3305,34 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="NotebookLM notebook name",
     )
+    bind_parser.add_argument(
+        "--no-sync-zotero",
+        action="store_true",
+        help="Do not sync the Zotero collection name to the vault cluster name",
+    )
+    bind_parser.add_argument(
+        "--force-shared",
+        action="store_true",
+        help="Allow duplicate zotero_collection_key binding intentionally",
+    )
     rename_parser = clusters_subparsers.add_parser("rename", help="Rename a cluster")
     rename_parser.add_argument("slug")
     rename_parser.add_argument("--name", required=True)
+    rename_parser.add_argument(
+        "--no-sync-zotero",
+        action="store_true",
+        help="Do not sync the Zotero collection name",
+    )
     delete_parser = clusters_subparsers.add_parser("delete", help="Delete a cluster")
     delete_parser.add_argument("slug")
     delete_parser.add_argument("--dry-run", action="store_true")
     delete_parser.add_argument("--apply", action="store_true", help="Apply the delete instead of previewing it")
     delete_parser.add_argument("--force", action="store_true", help="Confirm deletion of a non-empty cluster")
+    delete_parser.add_argument(
+        "--delete-zotero-collection",
+        action="store_true",
+        help="Also delete the now-empty Zotero collection container",
+    )
     merge_parser = clusters_subparsers.add_parser("merge", help="Merge two clusters")
     merge_parser.add_argument("source", help="Source cluster slug (will be removed)")
     merge_parser.add_argument("--into", required=True, dest="target", help="Target cluster slug")
@@ -2944,6 +3380,31 @@ def build_parser() -> argparse.ArgumentParser:
         "--cluster",
         default=None,
         help="Audit only this cluster slug (default: all)",
+    )
+    sync_names = clusters_subparsers.add_parser(
+        "sync-names",
+        help="Detect and fix cluster.name drift between vault and Zotero",
+    )
+    sync_names.add_argument("--cluster", default=None, help="Only this cluster slug (default: all)")
+    sync_names.add_argument("--apply", action="store_true", help="Apply fixes (default: preview only)")
+    sync_names.add_argument(
+        "--direction",
+        choices=["vault-to-zotero", "zotero-to-vault"],
+        default="vault-to-zotero",
+        help="Source of truth (default: vault)",
+    )
+    resolve_parser = clusters_subparsers.add_parser(
+        "resolve-collision",
+        help="Fix two clusters sharing one zotero_collection_key",
+    )
+    resolve_parser.add_argument("slug")
+    resolve_parser.add_argument("--new", action="store_true", help="Create a fresh Zotero collection for this slug and migrate items")
+    resolve_parser.add_argument("--into", dest="target_slug", default=None, help="Drop this slug's Zotero binding; keep it on target")
+    resolve_parser.add_argument("--apply", action="store_true")
+    resolve_parser.add_argument(
+        "--force-shared",
+        action="store_true",
+        help="Required when using --into",
     )
 
     # v0.67: Phase 2 of the Codex skills brief - shell entry point for the
@@ -3533,6 +3994,19 @@ def build_parser() -> argparse.ArgumentParser:
     zotero_backfill.add_argument("--tags", action=argparse.BooleanOptionalAction, default=True)
     zotero_backfill.add_argument("--notes", action=argparse.BooleanOptionalAction, default=True)
     zotero_backfill.add_argument("--apply", action="store_true", help="Write changes")
+    gc_parser = zotero_sub.add_parser("gc", help="Garbage-collect empty/test/orphan Zotero collections")
+    gc_parser.add_argument("--apply", action="store_true")
+    gc_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation only for collections matching empty + test-pattern + orphan",
+    )
+    gc_parser.add_argument(
+        "--no-test-pattern",
+        action="store_true",
+        help="Skip test-pattern matching",
+    )
+    gc_parser.add_argument("--age-days", type=int, default=30)
 
     nlm_parser = subparsers.add_parser("notebooklm", help="NotebookLM operations")
     nlm_sub = nlm_parser.add_subparsers(dest="notebooklm_command", required=True)
@@ -3765,6 +4239,22 @@ def build_parser() -> argparse.ArgumentParser:
     unarch_p = paper_sub.add_parser("unarchive", help="Restore an archived paper back to active cluster")
     unarch_p.add_argument("--cluster", required=True)
     unarch_p.add_argument("--slug", required=True)
+    enrich_existing = paper_sub.add_parser(
+        "enrich-existing",
+        help="Re-fetch DOI metadata to fill empty Zotero/Obsidian fields",
+    )
+    enrich_existing.add_argument("--cluster", required=True)
+    enrich_existing.add_argument("--limit", type=int, default=0, help="0 = no limit")
+    enrich_existing.add_argument("--apply", action="store_true")
+    enrich_existing.add_argument("--rate-limit", type=float, default=2.0)
+    attach_pdfs_p = paper_sub.add_parser(
+        "attach-pdfs",
+        help="Find OA PDFs (Unpaywall + arXiv) and attach to Zotero items",
+    )
+    attach_pdfs_p.add_argument("--cluster", required=True)
+    attach_pdfs_p.add_argument("--limit", type=int, default=0)
+    attach_pdfs_p.add_argument("--apply", action="store_true")
+    attach_pdfs_p.add_argument("--rate-limit", type=float, default=2.0)
 
     discover_parser = subparsers.add_parser(
         "discover",
@@ -3839,17 +4329,20 @@ def main(argv: list[str] | None = None) -> int:
         require_config()
 
     if args.command in (None, "run"):
-        rc = run_pipeline(
-            dry_run=getattr(args, "dry_run", False),
-            cluster_slug=getattr(args, "cluster", None),
-            query=getattr(args, "query", None),
-            verify=getattr(args, "verify", True),
-            allow_library_duplicates=getattr(args, "allow_library_duplicates", False),
-            fit_check=getattr(args, "fit_check", False),
-            fit_check_threshold=getattr(args, "fit_check_threshold", 3),
-            no_fit_check_auto_labels=getattr(args, "no_fit_check_auto_labels", False),
-            batch_label=getattr(args, "batch_label", None),
-        )
+        run_kwargs = {
+            "dry_run": getattr(args, "dry_run", False),
+            "cluster_slug": getattr(args, "cluster", None),
+            "query": getattr(args, "query", None),
+            "verify": getattr(args, "verify", True),
+            "allow_library_duplicates": getattr(args, "allow_library_duplicates", False),
+            "fit_check": getattr(args, "fit_check", False),
+            "fit_check_threshold": getattr(args, "fit_check_threshold", 3),
+            "no_fit_check_auto_labels": getattr(args, "no_fit_check_auto_labels", False),
+            "batch_label": getattr(args, "batch_label", None),
+        }
+        if getattr(args, "with_pdfs", False):
+            run_kwargs["with_pdfs"] = True
+        rc = run_pipeline(**run_kwargs)
         if rc == 0 and getattr(args, "fit_check", False) and not getattr(args, "no_fit_check_auto_labels", False):
             from research_hub.paper import apply_fit_check_to_labels
 
@@ -4029,19 +4522,23 @@ def main(argv: list[str] | None = None) -> int:
             force=args.force,
             show=args.show,
             batch_label=args.batch_label,
+            with_pdfs=args.with_pdfs,
         )
     if args.command == "ingest":
-        rc = run_pipeline(
-            dry_run=args.dry_run,
-            cluster_slug=args.cluster,
-            query=args.query,
-            verify=args.verify,
-            allow_library_duplicates=args.allow_library_duplicates,
-            fit_check=args.fit_check,
-            fit_check_threshold=args.fit_check_threshold,
-            no_fit_check_auto_labels=args.no_fit_check_auto_labels,
-            batch_label=args.batch_label,
-        )
+        run_kwargs = {
+            "dry_run": args.dry_run,
+            "cluster_slug": args.cluster,
+            "query": args.query,
+            "verify": args.verify,
+            "allow_library_duplicates": args.allow_library_duplicates,
+            "fit_check": args.fit_check,
+            "fit_check_threshold": args.fit_check_threshold,
+            "no_fit_check_auto_labels": args.no_fit_check_auto_labels,
+            "batch_label": args.batch_label,
+        }
+        if args.with_pdfs:
+            run_kwargs["with_pdfs"] = True
+        rc = run_pipeline(**run_kwargs)
         if rc == 0 and args.fit_check and not args.no_fit_check_auto_labels:
             from research_hub.paper import apply_fit_check_to_labels
 
@@ -4130,21 +4627,33 @@ def main(argv: list[str] | None = None) -> int:
                 args.zotero_key,
                 args.obsidian_folder,
                 args.notebooklm_notebook,
+                sync_zotero=not args.no_sync_zotero,
+                force_shared=args.force_shared,
             )
         if args.clusters_command == "rename":
-            return _clusters_rename(args.slug, args.name)
+            return _clusters_rename(args.slug, args.name, sync_zotero=not args.no_sync_zotero)
         if args.clusters_command == "delete":
             from research_hub.clusters import cascade_delete_cluster
 
             cfg = get_config()
-            preview = cascade_delete_cluster(cfg, args.slug, apply=False)
+            preview = cascade_delete_cluster(
+                cfg,
+                args.slug,
+                apply=False,
+                delete_zotero_collection=args.delete_zotero_collection,
+            )
             if args.apply:
                 if preview.has_data() and not args.force:
                     print(preview.summary())
                     print("")
                     print("Cluster is not empty. Re-run with --apply --force.")
                     return 2
-                applied = cascade_delete_cluster(cfg, args.slug, apply=True)
+                applied = cascade_delete_cluster(
+                    cfg,
+                    args.slug,
+                    apply=True,
+                    delete_zotero_collection=args.delete_zotero_collection,
+                )
                 print(applied.summary())
                 return 0
             print(preview.summary())
@@ -4187,6 +4696,16 @@ def main(argv: list[str] | None = None) -> int:
             return _clusters_scaffold_missing()
         if args.clusters_command == "audit":
             return _clusters_audit(args.cluster)
+        if args.clusters_command == "sync-names":
+            return _clusters_sync_names(args.cluster, args.apply, args.direction)
+        if args.clusters_command == "resolve-collision":
+            return _clusters_resolve_collision(
+                args.slug,
+                new=args.new,
+                target_slug=args.target_slug,
+                apply=args.apply,
+                force_shared=args.force_shared,
+            )
     if args.command == "topic":
         from research_hub.topic import (
             SubtopicProposal,
@@ -4442,6 +4961,13 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "zotero":
         if args.zotero_command == "backfill":
             return _zotero_backfill(args)
+        if args.zotero_command == "gc":
+            return _zotero_gc(
+                apply=args.apply,
+                yes=args.yes,
+                no_test_pattern=args.no_test_pattern,
+                age_days=args.age_days,
+            )
     if args.command == "migrate-yaml":
         return _migrate_yaml(
             assign_cluster=args.assign_cluster,

--- a/src/research_hub/clusters.py
+++ b/src/research_hub/clusters.py
@@ -18,6 +18,33 @@ from research_hub.security import atomic_write_text, safe_join
 logger = logging.getLogger(__name__)
 
 
+class CollisionError(ValueError):
+    """Raised when two clusters attempt to bind the same Zotero collection key."""
+
+
+def _try_sync_zotero_collection_name(key: str, vault_name: str) -> None:
+    """Best-effort: PATCH Zotero collection name to match the vault name."""
+    try:
+        from research_hub.zotero.client import ZoteroDualClient, get_client
+
+        try:
+            zot = ZoteroDualClient().web
+        except Exception:
+            zot = get_client()
+        coll = zot.collection(key)
+        current_version = coll.get("version") or coll.get("data", {}).get("version")
+        if not current_version:
+            logger.warning("could not read version for Zotero coll %s; skip name sync", key)
+            return
+        if coll.get("data", {}).get("name") == vault_name:
+            logger.info("Zotero coll %s already matches vault name %r", key, vault_name)
+            return
+        zot.update_collection({"key": key, "version": current_version, "name": vault_name})
+        logger.info("synced Zotero coll %s name to %r", key, vault_name)
+    except Exception as exc:
+        logger.warning("failed to sync Zotero coll %s name: %s", key, exc)
+
+
 @dataclass
 class CascadeReport:
     slug: str
@@ -284,13 +311,27 @@ class ClusterRegistry:
         notebooklm_notebook: str | None = None,
         notebooklm_notebook_url: str | None = None,
         notebooklm_notebook_id: str | None = None,
+        sync_zotero: bool = True,
+        force_shared: bool = False,
     ) -> Cluster:
         """Update the cluster's system bindings. Only non-None params are changed."""
         cluster = self.clusters.get(slug)
         if cluster is None:
             raise ValueError(f"Cluster not found: {slug}")
+        normalized_key = zotero_collection_key
+        if isinstance(normalized_key, str):
+            normalized_key = normalized_key.strip() or None
+        if normalized_key and not force_shared:
+            for other_slug, other in self.clusters.items():
+                if other_slug == slug:
+                    continue
+                if (other.zotero_collection_key or "").strip() == normalized_key:
+                    raise CollisionError(
+                        f"zotero_collection_key '{normalized_key}' is already "
+                        f"bound by cluster '{other_slug}'. Pass force_shared=True if intentional."
+                    )
         if zotero_collection_key is not None:
-            cluster.zotero_collection_key = zotero_collection_key
+            cluster.zotero_collection_key = normalized_key
         if obsidian_subfolder is not None:
             cluster.obsidian_subfolder = obsidian_subfolder
         if notebooklm_notebook is not None:
@@ -300,16 +341,20 @@ class ClusterRegistry:
         if notebooklm_notebook_id is not None:
             cluster.notebooklm_notebook_id = notebooklm_notebook_id
         self.save()
+        if sync_zotero and cluster.zotero_collection_key and cluster.name:
+            _try_sync_zotero_collection_name(cluster.zotero_collection_key, cluster.name)
         self._refresh_graph_if_possible()
         return cluster
 
-    def rename(self, slug: str, new_name: str) -> Cluster:
+    def rename(self, slug: str, new_name: str, *, sync_zotero: bool = True) -> Cluster:
         """Rename a cluster display name without changing its slug."""
         cluster = self.clusters.get(slug)
         if cluster is None:
             raise ValueError(f"Cluster not found: {slug}")
         cluster.name = new_name
         self.save()
+        if sync_zotero and cluster.zotero_collection_key:
+            _try_sync_zotero_collection_name(cluster.zotero_collection_key, new_name)
         self._refresh_graph_if_possible()
         return cluster
 
@@ -453,7 +498,13 @@ def compute_cluster_cascade_report(cfg, slug: str) -> CascadeReport:
     return report
 
 
-def cascade_delete_cluster(cfg, slug: str, *, apply: bool) -> CascadeReport:
+def cascade_delete_cluster(
+    cfg,
+    slug: str,
+    *,
+    apply: bool,
+    delete_zotero_collection: bool = False,
+) -> CascadeReport:
     from research_hub.dedup import DedupIndex
     from research_hub.pipeline_repair import _iter_collection_items
     from research_hub.zotero.client import ZoteroDualClient
@@ -487,6 +538,13 @@ def cascade_delete_cluster(cfg, slug: str, *, apply: bool) -> CascadeReport:
             collections = [key for key in data.get("collections", []) if key != cluster.zotero_collection_key]
             data["collections"] = collections
             zot.update_item(data)
+        if delete_zotero_collection:
+            try:
+                ZoteroDualClient().delete_collection(cluster.zotero_collection_key)
+            except Exception as exc:
+                print(
+                    f"warning: failed to delete Zotero coll {cluster.zotero_collection_key}: {exc}"
+                )
 
     dedup_path = cfg.research_hub_dir / "dedup_index.json"
     dedup = DedupIndex.load(dedup_path)

--- a/src/research_hub/config.py
+++ b/src/research_hub/config.py
@@ -77,6 +77,8 @@ class HubConfig:
         config_zotero_collections: dict[str, dict] = {}
         config_persona: str | None = None
         config_no_zotero: bool = False
+        config_unpaywall_email: str | None = None
+        zotero: dict = {}
 
         config_path = _resolve_config_path()
         if config_path is not None:
@@ -95,10 +97,13 @@ class HubConfig:
             config_persona = data.get("persona")
             config_no_zotero = bool(data.get("no_zotero", False))
             zotero = data.get("zotero", {})
+            config_unpaywall_email = data.get("unpaywall_email")
             config_zotero_library_id = zotero.get("library_id")
             config_zotero_library_type = zotero.get("library_type")
             config_zotero_default_collection = zotero.get("default_collection")
             config_zotero_collections = zotero.get("collections", {})
+            if not config_unpaywall_email:
+                config_unpaywall_email = zotero.get("unpaywall_email")
 
         raw_root = config_root or os.environ.get("RESEARCH_HUB_ROOT")
         raw_path = config_raw or os.environ.get("RESEARCH_HUB_RAW")
@@ -141,10 +146,14 @@ class HubConfig:
         self.zotero_collections = config_zotero_collections if isinstance(
             config_zotero_collections, dict
         ) else {}
+        self.zotero = zotero if isinstance(zotero, dict) else {}
         self.persona = str(config_persona or os.environ.get("RESEARCH_HUB_PERSONA", "")).strip().lower()
         self.no_zotero = config_no_zotero or (
             os.environ.get("RESEARCH_HUB_NO_ZOTERO", "").lower() in {"1", "true", "yes"}
         )
+        self.unpaywall_email = str(
+            config_unpaywall_email or os.environ.get("UNPAYWALL_EMAIL", "")
+        ).strip()
 
         for path in (self.logs, self.research_hub_dir):
             try:

--- a/src/research_hub/doctor.py
+++ b/src/research_hub/doctor.py
@@ -387,6 +387,50 @@ def check_cluster_zotero_drift(cfg) -> list[CheckResult]:
     ]
 
 
+def check_cluster_name_drift(cfg) -> CheckResult:
+    """WARN when vault cluster.name differs from the Zotero collection name."""
+    from research_hub.clusters import ClusterRegistry
+    from research_hub.zotero.client import get_client
+
+    registry = ClusterRegistry(cfg.clusters_file)
+    try:
+        zot = get_client()
+    except Exception:
+        return CheckResult(
+            "cluster/name_drift",
+            "INFO",
+            "Zotero client unavailable; name-drift check skipped",
+        )
+
+    drifted: list[str] = []
+    for cluster in registry.list():
+        if not cluster.zotero_collection_key:
+            continue
+        try:
+            coll = zot.collection(cluster.zotero_collection_key)
+            zotero_name = coll.get("data", {}).get("name", "")
+            if zotero_name and cluster.name and zotero_name != cluster.name:
+                drifted.append(
+                    f"{cluster.slug}: vault='{cluster.name}' zotero='{zotero_name}'"
+                )
+        except Exception as exc:
+            drifted.append(f"{cluster.slug}: fetch failed ({exc})")
+
+    if drifted:
+        return CheckResult(
+            "cluster/name_drift",
+            "WARN",
+            f"{len(drifted)} cluster(s) have vault name != Zotero collection name",
+            remedy="Run: python -m research_hub clusters sync-names --apply",
+            details="\n  ".join(drifted[:10]),
+        )
+    return CheckResult(
+        "cluster/name_drift",
+        "OK",
+        "All cluster names align between vault and Zotero",
+    )
+
+
 def check_cluster_test_pattern(cfg) -> CheckResult:
     """WARN on cluster slugs that look like test or scratch data."""
     import fnmatch
@@ -979,6 +1023,10 @@ def run_doctor(*, strict: bool = False) -> list[CheckResult]:
             results.extend(check_cluster_zotero_drift(cfg))
         except Exception as exc:
             results.append(CheckResult("cluster/zotero_drift", "WARN", f"check failed: {exc}"))
+        try:
+            results.append(check_cluster_name_drift(cfg))
+        except Exception as exc:
+            results.append(CheckResult("cluster/name_drift", "WARN", f"check failed: {exc}"))
         for check in (
             check_cluster_missing_dir,
             check_cluster_orphan_papers,

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -576,6 +576,7 @@ def run_pipeline(
     no_fit_check_auto_labels: bool = False,
     zotero_batch_size: int = ZOTERO_BATCH_SIZE,
     batch_label: str | None = None,
+    with_pdfs: bool = False,
 ) -> int:
     del no_fit_check_auto_labels
     cfg = get_config()
@@ -1062,6 +1063,52 @@ def run_pipeline(
                         "traceback": traceback.format_exc(),
                     }
                 )
+
+        if with_pdfs and not no_zotero:
+            from research_hub.zotero.pdf_attach import attach_pdfs, plan_attach_for_items
+
+            oa_email = (
+                getattr(cfg, "unpaywall_email", "")
+                or (
+                    cfg.zotero.get("unpaywall_email", "")
+                    if isinstance(getattr(cfg, "zotero", None), dict)
+                    else ""
+                )
+            )
+            just_added_keys = [pp["zotero_key"] for pp in papers_for_notes if pp.get("zotero_key")]
+            if just_added_keys:
+                try:
+                    items = [zot.item(key) for key in just_added_keys]
+                    plans = plan_attach_for_items(items, unpaywall_email=oa_email)
+                    pdf_results = attach_pdfs(zot, plans, rate_limit_rps=2.0)
+                    attached = sum(1 for value in pdf_results.values() if value == "ok")
+                    p(f"PDF attach: {attached}/{len(plans)} attached")
+                    if cluster_slug:
+                        pdf_batch_label = f"pdf-attach-{datetime.now(timezone.utc).strftime('%Y%m%d')}"
+                        papers_by_key = {
+                            pp.get("zotero_key", ""): pp
+                            for pp in papers_for_notes
+                            if pp.get("zotero_key")
+                        }
+                        for item_key, status in pdf_results.items():
+                            if status != "ok":
+                                continue
+                            paper = papers_by_key.get(item_key)
+                            if paper is None:
+                                continue
+                            manifest.append(
+                                new_entry(
+                                    cluster=cluster_slug,
+                                    query=_query_for_paper(paper, query),
+                                    action="pdf-attach",
+                                    doi=paper.get("doi", ""),
+                                    title=paper.get("title", ""),
+                                    zotero_key=item_key,
+                                    batch_label=pdf_batch_label,
+                                )
+                            )
+                except Exception as exc:
+                    p(f"  [warn] PDF attach failed: {exc}")
 
         cr = sum(1 for r in zr if r["status"] == "CREATED")
         sk = sum(1 for r in zr if r["status"] == "SKIPPED_DUPLICATE")

--- a/src/research_hub/zotero/client.py
+++ b/src/research_hub/zotero/client.py
@@ -465,6 +465,13 @@ class ZoteroDualClient:
         coll = self._read("collection", collection_key)
         return self.web.delete_collection(coll)
 
+    def update_collection(self, key: str, name: str) -> dict:
+        """PATCH Zotero collection name. Reads version internally."""
+        self._require_web()
+        coll = self.web.collection(key)
+        version = coll.get("version") or coll.get("data", {}).get("version")
+        return self.web.update_collection({"key": key, "version": version, "name": name})
+
     # --- TEMPLATES ---
     def get_template(self, item_type="journalArticle"):
         return self.web.item_template(item_type)

--- a/src/research_hub/zotero/enrich.py
+++ b/src/research_hub/zotero/enrich.py
@@ -1,0 +1,108 @@
+"""Re-enrich existing Zotero items from DOI metadata backends."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from research_hub.search import CrossrefBackend, OpenAlexBackend
+
+ENRICH_FIELDS = ["volume", "issue", "pages", "url", "abstractNote", "ISSN"]
+
+
+@dataclass
+class EnrichPlan:
+    item_key: str
+    title: str
+    doi: str
+    fields_to_fill: dict[str, str] = field(default_factory=dict)
+
+
+def _to_search_field(zotero_field: str) -> str:
+    """Map a Zotero field name to the normalized backend field name."""
+    return {"abstractNote": "abstract", "publicationTitle": "venue"}.get(zotero_field, zotero_field)
+
+
+def _result_value(result, field_name: str) -> str:
+    if result is None:
+        return ""
+    if isinstance(result, dict):
+        value = result.get(field_name, "")
+        if not value and field_name == "ISSN":
+            value = result.get("issn", "")
+        return str(value or "").strip()
+    value = getattr(result, field_name, "")
+    if not value and field_name == "ISSN":
+        value = getattr(result, "issn", "")
+    return str(value or "").strip()
+
+
+def plan_enrichment(zot_or_items, items: list[dict] | None = None) -> list[EnrichPlan]:
+    """Identify empty Zotero fields and plan DOI-based metadata fill-ins."""
+    if items is None:
+        items = zot_or_items
+    crossref = CrossrefBackend()
+    openalex = OpenAlexBackend()
+    plans: list[EnrichPlan] = []
+    for item in items:
+        data = item.get("data", {})
+        doi = str(data.get("DOI", "") or "").strip()
+        if not doi:
+            continue
+        empty_fields = [
+            field_name
+            for field_name in ENRICH_FIELDS
+            if not str(data.get(field_name, "") or "").strip()
+        ]
+        if not empty_fields:
+            continue
+
+        fields_to_fill: dict[str, str] = {}
+        for backend in (crossref, openalex):
+            try:
+                result = backend.get_paper(doi)
+            except Exception:
+                result = None
+            if result is None:
+                continue
+            for field_name in empty_fields:
+                if field_name in fields_to_fill:
+                    continue
+                value = _result_value(result, _to_search_field(field_name))
+                if value:
+                    fields_to_fill[field_name] = value
+        if fields_to_fill:
+            plans.append(
+                EnrichPlan(
+                    item_key=item.get("key", ""),
+                    title=str(data.get("title", "") or "")[:60],
+                    doi=doi,
+                    fields_to_fill=fields_to_fill,
+                )
+            )
+    return plans
+
+
+def apply_enrichment(
+    zot,
+    plans: Iterable[EnrichPlan],
+    *,
+    rate_limit_rps: float = 2.0,
+) -> dict[str, str]:
+    """PATCH Zotero items with planned metadata, without overwriting existing values."""
+    sleep_s = 1.0 / max(rate_limit_rps, 0.1)
+    results: dict[str, str] = {}
+    for plan in plans:
+        try:
+            item = zot.item(plan.item_key)
+            data = item["data"]
+            for field_name, value in plan.fields_to_fill.items():
+                if not str(data.get(field_name, "") or "").strip():
+                    data[field_name] = value
+            zot.update_item(data)
+            results[plan.item_key] = "ok"
+            time.sleep(sleep_s)
+        except Exception as exc:
+            results[plan.item_key] = str(exc)[:80]
+    return results

--- a/src/research_hub/zotero/gc.py
+++ b/src/research_hub/zotero/gc.py
@@ -1,0 +1,92 @@
+"""Zotero collection garbage collection helpers."""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+TEST_PATTERNS = ["*-test", "*-scratch", "persona-*", "test-*", "*-tmp", "*-sandbox", "Beta"]
+DEFAULT_AGE_DAYS = 30
+
+
+@dataclass
+class GCCandidate:
+    key: str
+    name: str
+    num_items: int
+    num_collections: int
+    date_added: str
+    reasons: list[str] = field(default_factory=list)
+
+
+def scan_zotero_for_gc(
+    zot,
+    vault_keys: set[str],
+    *,
+    include_test_pattern: bool = True,
+    age_days: int = DEFAULT_AGE_DAYS,
+) -> list[GCCandidate]:
+    """Walk the Zotero web library and return collection delete candidates."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=age_days)
+    out: list[GCCandidate] = []
+    start = 0
+    while True:
+        chunk = zot.collections(limit=200, start=start)
+        if not chunk:
+            break
+        for collection in chunk:
+            data = collection.get("data", {})
+            meta = collection.get("meta", {})
+            num_items = int(meta.get("numItems", 0) or 0)
+            num_collections = int(meta.get("numCollections", 0) or 0)
+            key = collection.get("key") or data.get("key", "")
+            name = data.get("name", "")
+            date_added = data.get("dateAdded", "")
+            reasons: list[str] = []
+
+            if num_items == 0 and num_collections == 0:
+                try:
+                    if datetime.fromisoformat(date_added.replace("Z", "+00:00")) < cutoff:
+                        reasons.append(f"empty>{age_days}d")
+                except Exception:
+                    pass
+
+            if include_test_pattern:
+                for pattern in TEST_PATTERNS:
+                    if fnmatch.fnmatch(name, pattern):
+                        reasons.append(f"test-pattern({pattern})")
+                        break
+
+            if key and key not in vault_keys:
+                reasons.append("orphan-from-vault")
+
+            if reasons:
+                out.append(
+                    GCCandidate(
+                        key=key,
+                        name=name,
+                        num_items=num_items,
+                        num_collections=num_collections,
+                        date_added=date_added,
+                        reasons=reasons,
+                    )
+                )
+        if len(chunk) < 200:
+            break
+        start += 200
+    return out
+
+
+def delete_candidates(zot, candidates: Iterable[GCCandidate]) -> dict[str, str]:
+    """Delete each candidate via the Zotero web API."""
+    results: dict[str, str] = {}
+    for candidate in candidates:
+        try:
+            coll = zot.collection(candidate.key)
+            zot.delete_collection(coll)
+            results[candidate.key] = "ok"
+        except Exception as exc:
+            results[candidate.key] = str(exc)[:80]
+    return results

--- a/src/research_hub/zotero/pdf_attach.py
+++ b/src/research_hub/zotero/pdf_attach.py
@@ -1,0 +1,105 @@
+"""Discover open-access PDFs and attach them to Zotero items."""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from typing import Iterable
+
+import requests
+
+UNPAYWALL_BASE = "https://api.unpaywall.org/v2"
+
+
+@dataclass
+class PdfAttachPlan:
+    item_key: str
+    title: str
+    doi: str
+    arxiv_id: str
+    pdf_url: str = ""
+    source: str = ""
+    error: str = ""
+
+
+def find_pdf_url(doi: str = "", arxiv_id: str = "", *, unpaywall_email: str = "") -> tuple[str, str]:
+    """Return (pdf_url, source) or ("", "") if none found."""
+    if arxiv_id:
+        return (f"https://arxiv.org/pdf/{arxiv_id}.pdf", "arxiv")
+    if doi and unpaywall_email:
+        try:
+            response = requests.get(
+                f"{UNPAYWALL_BASE}/{doi}",
+                params={"email": unpaywall_email},
+                timeout=15,
+            )
+            if response.ok:
+                data = response.json()
+                best = data.get("best_oa_location") or {}
+                pdf = str(best.get("url_for_pdf") or "").strip()
+                if pdf:
+                    return (pdf, "unpaywall")
+        except Exception:
+            pass
+    return ("", "")
+
+
+def _extract_arxiv_id(data: dict) -> str:
+    doi = str(data.get("DOI", "") or "").strip().lower()
+    match = re.match(r"10\.48550/arxiv\.(.+)", doi)
+    if match:
+        return match.group(1)
+    url = str(data.get("url", "") or "").strip()
+    match = re.search(r"arxiv\.org/(?:abs|pdf)/([^\s/?]+?)(?:\.pdf)?$", url)
+    if match:
+        return match.group(1)
+    return ""
+
+
+def plan_attach_for_items(items: list[dict], *, unpaywall_email: str = "") -> list[PdfAttachPlan]:
+    """Build PDF attach plans for the provided Zotero items."""
+    plans: list[PdfAttachPlan] = []
+    for item in items:
+        data = item.get("data", {})
+        doi = str(data.get("DOI", "") or "").strip()
+        arxiv_id = _extract_arxiv_id(data)
+        pdf_url, source = find_pdf_url(doi=doi, arxiv_id=arxiv_id, unpaywall_email=unpaywall_email)
+        plans.append(
+            PdfAttachPlan(
+                item_key=item.get("key", ""),
+                title=str(data.get("title", "") or "")[:60],
+                doi=doi,
+                arxiv_id=arxiv_id,
+                pdf_url=pdf_url,
+                source=source,
+            )
+        )
+    return plans
+
+
+def attach_pdfs(
+    zot,
+    plans: Iterable[PdfAttachPlan],
+    *,
+    rate_limit_rps: float = 2.0,
+) -> dict[str, str]:
+    """Create linked-PDF attachment items for each plan with a discovered PDF URL."""
+    sleep_s = 1.0 / max(rate_limit_rps, 0.1)
+    results: dict[str, str] = {}
+    for plan in plans:
+        if not plan.pdf_url:
+            results[plan.item_key] = "skip:no-source"
+            continue
+        try:
+            template = zot.item_template("attachment", "imported_url")
+            template["parentItem"] = plan.item_key
+            template["url"] = plan.pdf_url
+            template["title"] = "Full Text PDF"
+            template["contentType"] = "application/pdf"
+            zot.create_items([template])
+            results[plan.item_key] = "ok"
+            time.sleep(sleep_s)
+        except Exception as exc:
+            results[plan.item_key] = str(exc)[:80]
+    return results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import uuid
 from pathlib import Path
@@ -58,6 +59,12 @@ _ZOTERO_WRITE_TEST_MODULES = frozenset({
     "test_v073_parallel_summarize",
     "test_v074_drift_prevention",
     "test_v074_batch_collection",
+    "test_v075_name_drift",
+    "test_v075_collision_prevention",
+    "test_v075_zotero_gc",
+    "test_v075_test_isolation",
+    "test_v075_enrich_existing",
+    "test_v075_pdf_attach",
 })
 
 
@@ -94,6 +101,25 @@ def _block_real_zotero_writes(request, monkeypatch):
         "research_hub.auto._ensure_zotero_collection",
         _noop_ensure_zotero_collection,
     )
+
+
+@pytest.fixture(autouse=True)
+def _block_real_zotero(monkeypatch, request):
+    """Refuse real Zotero client construction inside tests unless opted in."""
+    if "ALLOW_REAL_ZOTERO" in os.environ:
+        return
+    if request.node.get_closest_marker("real_zotero"):
+        return
+
+    def _refuse(*_args, **_kwargs):
+        raise RuntimeError(
+            "Tests must not touch the real Zotero account. "
+            "Mock zotero.client.get_client / ZoteroDualClient. "
+            "Set ALLOW_REAL_ZOTERO=1 env var or @pytest.mark.real_zotero to bypass."
+        )
+
+    monkeypatch.setattr("research_hub.zotero.client.get_client", _refuse)
+    monkeypatch.setattr("research_hub.zotero.client.ZoteroDualClient.__init__", _refuse)
 
 
 @pytest.fixture
@@ -176,6 +202,21 @@ def _allow_external_vault_root_in_tests(monkeypatch):
     sandboxed tmp_paths, not against the user's real $HOME.
     """
     monkeypatch.setenv("RESEARCH_HUB_ALLOW_EXTERNAL_ROOT", "1")
+
+
+@pytest.fixture(autouse=True)
+def _force_writable_tempdir(monkeypatch):
+    """Point subprocess-created temp files at a writable workspace path.
+
+    Windows sandboxing in this environment intermittently denies writes under
+    the default user temp dir during `venv -> ensurepip`, which breaks the
+    extras-install smoke test even though the package metadata is fine.
+    """
+    temp_root = Path.cwd() / ".pytest-work" / "_tmp"
+    temp_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("TMP", str(temp_root))
+    monkeypatch.setenv("TEMP", str(temp_root))
+    monkeypatch.setenv("TMPDIR", str(temp_root))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_v074_drift_prevention.py
+++ b/tests/test_v074_drift_prevention.py
@@ -98,8 +98,13 @@ def test_doctor_collection_collision_warns_on_shared_key(tmp_path):
     registry = ClusterRegistry(cfg.clusters_file)
     registry.create(query="alpha", name="Alpha", slug="alpha")
     registry.create(query="beta", name="Beta", slug="beta")
-    registry.bind("alpha", zotero_collection_key="ABC123")
-    registry.bind("beta", zotero_collection_key="ABC123")
+    registry.bind("alpha", zotero_collection_key="ABC123", sync_zotero=False)
+    registry.bind(
+        "beta",
+        zotero_collection_key="ABC123",
+        sync_zotero=False,
+        force_shared=True,
+    )
 
     result = doctor.check_cluster_collection_collision(cfg)
     assert result.status == "WARN"
@@ -114,8 +119,8 @@ def test_doctor_collection_collision_ok_when_unique(tmp_path):
     registry = ClusterRegistry(cfg.clusters_file)
     registry.create(query="alpha", name="Alpha", slug="alpha")
     registry.create(query="beta", name="Beta", slug="beta")
-    registry.bind("alpha", zotero_collection_key="ABC123")
-    registry.bind("beta", zotero_collection_key="XYZ999")
+    registry.bind("alpha", zotero_collection_key="ABC123", sync_zotero=False)
+    registry.bind("beta", zotero_collection_key="XYZ999", sync_zotero=False)
 
     result = doctor.check_cluster_collection_collision(cfg)
     assert result.status == "OK"

--- a/tests/test_v075_collision_prevention.py
+++ b/tests/test_v075_collision_prevention.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from research_hub.auto import AutoReport, _ensure_zotero_collection
+from research_hub.clusters import ClusterRegistry, CollisionError
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "vault"
+    raw = root / "raw"
+    rh = root / ".research_hub"
+    raw.mkdir(parents=True)
+    rh.mkdir(parents=True)
+    return SimpleNamespace(
+        root=root,
+        raw=raw,
+        hub=root / "hub",
+        research_hub_dir=rh,
+        clusters_file=rh / "clusters.yaml",
+    )
+
+
+def test_bind_raises_collision_error_on_duplicate_key(tmp_path):
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="alpha", name="Alpha", slug="alpha")
+    registry.create(query="beta", name="Beta", slug="beta")
+    registry.bind("alpha", zotero_collection_key="SHARED1", sync_zotero=False)
+
+    with pytest.raises(CollisionError):
+        registry.bind("beta", zotero_collection_key="SHARED1", sync_zotero=False)
+
+
+def test_bind_allows_duplicate_key_with_force_shared(tmp_path):
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="alpha", name="Alpha", slug="alpha")
+    registry.create(query="beta", name="Beta", slug="beta")
+    registry.bind("alpha", zotero_collection_key="SHARED1", sync_zotero=False)
+
+    cluster = registry.bind(
+        "beta",
+        zotero_collection_key="SHARED1",
+        sync_zotero=False,
+        force_shared=True,
+    )
+
+    assert cluster.zotero_collection_key == "SHARED1"
+
+
+def test_auto_collection_reuse_skips_existing_key_already_bound_elsewhere(tmp_path, monkeypatch):
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="alpha", name="Existing Topic", slug="alpha")
+    registry.bind("alpha", zotero_collection_key="SHARED1", sync_zotero=False)
+    registry.create(query="beta", name="Existing Topic", slug="beta")
+    cluster = registry.get("beta")
+    assert cluster is not None
+
+    web = MagicMock(spec=["collections", "create_collections"])
+    web.collections.return_value = [{"data": {"key": "SHARED1", "name": "Existing Topic"}}]
+    web.create_collections.return_value = {
+        "successful": {"0": {"key": "NEWKEY1", "data": {"key": "NEWKEY1"}}}
+    }
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: web)
+    report = AutoReport(cluster_slug="beta", cluster_created=False)
+
+    _ensure_zotero_collection(registry, cluster, "beta", report, print_progress=False)
+
+    assert cluster.zotero_collection_key == "NEWKEY1"
+    web.create_collections.assert_called_once()
+
+
+def test_resolve_collision_new_creates_fresh_collection_and_retags_matching_items(tmp_path, monkeypatch):
+    from research_hub import cli
+
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="alpha", name="Alpha", slug="alpha")
+    registry.create(query="beta", name="Beta", slug="beta")
+    registry.bind("alpha", zotero_collection_key="SHARED1", sync_zotero=False, force_shared=True)
+    registry.bind("beta", zotero_collection_key="SHARED1", sync_zotero=False, force_shared=True)
+    note_dir = cfg.raw / "beta"
+    note_dir.mkdir(parents=True)
+    (note_dir / "paper.md").write_text(
+        "---\n"
+        'doi: "10.1000/one"\n'
+        "topic_cluster: beta\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    class _Zot:
+        def __init__(self) -> None:
+            self.updated: list[dict] = []
+
+        def create_collections(self, payload):
+            assert payload == [{"name": "Beta", "parentCollection": False}]
+            return {"successful": {"0": {"key": "NEWKEY1"}}}
+
+        def collection_items(self, collection_key, start=0, limit=100, itemType=""):
+            assert collection_key == "SHARED1"
+            return [{"key": "ITEM1", "data": {"DOI": "10.1000/one", "collections": ["SHARED1"]}}]
+
+        def item(self, key):
+            assert key == "ITEM1"
+            return {"data": {"key": key, "DOI": "10.1000/one", "collections": ["SHARED1"]}}
+
+        def update_item(self, data):
+            self.updated.append(data.copy())
+            return {}
+
+    monkeypatch.setattr(cli, "get_config", lambda: cfg)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: _Zot())
+
+    rc = cli.main(["clusters", "resolve-collision", "beta", "--new", "--apply"])
+
+    assert rc == 0
+    assert ClusterRegistry(cfg.clusters_file).get("beta").zotero_collection_key == "NEWKEY1"

--- a/tests/test_v075_enrich_existing.py
+++ b/tests/test_v075_enrich_existing.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from research_hub.clusters import ClusterRegistry
+from research_hub.search.base import SearchResult
+from research_hub.zotero.enrich import EnrichPlan, apply_enrichment, plan_enrichment
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "vault"
+    raw = root / "raw"
+    rh = root / ".research_hub"
+    raw.mkdir(parents=True)
+    rh.mkdir(parents=True)
+    return SimpleNamespace(
+        root=root,
+        raw=raw,
+        hub=root / "hub",
+        research_hub_dir=rh,
+        clusters_file=rh / "clusters.yaml",
+    )
+
+
+def _item(doi: str = "10.1000/one", **data) -> dict:
+    payload = {"DOI": doi, "title": "Example", "volume": "", "issue": "", "pages": "", "url": "", "abstractNote": ""}
+    payload.update(data)
+    return {"key": "ITEM1", "data": payload}
+
+
+def test_plan_enrichment_fills_fields_from_crossref(monkeypatch):
+    monkeypatch.setattr(
+        "research_hub.search.crossref.CrossrefBackend.get_paper",
+        lambda self, doi: SearchResult(
+            title="Example",
+            doi=doi,
+            abstract="Abstract",
+            url="https://doi.org/10.1000/one",
+            volume="12",
+            issue="4",
+            pages="10-20",
+        ),
+    )
+    monkeypatch.setattr("research_hub.search.openalex.OpenAlexBackend.get_paper", lambda self, doi: None)
+
+    plans = plan_enrichment([_item()])
+
+    assert len(plans) == 1
+    assert plans[0].fields_to_fill["volume"] == "12"
+    assert plans[0].fields_to_fill["abstractNote"] == "Abstract"
+
+
+def test_plan_enrichment_uses_openalex_as_fallback(monkeypatch):
+    monkeypatch.setattr(
+        "research_hub.search.crossref.CrossrefBackend.get_paper",
+        lambda self, doi: SearchResult(title="Example", doi=doi),
+    )
+    monkeypatch.setattr(
+        "research_hub.search.openalex.OpenAlexBackend.get_paper",
+        lambda self, doi: SearchResult(
+            title="Example",
+            doi=doi,
+            url="https://openalex.org/example",
+            pages="1-2",
+        ),
+    )
+
+    plans = plan_enrichment([_item()])
+
+    assert plans[0].fields_to_fill["url"] == "https://openalex.org/example"
+    assert plans[0].fields_to_fill["pages"] == "1-2"
+
+
+def test_plan_enrichment_skips_items_without_doi(monkeypatch):
+    monkeypatch.setattr("research_hub.search.crossref.CrossrefBackend.get_paper", lambda self, doi: None)
+    monkeypatch.setattr("research_hub.search.openalex.OpenAlexBackend.get_paper", lambda self, doi: None)
+
+    assert plan_enrichment([_item(doi="")]) == []
+
+
+def test_apply_enrichment_only_fills_empty_fields():
+    class _Zot:
+        def __init__(self) -> None:
+            self.updated: list[dict] = []
+
+        def item(self, key: str) -> dict:
+            return {
+                "data": {
+                    "key": key,
+                    "volume": "",
+                    "issue": "existing-issue",
+                    "pages": "",
+                }
+            }
+
+        def update_item(self, data: dict) -> dict:
+            self.updated.append(data.copy())
+            return {}
+
+    zot = _Zot()
+    results = apply_enrichment(
+        zot,
+        [
+            EnrichPlan(
+                item_key="ITEM1",
+                title="Example",
+                doi="10.1000/one",
+                fields_to_fill={"volume": "12", "issue": "9", "pages": "10-20"},
+            )
+        ],
+        rate_limit_rps=999.0,
+    )
+
+    assert results == {"ITEM1": "ok"}
+    assert zot.updated[0]["volume"] == "12"
+    assert zot.updated[0]["issue"] == "existing-issue"
+    assert zot.updated[0]["pages"] == "10-20"
+
+
+def test_cli_paper_enrich_existing_writes_manifest_entries(tmp_path, monkeypatch):
+    from research_hub import cli
+    from research_hub.manifest import Manifest
+
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="agents", name="Agents", slug="agents")
+    registry.bind("agents", zotero_collection_key="COLL1", sync_zotero=False)
+    monkeypatch.setattr(cli, "get_config", lambda: cfg)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: object())
+    monkeypatch.setattr(
+        "research_hub.vault.sync.list_zotero_collection_items",
+        lambda zot, key: [{"key": "ITEM1", "data": {"DOI": "10.1000/one", "title": "Example"}}],
+    )
+    monkeypatch.setattr(
+        "research_hub.zotero.enrich.plan_enrichment",
+        lambda items: [
+            EnrichPlan(
+                item_key="ITEM1",
+                title="Example",
+                doi="10.1000/one",
+                fields_to_fill={"volume": "12"},
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "research_hub.zotero.enrich.apply_enrichment",
+        lambda zot, plans, rate_limit_rps=2.0: {"ITEM1": "ok"},
+    )
+
+    rc = cli.main(["paper", "enrich-existing", "--cluster", "agents", "--apply"])
+
+    assert rc == 0
+    entries = Manifest(cfg.research_hub_dir / "manifest.jsonl").read_all()
+    assert entries[-1].action == "enrich-existing"
+    assert entries[-1].zotero_key == "ITEM1"

--- a/tests/test_v075_name_drift.py
+++ b/tests/test_v075_name_drift.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from research_hub.clusters import ClusterRegistry
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "vault"
+    raw = root / "raw"
+    rh = root / ".research_hub"
+    raw.mkdir(parents=True)
+    rh.mkdir(parents=True)
+    return SimpleNamespace(
+        root=root,
+        raw=raw,
+        hub=root / "hub",
+        research_hub_dir=rh,
+        clusters_file=rh / "clusters.yaml",
+    )
+
+
+class _ZoteroStub:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.updated: list[dict] = []
+
+    def collection(self, key: str) -> dict:
+        return {"key": key, "version": 7, "data": {"name": self.name}}
+
+    def update_collection(self, payload: dict) -> dict:
+        self.updated.append(payload.copy())
+        self.name = payload["name"]
+        return payload
+
+
+def test_check_cluster_name_drift_warns_on_mismatch(tmp_path, monkeypatch):
+    from research_hub import doctor
+
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="agents", name="Vault Name", slug="agents")
+    registry.bind("agents", zotero_collection_key="COLL1", sync_zotero=False)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: _ZoteroStub("Zotero Name"))
+
+    result = doctor.check_cluster_name_drift(cfg)
+
+    assert result.status == "WARN"
+    assert "agents" in result.details
+    assert "Vault Name" in result.details
+    assert "Zotero Name" in result.details
+
+
+def test_check_cluster_name_drift_ok_when_aligned(tmp_path, monkeypatch):
+    from research_hub import doctor
+
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="agents", name="Shared Name", slug="agents")
+    registry.bind("agents", zotero_collection_key="COLL1", sync_zotero=False)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: _ZoteroStub("Shared Name"))
+
+    result = doctor.check_cluster_name_drift(cfg)
+
+    assert result.status == "OK"
+
+
+def test_bind_syncs_zotero_name_by_default(tmp_path, monkeypatch):
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="agents", name="Vault Name", slug="agents")
+    zot = _ZoteroStub("Old Name")
+    monkeypatch.setattr(
+        "research_hub.zotero.client.ZoteroDualClient",
+        lambda: SimpleNamespace(web=zot),
+    )
+
+    registry.bind("agents", zotero_collection_key="COLL1")
+
+    assert zot.updated == [{"key": "COLL1", "version": 7, "name": "Vault Name"}]
+
+
+def test_bind_can_skip_zotero_name_sync(tmp_path, monkeypatch):
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="agents", name="Vault Name", slug="agents")
+    zot = _ZoteroStub("Old Name")
+    monkeypatch.setattr(
+        "research_hub.zotero.client.ZoteroDualClient",
+        lambda: SimpleNamespace(web=zot),
+    )
+
+    registry.bind("agents", zotero_collection_key="COLL1", sync_zotero=False)
+
+    assert zot.updated == []
+
+
+def test_clusters_sync_names_can_apply_zotero_to_vault(tmp_path, monkeypatch):
+    from research_hub import cli
+
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="agents", name="Vault Name", slug="agents")
+    registry.bind("agents", zotero_collection_key="COLL1", sync_zotero=False)
+    monkeypatch.setattr(cli, "get_config", lambda: cfg)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: _ZoteroStub("Zotero Name"))
+
+    rc = cli.main(
+        [
+            "clusters",
+            "sync-names",
+            "--cluster",
+            "agents",
+            "--direction",
+            "zotero-to-vault",
+            "--apply",
+        ]
+    )
+
+    assert rc == 0
+    assert ClusterRegistry(cfg.clusters_file).get("agents").name == "Zotero Name"

--- a/tests/test_v075_pdf_attach.py
+++ b/tests/test_v075_pdf_attach.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from research_hub.clusters import ClusterRegistry
+from research_hub.zotero.pdf_attach import (
+    PdfAttachPlan,
+    _extract_arxiv_id,
+    attach_pdfs,
+    find_pdf_url,
+    plan_attach_for_items,
+)
+from tests.test_pipeline import _configure, _paper
+
+
+def test_extract_arxiv_id_from_doi():
+    assert _extract_arxiv_id({"DOI": "10.48550/arXiv.2604.08224"}) == "2604.08224"
+
+
+def test_extract_arxiv_id_from_url():
+    assert _extract_arxiv_id({"url": "https://arxiv.org/abs/2604.08224"}) == "2604.08224"
+
+
+def test_find_pdf_url_prefers_arxiv_without_network(monkeypatch):
+    monkeypatch.setattr("research_hub.zotero.pdf_attach.requests.get", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("no network")))
+
+    pdf_url, source = find_pdf_url(arxiv_id="2604.08224")
+
+    assert pdf_url == "https://arxiv.org/pdf/2604.08224.pdf"
+    assert source == "arxiv"
+
+
+def test_find_pdf_url_uses_unpaywall_when_email_is_available(monkeypatch):
+    class _Resp:
+        ok = True
+
+        @staticmethod
+        def json():
+            return {"best_oa_location": {"url_for_pdf": "https://example.test/full.pdf"}}
+
+    monkeypatch.setattr("research_hub.zotero.pdf_attach.requests.get", lambda *args, **kwargs: _Resp())
+
+    pdf_url, source = find_pdf_url(doi="10.1000/one", unpaywall_email="user@example.com")
+
+    assert pdf_url == "https://example.test/full.pdf"
+    assert source == "unpaywall"
+
+
+def test_plan_attach_for_items_builds_source_and_pdf_url(monkeypatch):
+    monkeypatch.setattr(
+        "research_hub.zotero.pdf_attach.find_pdf_url",
+        lambda doi="", arxiv_id="", unpaywall_email="": ("https://arxiv.org/pdf/2604.08224.pdf", "arxiv"),
+    )
+
+    plans = plan_attach_for_items(
+        [
+            {
+                "key": "ITEM1",
+                "data": {
+                    "title": "Paper",
+                    "DOI": "10.48550/arXiv.2604.08224",
+                    "url": "https://arxiv.org/abs/2604.08224",
+                },
+            }
+        ]
+    )
+
+    assert plans[0].item_key == "ITEM1"
+    assert plans[0].source == "arxiv"
+    assert plans[0].pdf_url.endswith("2604.08224.pdf")
+
+
+def test_attach_pdfs_creates_imported_url_attachment():
+    zot = MagicMock()
+    zot.item_template.side_effect = lambda *args: {"itemType": "attachment"}
+
+    results = attach_pdfs(
+        zot,
+        [
+            PdfAttachPlan(item_key="ITEM0", title="Missing", doi="", arxiv_id=""),
+            PdfAttachPlan(
+                item_key="ITEM1",
+                title="Paper",
+                doi="10.1000/one",
+                arxiv_id="",
+                pdf_url="https://example.test/full.pdf",
+                source="unpaywall",
+            )
+        ],
+        rate_limit_rps=999.0,
+    )
+
+    assert results == {"ITEM0": "skip:no-source", "ITEM1": "ok"}
+    payload = zot.create_items.call_args.args[0][0]
+    assert payload["parentItem"] == "ITEM1"
+    assert payload["contentType"] == "application/pdf"
+
+
+def test_run_pipeline_with_pdfs_invokes_attach_helpers(tmp_path, monkeypatch):
+    from research_hub import config as hub_config
+    from research_hub import pipeline
+    from research_hub.manifest import Manifest
+
+    cfg = _configure(monkeypatch, tmp_path, default_collection="ABCD1234")
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="agents", name="Agents", slug="agents")
+    registry.bind("agents", zotero_collection_key="CLUSTER123", sync_zotero=False)
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps([_paper("Paper One", "paper-one", "10.1000/one")]),
+        encoding="utf-8",
+    )
+
+    zot = MagicMock()
+    zot.item_template.side_effect = lambda item_type: {"itemType": item_type}
+    zot.create_items.side_effect = lambda items: {"successful": {"0": {"key": "Z0"}}}
+    zot.item.side_effect = lambda key: {"key": key, "data": {"key": key, "title": "Paper One", "DOI": "10.1000/one"}}
+    monkeypatch.setattr(pipeline, "get_client", lambda: zot)
+    monkeypatch.setattr(pipeline, "check_duplicate", lambda zot, title, doi="", **kwargs: False)
+    monkeypatch.setattr(pipeline, "add_note", lambda zot, key, content: True)
+    monkeypatch.setattr(pipeline.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(pipeline, "update_cluster_links", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline, "_refresh_cluster_base", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "research_hub.zotero.pdf_attach.plan_attach_for_items",
+        lambda items, unpaywall_email="": [
+            PdfAttachPlan(
+                item_key="Z0",
+                title="Paper One",
+                doi="10.1000/one",
+                arxiv_id="2604.08224",
+                pdf_url="https://arxiv.org/pdf/2604.08224.pdf",
+                source="arxiv",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "research_hub.zotero.pdf_attach.attach_pdfs",
+        lambda zot, plans, rate_limit_rps=2.0: {"Z0": "ok"},
+    )
+
+    try:
+        assert pipeline.run_pipeline(dry_run=False, cluster_slug="agents", verify=False, with_pdfs=True) == 0
+        entries = Manifest(cfg.research_hub_dir / "manifest.jsonl").read_all()
+        assert any(entry.action == "pdf-attach" and entry.zotero_key == "Z0" for entry in entries)
+    finally:
+        hub_config._config = None
+        hub_config._config_path = None

--- a/tests/test_v075_test_isolation.py
+++ b/tests/test_v075_test_isolation.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_real_zotero_get_client_is_blocked_by_default():
+    from research_hub.zotero.client import get_client
+
+    with pytest.raises(RuntimeError, match="Tests must not touch the real Zotero account"):
+        get_client()
+
+
+def test_real_zotero_dual_client_is_blocked_by_default():
+    from research_hub.zotero.client import ZoteroDualClient
+
+    with pytest.raises(RuntimeError, match="Tests must not touch the real Zotero account"):
+        ZoteroDualClient()

--- a/tests/test_v075_zotero_gc.py
+++ b/tests/test_v075_zotero_gc.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from research_hub.clusters import ClusterRegistry
+from research_hub.zotero.gc import GCCandidate, delete_candidates, scan_zotero_for_gc
+
+
+def _collection(
+    key: str,
+    name: str,
+    *,
+    num_items: int = 0,
+    num_collections: int = 0,
+    date_added: str = "2025-01-01T00:00:00Z",
+) -> dict:
+    return {
+        "key": key,
+        "data": {"key": key, "name": name, "dateAdded": date_added},
+        "meta": {"numItems": num_items, "numCollections": num_collections},
+    }
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "vault"
+    raw = root / "raw"
+    rh = root / ".research_hub"
+    raw.mkdir(parents=True)
+    rh.mkdir(parents=True)
+    return SimpleNamespace(
+        root=root,
+        raw=raw,
+        hub=root / "hub",
+        research_hub_dir=rh,
+        clusters_file=rh / "clusters.yaml",
+    )
+
+
+class _ZotCollections:
+    def __init__(self, collections: list[dict]) -> None:
+        self._collections = collections
+        self.deleted: list[str] = []
+
+    def collections(self, *, limit=200, start=0):
+        return self._collections[start : start + limit]
+
+    def collection(self, key: str) -> dict:
+        return {"key": key, "data": {"key": key}}
+
+    def delete_collection(self, coll: dict) -> dict:
+        self.deleted.append(coll["key"])
+        return {}
+
+
+def test_scan_zotero_for_gc_flags_old_empty_test_orphan_collection():
+    zot = _ZotCollections([_collection("A1", "test-topic")])
+
+    candidates = scan_zotero_for_gc(zot, set())
+
+    assert len(candidates) == 1
+    assert "orphan-from-vault" in candidates[0].reasons
+    assert any(reason.startswith("empty>") for reason in candidates[0].reasons)
+    assert any(reason.startswith("test-pattern(") for reason in candidates[0].reasons)
+
+
+def test_scan_zotero_for_gc_skips_recent_empty_collection():
+    zot = _ZotCollections([_collection("A1", "fresh-empty", date_added="2026-04-25T00:00:00Z")])
+
+    candidates = scan_zotero_for_gc(zot, set(), age_days=30)
+
+    assert candidates == [GCCandidate(key="A1", name="fresh-empty", num_items=0, num_collections=0, date_added="2026-04-25T00:00:00Z", reasons=["orphan-from-vault"])]
+
+
+def test_scan_zotero_for_gc_marks_orphan_without_test_pattern():
+    zot = _ZotCollections([_collection("A1", "survey", num_items=4)])
+
+    candidates = scan_zotero_for_gc(zot, set())
+
+    assert len(candidates) == 1
+    assert candidates[0].reasons == ["orphan-from-vault"]
+
+
+def test_delete_candidates_returns_ok_and_error():
+    class _DeleteZot(_ZotCollections):
+        def delete_collection(self, coll: dict) -> dict:
+            if coll["key"] == "ERR":
+                raise RuntimeError("boom")
+            return super().delete_collection(coll)
+
+    zot = _DeleteZot([])
+
+    results = delete_candidates(
+        zot,
+        [
+            GCCandidate(key="OK1", name="ok", num_items=0, num_collections=0, date_added=""),
+            GCCandidate(key="ERR", name="err", num_items=0, num_collections=0, date_added=""),
+        ],
+    )
+
+    assert results["OK1"] == "ok"
+    assert "boom" in results["ERR"]
+
+
+def test_cli_zotero_gc_yes_only_deletes_triple_match(tmp_path, monkeypatch):
+    from research_hub import cli
+
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="live", name="Live", slug="live")
+    registry.bind("live", zotero_collection_key="LIVE1", sync_zotero=False)
+    zot = _ZotCollections(
+        [
+            _collection("DEL1", "test-topic"),
+            _collection("KEEP1", "orphan-real", num_items=2),
+        ]
+    )
+    monkeypatch.setattr(cli, "get_config", lambda: cfg)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: zot)
+
+    rc = cli.main(["zotero", "gc", "--apply", "--yes"])
+
+    assert rc == 0
+    assert zot.deleted == ["DEL1"]


### PR DESCRIPTION
## Summary
Stacked on #22. Closes 6 more workflow gaps surfaced by re-ingesting today's society/env batch under v0.74.

## Why
v0.74 surfaced new gaps:
1. Cluster `name` drift between vault and Zotero (maintainer literally couldn't find his ingest because Zotero showed `research-hub-test-llm-behav-env-abm` while vault said `LLM × Behavioral × Environmental × ABM`)
2. `zotero_collection_key` collision allowed at `bind()` time (`WNV9SWVA` shared by 2 clusters)
3. `cascade_delete_cluster` left stale empty Zotero collections behind
4. Tests polluted real Zotero (`test-topic` × 2, `persona-a-test` × 3, `Beta`)
5. Search-backend metadata gaps (vol/issue/pages empty) with no re-enrich path
6. No PDF auto-attach — research-hub had zero PDF code

## Changes
- `clusters bind`/`rename` PATCH the corresponding Zotero collection name by default (`--no-sync-zotero` opts out)
- `ClusterRegistry.bind()` raises `CollisionError` on duplicate `zotero_collection_key` (`--force-shared` bypass)
- `clusters sync-names [--apply]` — fix vault↔Zotero name drift across all clusters
- `clusters resolve-collision <slug> --new|--into <other>` — fix shared collection_keys
- `clusters delete --delete-zotero-collection` cascades to Zotero side
- `zotero gc [--apply]` — find empty / test-pattern / orphan Zotero collections + propose deletion
- `paper enrich-existing` fills empty `vol/issue/pages/url/abstract/ISSN` from Crossref + OpenAlex (never overwrites)
- `paper attach-pdfs` (+ `auto --with-pdfs`) attaches arXiv + Unpaywall PDFs to existing Zotero items
- doctor `cluster/name_drift` (5th cluster check)
- `tests/conftest.py` autouse `_block_real_zotero` fixture — ALLOW_REAL_ZOTERO=1 / @pytest.mark.real_zotero opt-out
- 28 new tests across `tests/test_v075_*.py` (6 files)

## Test plan
- [ ] `pytest tests/test_v075_*.py -v` → 28 green
- [ ] `pytest -q` → no regression vs v0.74 baseline (2032 → 2070+)
- [ ] `clusters sync-names --apply` on the maintainer vault aligns 3 known mismatches (BZTMR5E9 / L65BIR88 / WNV9SWVA)
- [ ] `clusters resolve-collision llm-evaluation-harness --new --apply` resolves the WNV9SWVA collision
- [ ] `zotero gc --apply` (interactive) cleans 11 empty/test/orphan Zotero collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)