### PR TITLE
fix(v0.77.0): polish fixes from v0.74-v0.76 review (#7-#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v0.77.0 (2026-05-03)
+
+Polish fixes from the v0.74-v0.76 stacked-PR code review (items #7-#10).
+No new features; correctness, rate-limit, and test-isolation tweaks only.
+
+### Changed
+- `zotero/enrich.py` `plan_enrichment()` gains `rate_limit_rps=5.0`
+  default (sleep between Crossref/OpenAlex backend calls). Prevents
+  hitting either backend's polite-pool when re-enriching 250+ items.
+- `doctor.check_cluster_pdf_coverage` caps per-cluster sampling at
+  50 items (was N+1 unbounded). The reported percentage is still
+  representative; users wanting the exact count run
+  `paper attach-pdfs --cluster <slug>` directly.
+- `auto --full-auto` help text now explicitly notes that NotebookLM
+  upload also stays ON by default — pair with `--no-nlm` for fully
+  local automation without the patchright/Google login step.
+
+### Fixed
+- `zotero/pdf_attach._HINT_SHOWN` is module-level state that survived
+  across pytest tests. Added `_reset_hint_state()` + autouse fixture
+  in `tests/conftest.py` so hint-text assertions are no longer
+  order-dependent.
+
+Tests: 2083 passing (no regression).
+
 ## v0.76.0 (2026-05-03)
 
 PDF coverage 4-source chain + true full-auto mode + pdf_coverage doctor check.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.76.0"
+version = "0.77.0"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.76.0"
+__version__ = "0.77.0"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -3186,7 +3186,12 @@ def build_parser() -> argparse.ArgumentParser:
     auto_parser.add_argument(
         "--full-auto",
         action="store_true",
-        help="Enable --with-pdfs --with-summary --with-crystals (do_nlm stays default ON)",
+        help=(
+            "Enable --with-pdfs --with-summary --with-crystals. "
+            "NotebookLM upload also stays ON by default — pair with "
+            "--no-nlm if you want fully local automation without the "
+            "browser step (NLM upload uses patchright + Google login)."
+        ),
     )
     auto_parser.add_argument(
         "--no-cluster-overview", action="store_true",

--- a/src/research_hub/doctor.py
+++ b/src/research_hub/doctor.py
@@ -514,6 +514,12 @@ def check_cluster_pdf_coverage(cfg) -> CheckResult:
             "Zotero client unavailable; pdf coverage check skipped",
         )
 
+    # PDF coverage requires N+1 API calls per cluster (one zot.children
+    # per item). Cap at 50 sampled items per cluster to keep `doctor`
+    # response time reasonable on large vaults — the percentage is still
+    # representative; users wanting the exact count can run
+    # `research-hub paper attach-pdfs --cluster <slug>` directly.
+    SAMPLE_CAP = 50
     low: list[str] = []
     for cluster in registry.list():
         if not cluster.zotero_collection_key:
@@ -524,8 +530,9 @@ def check_cluster_pdf_coverage(cfg) -> CheckResult:
             continue
         if not items:
             continue
+        sampled = items[:SAMPLE_CAP]
         with_pdf = 0
-        for item in items:
+        for item in sampled:
             try:
                 children = zot.children(item.get("key", "")) or []
             except Exception:
@@ -536,9 +543,10 @@ def check_cluster_pdf_coverage(cfg) -> CheckResult:
                 for child in children
             ):
                 with_pdf += 1
-        pct = (with_pdf / len(items)) * 100
+        pct = (with_pdf / len(sampled)) * 100
         if pct < 50:
-            low.append(f"{cluster.slug}: {with_pdf}/{len(items)} ({pct:.0f}%)")
+            sampled_note = f" (sampled {len(sampled)}/{len(items)})" if len(items) > SAMPLE_CAP else ""
+            low.append(f"{cluster.slug}: {with_pdf}/{len(sampled)} ({pct:.0f}%){sampled_note}")
 
     if low:
         remedy = "Run: python -m research_hub paper attach-pdfs --cluster <slug> --apply"

--- a/src/research_hub/zotero/enrich.py
+++ b/src/research_hub/zotero/enrich.py
@@ -38,12 +38,25 @@ def _result_value(result, field_name: str) -> str:
     return str(value or "").strip()
 
 
-def plan_enrichment(zot_or_items, items: list[dict] | None = None) -> list[EnrichPlan]:
-    """Identify empty Zotero fields and plan DOI-based metadata fill-ins."""
+def plan_enrichment(
+    zot_or_items,
+    items: list[dict] | None = None,
+    *,
+    rate_limit_rps: float = 5.0,
+) -> list[EnrichPlan]:
+    """Identify empty Zotero fields and plan DOI-based metadata fill-ins.
+
+    Each per-item probe hits both Crossref AND OpenAlex (~2 outbound HTTP
+    per item). For 250+ items that's 500 calls — Crossref's polite-pool
+    allows ~50 rps, OpenAlex caps at ~10 rps. Default 5 rps stays safely
+    under both. Override via rate_limit_rps for explicit faster/slower.
+    """
+    import time as _time
     if items is None:
         items = zot_or_items
     crossref = CrossrefBackend()
     openalex = OpenAlexBackend()
+    sleep_s = 1.0 / max(rate_limit_rps, 0.1)
     plans: list[EnrichPlan] = []
     for item in items:
         data = item.get("data", {})
@@ -64,6 +77,7 @@ def plan_enrichment(zot_or_items, items: list[dict] | None = None) -> list[Enric
                 result = backend.get_paper(doi)
             except Exception:
                 result = None
+            _time.sleep(sleep_s)
             if result is None:
                 continue
             for field_name in empty_fields:

--- a/src/research_hub/zotero/pdf_attach.py
+++ b/src/research_hub/zotero/pdf_attach.py
@@ -14,7 +14,14 @@ OPENALEX_BASE = "https://api.openalex.org/works/doi"
 UNPAYWALL_BASE = "https://api.unpaywall.org/v2"
 CROSSREF_BASE = "https://api.crossref.org/works"
 
-_HINT_SHOWN = False
+_HINT_SHOWN = False  # once-per-process flag for the unpaywall_email hint
+
+
+def _reset_hint_state() -> None:
+    """Reset the once-per-process hint flag. Used by tests to avoid
+    order-dependent behavior when multiple tests exercise the hint path."""
+    global _HINT_SHOWN
+    _HINT_SHOWN = False
 
 
 @dataclass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,19 @@ def pytest_configure(config) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _reset_pdf_hint_flag():
+    """v0.77: pdf_attach._HINT_SHOWN is module-level state that survives
+    across tests in the same process. Reset before every test so hint-text
+    assertions are not order-dependent."""
+    try:
+        from research_hub.zotero.pdf_attach import _reset_hint_state
+        _reset_hint_state()
+    except Exception:
+        pass
+    yield
+
+
+@pytest.fixture(autouse=True)
 def _block_real_webbrowser_open(monkeypatch):
     """v0.68.5: globally stub `webbrowser.open` for every test.
 


### PR DESCRIPTION
## Summary
Stacked on #24. Top of the 4-PR stack. No new features — 4 polish/correctness fixes from the review backlog left after v0.76's critical+important hotfix.

## Why
Code-review on the v0.74-v0.76 stack flagged 6 critical + 5 important + 3 nice-to-have items. The critical+important were folded into v0.76 hotfix `3ce01c0`. v0.77 ships the remaining 4 polish fixes:

- (review #7) `enrich.plan_enrichment` had no rate-limit between Crossref/OpenAlex calls — risk of silent rate-limit-induced data loss on 250+ items
- (review #8) `doctor.check_cluster_pdf_coverage` was N+1 unbounded — slow on large vaults
- (review #9) `auto --full-auto` help text didn't mention NLM stays default ON — footgun for users wanting local-only automation
- (review #10) `pdf_attach._HINT_SHOWN` module-level state survived across pytest tests → order-dependent hint behavior

## Changes
- `enrich.plan_enrichment(rate_limit_rps=5.0)` — sleeps between backend calls per item; safely under both Crossref's polite-pool and OpenAlex's 10-rps cap
- `doctor.check_cluster_pdf_coverage` caps per-cluster sample at 50 items (representative %, exact count via `paper attach-pdfs`)
- `auto --full-auto` help: explicit \"NotebookLM upload also stays ON; pair with --no-nlm for fully local\"
- `pdf_attach._reset_hint_state()` helper + autouse `tests/conftest.py` fixture resets the flag before every test

Bumped 0.76.0 → 0.77.0; CHANGELOG entry. 60/60 v0.74-v0.76 + version_sync still green.

## Test plan
- [ ] `pytest tests/test_v074_*.py tests/test_v075_*.py tests/test_v076_*.py tests/test_v068_3_version_sync.py -v` → 60 green
- [ ] `pytest -q` → 2083 passing, no regression vs v0.76 baseline
- [ ] `python -m research_hub auto --help` shows the updated --full-auto help text
- [ ] `python -m research_hub doctor` on a large vault (≥50-paper cluster) returns in reasonable time

🤖 Generated with [Claude Code](https://claude.com/claude-code)