### PR TITLE
fix(v0.78.0): decode HTML entities in paper metadata before Zotero write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.78.0 (2026-05-03)
+
+Single-bug hotfix: HTML-entity decoding before Zotero write.
+
+### Fixed
+- Search backends (Crossref, OpenAlex, Semantic Scholar) sometimes
+  returned HTML-escaped strings (e.g. `AI &amp; SOCIETY`,
+  `Computers &amp; Education`, `M&uuml;ller`). The pipeline wrote
+  these straight to Zotero `publicationTitle` / `title` /
+  `abstractNote` / author name fields. Now `_unescape_html_in_paper`
+  decodes once at the pipeline layer right after
+  `_auto_generate_missing_fields` — before validation, dedup, and
+  Zotero/Obsidian writes. Catches the issue regardless of which
+  backend supplied the data.
+- 8 new tests in `tests/test_v078_html_entity.py`.
+
+Tests: 2083 → 2091.
+
 ## v0.77.0 (2026-05-03)
 
 Polish fixes from the v0.74-v0.76 stacked-PR code review (items #7-#10).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.77.0"
+version = "0.78.0"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.77.0"
+__version__ = "0.78.0"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -115,6 +115,42 @@ def _auto_generate_missing_fields(pp: dict, cluster_slug: str | None) -> None:
         pp["sub_category"] = cluster_slug or "uncategorized"
 
 
+_HTML_TEXT_FIELDS = ("title", "journal", "abstract", "publicationTitle", "abstractNote")
+
+
+def _unescape_html_in_paper(pp: dict) -> None:
+    """Decode HTML entities in user-visible string fields, in-place.
+
+    Search backends (Crossref, OpenAlex, Semantic Scholar) sometimes
+    return HTML-escaped strings in journal names, titles, and abstracts —
+    e.g. "AI &amp; SOCIETY", "Computers &amp; Education". Decoding once
+    at the pipeline layer keeps Zotero items + Obsidian frontmatter clean
+    regardless of which backend supplied the data.
+    """
+    import html as _html
+
+    for field in _HTML_TEXT_FIELDS:
+        value = pp.get(field)
+        if isinstance(value, str) and "&" in value:
+            decoded = _html.unescape(value)
+            if decoded != value:
+                pp[field] = decoded
+    # Authors are a list of dicts (creatorType, firstName, lastName, name);
+    # decode the name parts too (publishers occasionally HTML-escape
+    # diacritics in author names).
+    authors = pp.get("authors") or []
+    if isinstance(authors, list):
+        for author in authors:
+            if not isinstance(author, dict):
+                continue
+            for name_field in ("firstName", "lastName", "name"):
+                v = author.get(name_field)
+                if isinstance(v, str) and "&" in v:
+                    decoded = _html.unescape(v)
+                    if decoded != v:
+                        author[name_field] = decoded
+
+
 def _validate_paper_input(pp: dict, idx: int) -> list[str]:
     """Validate one paper entry before any Zotero writes."""
     errors: list[str] = []
@@ -661,6 +697,7 @@ def run_pipeline(
             skipped_invalid: list[tuple[int, dict, list[str]]] = []
             for idx, paper in enumerate(papers):
                 _auto_generate_missing_fields(paper, cluster_slug)
+                _unescape_html_in_paper(paper)
                 paper_errors = _validate_paper_input(paper, idx)
                 missing_doi_only = (
                     not dry_run

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,7 @@ _ZOTERO_WRITE_TEST_MODULES = frozenset({
     "test_v076_pdf_chain",
     "test_v076_full_auto",
     "test_v076_pdf_coverage_check",
+    "test_v078_html_entity",
 })
 
 

--- a/tests/test_v078_html_entity.py
+++ b/tests/test_v078_html_entity.py
@@ -1,0 +1,62 @@
+"""v0.78: html-entity decoding for search-backend output before Zotero write."""
+
+from __future__ import annotations
+
+from research_hub.pipeline import _unescape_html_in_paper
+
+
+def test_decodes_journal_amp():
+    pp = {"journal": "AI &amp; SOCIETY", "title": "x"}
+    _unescape_html_in_paper(pp)
+    assert pp["journal"] == "AI & SOCIETY"
+
+
+def test_decodes_title_with_lt_gt():
+    pp = {"title": "Foo &lt;tag&gt; bar &amp; baz"}
+    _unescape_html_in_paper(pp)
+    assert pp["title"] == "Foo <tag> bar & baz"
+
+
+def test_decodes_abstract_field():
+    pp = {"abstract": "p &amp; q"}
+    _unescape_html_in_paper(pp)
+    assert pp["abstract"] == "p & q"
+
+
+def test_decodes_publication_title_alias():
+    pp = {"publicationTitle": "Computers &amp; Education"}
+    _unescape_html_in_paper(pp)
+    assert pp["publicationTitle"] == "Computers & Education"
+
+
+def test_decodes_author_name_parts():
+    pp = {
+        "authors": [
+            {"creatorType": "author", "firstName": "M&uuml;ller", "lastName": "Smith"},
+            {"creatorType": "author", "name": "Plain &amp; Co"},
+            "string-author",  # tolerated, ignored
+        ]
+    }
+    _unescape_html_in_paper(pp)
+    assert pp["authors"][0]["firstName"] == "Müller"
+    assert pp["authors"][1]["name"] == "Plain & Co"
+
+
+def test_no_change_when_no_entities():
+    pp = {"title": "Plain title", "journal": "JASS", "abstract": "no entities"}
+    expected = {k: v for k, v in pp.items()}
+    _unescape_html_in_paper(pp)
+    assert pp == expected
+
+
+def test_handles_missing_fields():
+    pp = {"slug": "x", "doi": "10.x/y"}
+    _unescape_html_in_paper(pp)  # must not raise
+    assert pp == {"slug": "x", "doi": "10.x/y"}
+
+
+def test_handles_non_string_values():
+    pp = {"title": None, "journal": 123, "abstract": ["list"]}
+    _unescape_html_in_paper(pp)  # must not raise
+    assert pp["title"] is None
+    assert pp["journal"] == 123


### PR DESCRIPTION
## Summary
Single-bug hotfix found while running v0.77 `auto --full-auto` on the BSE cluster. 4 Zotero items came in with literal `AI &amp; SOCIETY` / `Computers &amp; Education` in publicationTitle.

## Root cause
Search backends (Crossref, OpenAlex, Semantic Scholar) sometimes return HTML-escaped strings. Pipeline wrote them straight through without `html.unescape()`.

## Fix
- New `_unescape_html_in_paper(pp)` helper in `pipeline.py` runs `html.unescape()` on `title` / `journal` / `abstract` / `publicationTitle` / `abstractNote` + author `firstName` / `lastName` / `name` fields, in-place
- Wired into `run_pipeline()` right after `_auto_generate_missing_fields`, before validation. Catches the issue regardless of which backend supplied the data.
- 8 new tests in `tests/test_v078_html_entity.py`

Tests: 2083 → 2091. Version 0.77.0 → 0.78.0.

## Test plan
- [ ] `pytest tests/test_v078_html_entity.py -v` → 8 green
- [ ] `pytest -q` → no regression vs v0.77 baseline
- [ ] Real-vault: next `auto` run on a journal with `&` in name (e.g. `AI & SOCIETY`) → Zotero gets `AI & SOCIETY` not `AI &amp; SOCIETY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)