### PR TITLE
fix(v0.81.0): summarize fills ## Summary block + doctor skips raw/_deleted_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## v0.81.0 (2026-05-04)
+
+Two small bugs surfaced by the v0.80 end-to-end audit.
+
+### Fixed
+- `summarize.py` `_replace_obsidian_block` was leaving `## Summary` at
+  the ingest-time `[TODO] <title>` placeholder forever — even when
+  claude returned substantive Key Findings. Root cause: the
+  `PaperSummary` dataclass had no `summary` field, the LLM prompt
+  didn't ask for one, and the writer never targeted the block.
+  Fix: prompt now asks for a 1-2 sentence TLDR; `PaperSummary.summary`
+  field added; new `_SUMMARY_BLOCK_RE` writes it. Back-compat: when
+  LLM omits the field, Summary block stays at [TODO] (no-op).
+- `doctor.check_cluster_orphan_papers` was counting `raw/_deleted_*/`
+  soft-delete folders as orphan, producing false WARNs (today's
+  audit showed `!14 folder(s)` from accumulated cleanup history).
+  Fix: skip directories whose name starts with `_deleted_`, mirroring
+  the existing exclusion in `vault/sync.list_cluster_notes`.
+
+### Added
+- `_build_zotero_note_html` includes the new summary block so Zotero
+  child notes also get the TLDR in addition to Key Findings.
+
+### Tests
+- 6 new tests in `tests/test_v081_summary_block_and_orphan_skip.py`.
+
+Tests: 2123 → ~2129.
+
 ## v0.80.0 (2026-05-04)
 
 Clickable PDFs (imported_file) + abstract recovery + chained re-summarize.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "research-hub-pipeline"
-version = "0.80.0"
+version = "0.81.0"
 description = "AI-operable research workspace for Zotero, Obsidian, and NotebookLM. Use any two, or all three, through CLI, MCP, REST, and dashboard."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/research_hub/__init__.py
+++ b/src/research_hub/__init__.py
@@ -11,7 +11,7 @@ import threading as _threading
 # Keep in sync with pyproject.toml [project].version. Drift caught by
 # tests/test_v068_3_version_sync.py and by publish.yml's wheel-validate
 # step (which asserts __version__ matches the git tag before twine upload).
-__version__ = "0.80.0"
+__version__ = "0.81.0"
 
 
 if sys.platform.startswith("win") and "pytest" in sys.modules:

--- a/src/research_hub/doctor.py
+++ b/src/research_hub/doctor.py
@@ -205,6 +205,12 @@ def check_cluster_orphan_papers(cfg) -> CheckResult:
     for sub in raw_dir.iterdir():
         if not sub.is_dir() or sub.name.startswith(".") or sub.name in {"pdfs", "attachments"}:
             continue
+        # v0.81: skip soft-delete folders (mirrors vault/sync.list_cluster_notes
+        # which has the same exclusion). raw/_deleted_<slug>/ holds notes
+        # that were intentionally moved out of a cluster; they are NOT
+        # orphan papers needing rebind.
+        if sub.name.startswith("_deleted_"):
+            continue
         if sub.name not in bound_dirs:
             md_count = sum(1 for _ in sub.glob("*.md"))
             if md_count > 0:

--- a/src/research_hub/summarize.py
+++ b/src/research_hub/summarize.py
@@ -48,6 +48,7 @@ class PaperSummary:
     """One LLM-generated summary entry for a single paper."""
 
     paper_slug: str
+    summary: str = ""           # v0.81: 1-2 sentence TL;DR for `## Summary` block
     key_findings: list[str] = field(default_factory=list)
     methodology: str = ""
     relevance: str = ""
@@ -224,6 +225,7 @@ def build_summarize_prompt(
             "summaries": [
                 {
                     "paper_slug": papers[0]["slug"],
+                    "summary": "1-2 sentence TL;DR (what the paper does + the headline finding).",
                     "key_findings": [
                         "Finding 1, one sentence.",
                         "Finding 2, one sentence.",
@@ -257,12 +259,17 @@ def _validate_entry(entry: dict, valid_slugs: set[str]) -> tuple[Optional[PaperS
         return None, "key_findings is empty"
     methodology = str(entry.get("methodology", "") or "").strip()
     relevance = str(entry.get("relevance", "") or "").strip()
+    summary = str(entry.get("summary", "") or "").strip()
     if not methodology:
         return None, "methodology is empty"
     if not relevance:
         return None, "relevance is empty"
+    # v0.81: summary is OPTIONAL (older LLM outputs and abstract-too-thin
+    # cases may legitimately produce only findings/methodology/relevance).
+    # When present, it fills the `## Summary` block instead of leaving [TODO].
     return PaperSummary(
         paper_slug=slug,
+        summary=summary,
         key_findings=findings,
         methodology=methodology,
         relevance=relevance,
@@ -272,6 +279,10 @@ def _validate_entry(entry: dict, valid_slugs: set[str]) -> tuple[Optional[PaperS
 # -- write back ---------------------------------------------------------
 
 
+_SUMMARY_BLOCK_RE = re.compile(
+    r"(##\s+Summary\n\n>\s+\[!abstract\]\n)(?:>[^\n]*\n)+(\^summary)",
+    re.MULTILINE,
+)
 _FINDINGS_BLOCK_RE = re.compile(
     r"(##\s+Key Findings\n\n>\s+\[!success\]\n)(?:>[^\n]*\n)+(\^findings)",
     re.MULTILINE,
@@ -287,6 +298,12 @@ _RELEVANCE_BLOCK_RE = re.compile(
 
 
 def _replace_obsidian_block(text: str, summary: PaperSummary) -> str:
+    # v0.81: also fill `## Summary` block when summary text present.
+    # Previously this block was only ever set to "[TODO] <title>" by the
+    # ingest pipeline and never overwritten; even when claude returned
+    # substantive Key Findings the Summary block stayed [TODO].
+    if summary.summary:
+        text = _SUMMARY_BLOCK_RE.sub(rf"\1> {summary.summary}\n\2", text)
     findings_block = "".join(f"> - {f}\n" for f in summary.key_findings)
     text = _FINDINGS_BLOCK_RE.sub(rf"\1{findings_block}\2", text)
     text = _METHODOLOGY_BLOCK_RE.sub(rf"\1> {summary.methodology}\n\2", text)
@@ -298,7 +315,9 @@ def _build_zotero_note_html(paper_meta: dict, summary: PaperSummary) -> str:
     title = paper_meta.get("title", "(no title)")
     abstract = paper_meta.get("abstract", "")
     findings_html = "".join(f"<li>{f}</li>" for f in summary.key_findings)
-    html = f"<h1>Summary</h1><p>{title}</p>"
+    # v0.81: include the explicit summary if claude returned one.
+    summary_html = f"<p>{summary.summary}</p>" if summary.summary else f"<p>{title}</p>"
+    html = f"<h1>Summary</h1>{summary_html}"
     if abstract:
         html += f"<h2>Abstract</h2><p>{abstract}</p>"
     html += "<h2>Key Findings</h2><ul>" + findings_html + "</ul>"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,7 @@ _ZOTERO_WRITE_TEST_MODULES = frozenset({
     "test_v080_abstract_recovery_in_ingest",
     "test_v080_resummarize",
     "test_v080_summary_thin_check",
+    "test_v081_summary_block_and_orphan_skip",
 })
 
 

--- a/tests/test_v081_summary_block_and_orphan_skip.py
+++ b/tests/test_v081_summary_block_and_orphan_skip.py
@@ -1,0 +1,138 @@
+"""v0.81: summarize fills `## Summary` block + doctor skips raw/_deleted_*."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from research_hub import doctor
+from research_hub.summarize import (
+    PaperSummary,
+    _replace_obsidian_block,
+    _validate_entry,
+)
+
+
+# ---------- Part 1: summary block ----------
+
+def _make_md_with_blocks() -> str:
+    return (
+        "---\n"
+        "title: foo\n"
+        "---\n\n"
+        "## Summary\n\n"
+        "> [!abstract]\n"
+        "> [TODO] foo\n"
+        "^summary\n\n"
+        "## Key Findings\n\n"
+        "> [!success]\n"
+        "> - [abstract too thin to extract findings]\n"
+        "^findings\n\n"
+        "## Methodology\n\n"
+        "> [!info]\n"
+        "> [TODO]\n"
+        "^methodology\n\n"
+        "## Relevance\n\n"
+        "> [!note]\n"
+        "> [TODO]\n"
+        "^relevance\n"
+    )
+
+
+def test_summary_block_filled_when_summary_present():
+    summary = PaperSummary(
+        paper_slug="x", summary="A 1-2 sentence TLDR.",
+        key_findings=["finding A"], methodology="m", relevance="r",
+    )
+    out = _replace_obsidian_block(_make_md_with_blocks(), summary)
+    assert "> A 1-2 sentence TLDR." in out
+    assert "[TODO] foo" not in out
+
+
+def test_summary_block_unchanged_when_summary_absent():
+    summary = PaperSummary(
+        paper_slug="x", summary="",
+        key_findings=["finding A"], methodology="m", relevance="r",
+    )
+    out = _replace_obsidian_block(_make_md_with_blocks(), summary)
+    # Summary block stays at [TODO] when LLM didn't return one (back-compat).
+    assert "[TODO] foo" in out
+    # But Findings/Methodology/Relevance still get filled.
+    assert "> - finding A" in out
+
+
+def test_validate_entry_accepts_summary_field():
+    entry = {
+        "paper_slug": "x", "summary": "TLDR sentence.",
+        "key_findings": ["f1"], "methodology": "m", "relevance": "r",
+    }
+    sm, reason = _validate_entry(entry, valid_slugs={"x"})
+    assert sm is not None and sm.summary == "TLDR sentence."
+
+
+def test_validate_entry_omits_summary_field_back_compat():
+    """Old LLM outputs without `summary` key still pass validation."""
+    entry = {
+        "paper_slug": "x",  # no `summary` key
+        "key_findings": ["f1"], "methodology": "m", "relevance": "r",
+    }
+    sm, reason = _validate_entry(entry, valid_slugs={"x"})
+    assert sm is not None and sm.summary == ""
+
+
+# ---------- Part 2: doctor orphan_papers skips _deleted_* ----------
+
+
+class _StubCfg:
+    def __init__(self, raw_dir, clusters_file):
+        self.raw = raw_dir
+        self.clusters_file = clusters_file
+
+
+def test_orphan_papers_skips_deleted_folders(tmp_path, monkeypatch):
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    # A real orphan folder (not bound, not deleted) → should WARN
+    (raw / "true-orphan").mkdir()
+    (raw / "true-orphan" / "p.md").write_text("title", encoding="utf-8")
+    # A soft-deleted folder → should NOT count as orphan
+    (raw / "_deleted_old-cluster").mkdir()
+    (raw / "_deleted_old-cluster" / "p.md").write_text("title", encoding="utf-8")
+    # Another deleted variant
+    (raw / "_deleted_today_28_obsidian").mkdir()
+    (raw / "_deleted_today_28_obsidian" / "p.md").write_text("title", encoding="utf-8")
+
+    # Stub registry: no bound folders
+    class _ClusterStub:
+        slug = "x"
+        obsidian_subfolder = "x"
+
+    class _RegistryStub:
+        def __init__(self, *a, **kw): pass
+        def list(self): return []
+
+    monkeypatch.setattr("research_hub.clusters.ClusterRegistry", _RegistryStub)
+    cfg = _StubCfg(raw, tmp_path / "fake-clusters.yaml")
+
+    result = doctor.check_cluster_orphan_papers(cfg)
+    assert result.status == "WARN"
+    assert "true-orphan" in (result.details or "")
+    # _deleted_* folders should NOT appear in the orphan list
+    assert "_deleted_old-cluster" not in (result.details or "")
+    assert "_deleted_today_28_obsidian" not in (result.details or "")
+
+
+def test_orphan_papers_ok_when_only_deleted_folders(tmp_path, monkeypatch):
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    (raw / "_deleted_x").mkdir()
+    (raw / "_deleted_x" / "p.md").write_text("t", encoding="utf-8")
+
+    class _RegistryStub:
+        def __init__(self, *a, **kw): pass
+        def list(self): return []
+
+    monkeypatch.setattr("research_hub.clusters.ClusterRegistry", _RegistryStub)
+    cfg = _StubCfg(raw, tmp_path / "fake.yaml")
+
+    result = doctor.check_cluster_orphan_papers(cfg)
+    assert result.status == "OK"


### PR DESCRIPTION
End-to-end audit after v0.80 surfaced 2 small bugs:

**Bug 1**: summarize never overwrote `## Summary` block (PaperSummary lacked `summary` field, prompt didn't ask, regex didn't exist). Fix adds all three. Back-compat preserved.

**Bug 2**: doctor.check_cluster_orphan_papers counted `raw/_deleted_*/` soft-delete folders as orphan papers (today's audit: !14 false WARNs). Fix skips `_deleted_*` (mirrors vault/sync exclusion).

6 new tests. 2123 → 2129 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)