### PR TITLE
feat(research-hub-multi-ai): reposition as router in router/leaves architecture

### DIFF
--- a/skills/research-hub-multi-ai/SKILL.md
+++ b/skills/research-hub-multi-ai/SKILL.md
@@ -1,27 +1,39 @@
 ---
 name: research-hub-multi-ai
-description: Multi-AI orchestration for research-hub workflows. Use when the user wants Claude, Codex CLI, Gemini CLI, or another shell-capable assistant to share research-hub work such as planning, ingesting, crystal generation, Chinese/English summaries, or long-running literature workflows.
+description: Router skill that writes `.coord/multi_ai_plan.md` when a single round of work will need two or more delegates (Codex + Gemini, multiple parallel Codex sessions, or a sequence of mixed handoffs). For a single delegate, use `codex-delegate` or `gemini-delegate` directly — do not invoke this skill. The router decides task splitting, dependency ordering, and reconciliation; the leaves execute.
 ---
 
-# research-hub Multi-AI Orchestration
+# research-hub Multi-AI Router
 
-research-hub can be driven by any AI that can run shell commands, call MCP tools, or call REST endpoints. Use this skill to decide when the primary assistant should work directly and when to delegate long or language-specific work to Codex CLI or Gemini CLI. The underlying workspace may connect Zotero, Obsidian, and NotebookLM, or any useful two-tool subset.
+This skill is the **router** in a router/leaves architecture. The leaves are `codex-delegate` and `gemini-delegate`. The router's only job is to write a coordination plan; the leaves read their assigned task brief from that plan and execute.
 
-## Prerequisite check (do this first)
+## When to Invoke
 
-Every command this skill emits goes through the `research-hub` CLI
-(`research-hub auto`, `research-hub plan`, `research-hub ask`, etc.).
-Before producing a delegation plan, verify the CLI exists:
+Invoke this skill **only** when a single round of work will need two or more delegates. Examples:
+
+- Codex writes the test scaffolding **and** Gemini drafts the zh-TW companion doc — same round, both delegates.
+- Three parallel Codex runs against independent subtrees of the same repo, with a final Claude reconciliation step.
+- A sequence of mixed handoffs: Codex generates data, Gemini summarises in zh-TW, Codex writes a plot script.
+
+If only one delegate is needed this round, **use the leaf skill directly**. Do not produce a router plan for a one-task delegation — it adds ceremony with no benefit.
+
+## When Not to Invoke
+
+- Single delegate this round (just Codex, just Gemini): use the leaf skill.
+- Single-LLM `research-hub auto` runs that pass `--llm-cli codex` or `--llm-cli gemini`: the flag is a research-hub feature, not a router decision. See "Single-LLM research-hub routing" below for reference.
+- Pure-Claude planning, review, or judgment work: keep it in Claude.
+
+## Prerequisite check
+
+The router emits commands that go through the `research-hub` CLI in many cases. Before producing a plan, verify the CLI exists:
 
 ```bash
 research-hub --version
 ```
 
-If that command is **not found**, the user installed only the Claude
-Code marketplace plugin. Stop and tell them:
+If `research-hub` is **not found**, the user installed only the Claude Code marketplace plugin. Stop and tell them:
 
-> This skill orchestrates `research-hub` CLI commands across multiple
-> AIs, but the CLI itself isn't installed. Please run:
+> This skill orchestrates `research-hub` CLI commands across multiple AIs, but the CLI itself isn't installed. Please run:
 >
 > ```bash
 > pip install research-hub-pipeline
@@ -30,36 +42,62 @@ Code marketplace plugin. Stop and tell them:
 >
 > Then re-run your request.
 
-Do **not** produce a plan that calls `research-hub ...` if the CLI is
-missing — the user can't execute it.
+Do **not** produce a plan that calls `research-hub ...` if the CLI is missing — the user can't execute it. Plans that only call `codex-delegate` / `gemini-delegate` (no research-hub CLI) are fine without it.
 
-**Stage-agnostic, character-driven routing.** This skill is NOT bound to a specific research stage (discover / ingest / design / write / submit). The decision to delegate is driven by **task character** — token-heavy code, long-context reading, CJK prose, mechanical bulk edits — not by which stage of the research pipeline you happen to be in. A 200-page systematic-review summary in Stage 1 routes to Gemini for the same reason a zh-TW cover letter in Stage 8 does: long CJK prose that pays off Gemini's strength.
+## Output artifact: `.coord/multi_ai_plan.md`
 
-## Roles
+The router's only output is `.coord/multi_ai_plan.md` at the workspace root. Every plan has YAML frontmatter and a per-task brief block.
 
-| AI | Best role | Use when |
-|---|---|---|
-| Primary assistant | planning, review, domain judgment, user-facing explanation | ambiguous tasks, quality control, final synthesis |
-| Codex CLI | Python/backend execution, tests, mechanical bulk work, crystal generation | long local processing or code-heavy workflows |
-| Gemini CLI | long-context drafting and CJK output | Traditional Chinese summaries, bilingual briefs, long prose drafts |
+Schema:
 
-## Decision Rules
+```yaml
+---
+plan_id: <short-slug>             # e.g. paper-corpus-2026-05
+created_utc: 2026-05-09T12:34:56Z
+goal: <one paragraph>
+success_criteria:
+  - <observable check 1>
+  - <observable check 2>
+tasks:
+  - id: t1
+    agent: codex                  # codex | gemini | claude
+    brief_path: .ai/codex_task_t1.md
+    depends_on: []
+    success_criteria:
+      - <verification command or assertion>
+  - id: t2
+    agent: gemini
+    brief_path: .ai/gemini_task_t2.md
+    depends_on: [t1]
+    success_criteria:
+      - <verification>
+risks:
+  - <known risk>
+---
+```
 
-- Start with `research-hub plan "intent"` for broad research requests.
-- Use `research-hub auto "topic" --with-crystals --llm-cli codex` for long mechanical crystal generation when Codex is available.
-- Use `research-hub auto "topic" --with-crystals --llm-cli gemini` when the user explicitly wants Chinese/Japanese/Korean output.
-- Use `research-hub auto "topic" --no-nlm` for first-run validation before NotebookLM automation is trusted.
-- Use cached crystals or `research-hub ask <cluster> "question"` before spending tokens on a fresh synthesis.
+A ready-to-paste template lives in `references/multi_ai_plan_template.md`.
 
-## Commands
+The router writes the plan **and** writes each per-task brief at the path declared in `brief_path`. Leaves read the brief and execute.
+
+## Hand-off contract
+
+The plan is the source of truth. After the router writes it:
+
+1. Each leaf is invoked with the brief path as input. Leaves do not read the plan — they read their own brief.
+2. Claude (or another reconciler) reads `result.json` from each leaf, compares against `success_criteria` in the plan, and decides accept / re-run / fall back.
+3. Plans are append-mostly: if a re-run is needed, append a new task with a fresh id rather than mutating an existing one.
+
+## Single-LLM research-hub routing (reference only)
+
+The `research-hub auto` command takes a `--llm-cli` flag to pick which CLI handles long mechanical work like crystal generation. This is a research-hub feature, not router logic. Use it directly without invoking this skill:
 
 ```bash
-research-hub plan "TOPIC"
-research-hub auto "TOPIC" --with-crystals
 research-hub auto "TOPIC" --with-crystals --llm-cli codex
 research-hub auto "TOPIC" --with-crystals --llm-cli gemini
-research-hub ask <cluster> "question"
 ```
+
+Pick `codex` for token-heavy mechanical generation; pick `gemini` for long-context reading or CJK output. If you also need a second delegate in the same round (e.g. translate the resulting brief to zh-TW with Gemini), then this becomes a multi-AI plan and the router applies.
 
 Check available CLIs:
 
@@ -69,7 +107,8 @@ python -c "from research_hub.auto import detect_llm_cli; print(detect_llm_cli())
 
 ## Guardrails
 
-- Do not delegate before the workflow is clear.
-- Do not fabricate citations or metadata.
-- Do not assume Gemini is Chinese-only; it can be used in English, but its strongest reason to choose it over Codex is language-heavy or long-context prose.
+- Do not produce a plan with a single task — that is a misuse; use the leaf skill directly.
+- Do not fabricate citations or metadata in either the plan or the per-task briefs.
+- Do not assume Gemini is Chinese-only; route by task character (long context, CJK prose, second-opinion review), not by language alone.
+- Do not overwrite `.coord/multi_ai_plan.md` of a different plan_id — append a new file `.coord/multi_ai_plan_<plan_id>.md` if the workspace already has an active plan.
 - Do not overwrite vault notes or delete clusters without explicit user approval.

--- a/skills/research-hub-multi-ai/evals/evals.json
+++ b/skills/research-hub-multi-ai/evals/evals.json
@@ -2,16 +2,24 @@
   "skill": "research-hub-multi-ai",
   "evals": [
     {
+      "prompt": "I need Codex to write the test scaffolding for src/util.py and Gemini to draft the zh-TW companion for docs/util.md, both this round.",
+      "expected_behavior": "Recognize this is a multi-delegate round (>=2 delegates): write `.coord/multi_ai_plan.md` with a task for codex (test scaffolding) and a task for gemini (zh-TW translation), each pointing to its own brief file. Do NOT execute either task in this skill — the leaves do that."
+    },
+    {
       "prompt": "Delegate this 200-line refactor to Codex.",
-      "expected_behavior": "Recognize this is a heavy code task: write a brief at `.ai/codex_task_*.md`, then `codex exec --full-auto -C <repo> ...` in background; review diff before committing."
+      "expected_behavior": "Recognize this is a single-delegate task: do NOT invoke this skill. Route to `codex-delegate` directly — write a `.ai/codex_task_*.md` brief and launch the wrapper. Producing a router plan for one task is misuse."
     },
     {
       "prompt": "Generate a Traditional Chinese summary of this 8000-word paper.",
-      "expected_behavior": "Recognize this is a CJK long-form task: defer to Gemini CLI via the gemini-delegate pattern; preserve technical terms; review for hallucination before posting."
+      "expected_behavior": "Recognize this is a single-delegate CJK task: do NOT invoke this skill. Route to `gemini-delegate` directly. The router only applies when this same round will also need a second delegate."
+    },
+    {
+      "prompt": "Run `research-hub auto \"agent-based modeling\" --with-crystals --llm-cli codex`.",
+      "expected_behavior": "Recognize this is a single-LLM research-hub CLI run: the `--llm-cli` flag is a research-hub feature, not a router decision. Do NOT produce a multi-AI plan. Just run the command (after verifying the CLI is installed)."
     },
     {
       "prompt": "Should you write this 30-line bug fix yourself or delegate?",
-      "expected_behavior": "Decide locally: <50 LOC + needs project context = Claude direct, no delegation. Reply with one sentence on why."
+      "expected_behavior": "Decide locally: <50 LOC + needs project context = Claude direct, no delegation. Do not invoke this skill. Reply with one sentence on why."
     }
   ]
 }

--- a/skills/research-hub-multi-ai/references/multi_ai_plan_template.md
+++ b/skills/research-hub-multi-ai/references/multi_ai_plan_template.md
@@ -1,0 +1,95 @@
+# `.coord/multi_ai_plan.md` Template
+
+Drop this template at `.coord/multi_ai_plan.md` (or `.coord/multi_ai_plan_<slug>.md` if a plan already lives at the default name) and fill in the fields. Do not invent fields — the schema is enforced by reconcilers.
+
+```yaml
+---
+plan_id: <short-slug-2026-05-09>
+created_utc: 2026-05-09T00:00:00Z
+goal: |
+  One paragraph. What does this multi-AI round accomplish that a single delegate cannot?
+  Why split now rather than sequence later?
+
+success_criteria:
+  - <observable check that the whole round succeeded — e.g. "tests pass and zh-TW companion exists">
+  - <second check if relevant>
+
+tasks:
+  - id: t1
+    agent: codex
+    brief_path: .ai/codex_task_t1.md
+    depends_on: []
+    success_criteria:
+      - <e.g. "pytest -q passes in tests/test_module.py">
+      - <e.g. "result.json status == success">
+
+  - id: t2
+    agent: gemini
+    brief_path: .ai/gemini_task_t2.md
+    depends_on: [t1]
+    success_criteria:
+      - <e.g. "docs/feature.zh-TW.md exists with same heading count as docs/feature.md">
+
+  - id: t3
+    agent: claude
+    brief_path: inline       # for Claude tasks, brief lives in this file
+    depends_on: [t1, t2]
+    success_criteria:
+      - <e.g. "PR description references both t1 and t2 outputs">
+
+risks:
+  - <known risk that Claude must watch for during reconciliation>
+
+reconciliation:
+  agent: claude
+  steps:
+    - Read each leaf's result.json and compare with success_criteria.
+    - On mismatch, append a fix-up task with a fresh id; do not mutate existing tasks.
+    - Once all tasks pass success_criteria, mark plan as done with a `done_utc` field.
+---
+
+# Brief: t3 (claude, inline)
+
+(Free-form per-task brief for tasks where `brief_path: inline`. For tasks with a real brief path, leave this section out — the leaf reads the brief from its own file.)
+
+## Context
+- ...
+
+## Goal
+- ...
+
+## Constraints
+- Stay within the success_criteria above.
+- Do not silently widen scope.
+
+## Acceptance
+- ...
+```
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| `plan_id` | yes | Short slug, append date if multiple plans land same week |
+| `created_utc` | yes | ISO 8601 UTC |
+| `goal` | yes | One paragraph; this drives accept/reject judgment downstream |
+| `success_criteria` | yes | Round-level. Per-task criteria live under each task |
+| `tasks[].id` | yes | Unique within the plan; referenced in `depends_on` |
+| `tasks[].agent` | yes | One of `codex`, `gemini`, `claude` |
+| `tasks[].brief_path` | yes | Path to the task brief file. Use `inline` for Claude tasks whose brief lives below the YAML in this same file |
+| `tasks[].depends_on` | yes | List of task ids; can be empty |
+| `tasks[].success_criteria` | yes | Verifiable assertions or commands |
+| `risks` | optional | Free-form notes for reconciler |
+| `reconciliation` | optional | Defaults to `agent: claude` if absent |
+
+## Conventions
+
+- One plan per round of work. If the round expands, append `_v2` to the plan_id and create a sibling file rather than editing in place.
+- Briefs at `brief_path` follow the per-leaf-skill conventions (see `codex-delegate` and `gemini-delegate` for their respective brief shapes).
+- Every leaf must emit a machine-readable `result.json` so the reconciler can check `success_criteria` programmatically.
+
+## Anti-patterns
+
+- A plan with one task: use the leaf skill directly, skip the router.
+- A plan whose tasks all have the same agent and no dependencies: use the leaf's parallel-execution pattern, skip the router.
+- Mutating an existing task's `success_criteria` after a leaf finished: append a fix-up task instead.

--- a/src/research_hub/skills_data/research-hub-multi-ai/SKILL.md
+++ b/src/research_hub/skills_data/research-hub-multi-ai/SKILL.md
@@ -1,27 +1,39 @@
 ---
 name: research-hub-multi-ai
-description: Multi-AI orchestration for research-hub workflows. Use when the user wants Claude, Codex CLI, Gemini CLI, or another shell-capable assistant to share research-hub work such as planning, ingesting, crystal generation, Chinese/English summaries, or long-running literature workflows.
+description: Router skill that writes `.coord/multi_ai_plan.md` when a single round of work will need two or more delegates (Codex + Gemini, multiple parallel Codex sessions, or a sequence of mixed handoffs). For a single delegate, use `codex-delegate` or `gemini-delegate` directly — do not invoke this skill. The router decides task splitting, dependency ordering, and reconciliation; the leaves execute.
 ---
 
-# research-hub Multi-AI Orchestration
+# research-hub Multi-AI Router
 
-research-hub can be driven by any AI that can run shell commands, call MCP tools, or call REST endpoints. Use this skill to decide when the primary assistant should work directly and when to delegate long or language-specific work to Codex CLI or Gemini CLI. The underlying workspace may connect Zotero, Obsidian, and NotebookLM, or any useful two-tool subset.
+This skill is the **router** in a router/leaves architecture. The leaves are `codex-delegate` and `gemini-delegate`. The router's only job is to write a coordination plan; the leaves read their assigned task brief from that plan and execute.
 
-## Prerequisite check (do this first)
+## When to Invoke
 
-Every command this skill emits goes through the `research-hub` CLI
-(`research-hub auto`, `research-hub plan`, `research-hub ask`, etc.).
-Before producing a delegation plan, verify the CLI exists:
+Invoke this skill **only** when a single round of work will need two or more delegates. Examples:
+
+- Codex writes the test scaffolding **and** Gemini drafts the zh-TW companion doc — same round, both delegates.
+- Three parallel Codex runs against independent subtrees of the same repo, with a final Claude reconciliation step.
+- A sequence of mixed handoffs: Codex generates data, Gemini summarises in zh-TW, Codex writes a plot script.
+
+If only one delegate is needed this round, **use the leaf skill directly**. Do not produce a router plan for a one-task delegation — it adds ceremony with no benefit.
+
+## When Not to Invoke
+
+- Single delegate this round (just Codex, just Gemini): use the leaf skill.
+- Single-LLM `research-hub auto` runs that pass `--llm-cli codex` or `--llm-cli gemini`: the flag is a research-hub feature, not a router decision. See "Single-LLM research-hub routing" below for reference.
+- Pure-Claude planning, review, or judgment work: keep it in Claude.
+
+## Prerequisite check
+
+The router emits commands that go through the `research-hub` CLI in many cases. Before producing a plan, verify the CLI exists:
 
 ```bash
 research-hub --version
 ```
 
-If that command is **not found**, the user installed only the Claude
-Code marketplace plugin. Stop and tell them:
+If `research-hub` is **not found**, the user installed only the Claude Code marketplace plugin. Stop and tell them:
 
-> This skill orchestrates `research-hub` CLI commands across multiple
-> AIs, but the CLI itself isn't installed. Please run:
+> This skill orchestrates `research-hub` CLI commands across multiple AIs, but the CLI itself isn't installed. Please run:
 >
 > ```bash
 > pip install research-hub-pipeline
@@ -30,36 +42,62 @@ Code marketplace plugin. Stop and tell them:
 >
 > Then re-run your request.
 
-Do **not** produce a plan that calls `research-hub ...` if the CLI is
-missing — the user can't execute it.
+Do **not** produce a plan that calls `research-hub ...` if the CLI is missing — the user can't execute it. Plans that only call `codex-delegate` / `gemini-delegate` (no research-hub CLI) are fine without it.
 
-**Stage-agnostic, character-driven routing.** This skill is NOT bound to a specific research stage (discover / ingest / design / write / submit). The decision to delegate is driven by **task character** — token-heavy code, long-context reading, CJK prose, mechanical bulk edits — not by which stage of the research pipeline you happen to be in. A 200-page systematic-review summary in Stage 1 routes to Gemini for the same reason a zh-TW cover letter in Stage 8 does: long CJK prose that pays off Gemini's strength.
+## Output artifact: `.coord/multi_ai_plan.md`
 
-## Roles
+The router's only output is `.coord/multi_ai_plan.md` at the workspace root. Every plan has YAML frontmatter and a per-task brief block.
 
-| AI | Best role | Use when |
-|---|---|---|
-| Primary assistant | planning, review, domain judgment, user-facing explanation | ambiguous tasks, quality control, final synthesis |
-| Codex CLI | Python/backend execution, tests, mechanical bulk work, crystal generation | long local processing or code-heavy workflows |
-| Gemini CLI | long-context drafting and CJK output | Traditional Chinese summaries, bilingual briefs, long prose drafts |
+Schema:
 
-## Decision Rules
+```yaml
+---
+plan_id: <short-slug>             # e.g. paper-corpus-2026-05
+created_utc: 2026-05-09T12:34:56Z
+goal: <one paragraph>
+success_criteria:
+  - <observable check 1>
+  - <observable check 2>
+tasks:
+  - id: t1
+    agent: codex                  # codex | gemini | claude
+    brief_path: .ai/codex_task_t1.md
+    depends_on: []
+    success_criteria:
+      - <verification command or assertion>
+  - id: t2
+    agent: gemini
+    brief_path: .ai/gemini_task_t2.md
+    depends_on: [t1]
+    success_criteria:
+      - <verification>
+risks:
+  - <known risk>
+---
+```
 
-- Start with `research-hub plan "intent"` for broad research requests.
-- Use `research-hub auto "topic" --with-crystals --llm-cli codex` for long mechanical crystal generation when Codex is available.
-- Use `research-hub auto "topic" --with-crystals --llm-cli gemini` when the user explicitly wants Chinese/Japanese/Korean output.
-- Use `research-hub auto "topic" --no-nlm` for first-run validation before NotebookLM automation is trusted.
-- Use cached crystals or `research-hub ask <cluster> "question"` before spending tokens on a fresh synthesis.
+A ready-to-paste template lives in `references/multi_ai_plan_template.md`.
 
-## Commands
+The router writes the plan **and** writes each per-task brief at the path declared in `brief_path`. Leaves read the brief and execute.
+
+## Hand-off contract
+
+The plan is the source of truth. After the router writes it:
+
+1. Each leaf is invoked with the brief path as input. Leaves do not read the plan — they read their own brief.
+2. Claude (or another reconciler) reads `result.json` from each leaf, compares against `success_criteria` in the plan, and decides accept / re-run / fall back.
+3. Plans are append-mostly: if a re-run is needed, append a new task with a fresh id rather than mutating an existing one.
+
+## Single-LLM research-hub routing (reference only)
+
+The `research-hub auto` command takes a `--llm-cli` flag to pick which CLI handles long mechanical work like crystal generation. This is a research-hub feature, not router logic. Use it directly without invoking this skill:
 
 ```bash
-research-hub plan "TOPIC"
-research-hub auto "TOPIC" --with-crystals
 research-hub auto "TOPIC" --with-crystals --llm-cli codex
 research-hub auto "TOPIC" --with-crystals --llm-cli gemini
-research-hub ask <cluster> "question"
 ```
+
+Pick `codex` for token-heavy mechanical generation; pick `gemini` for long-context reading or CJK output. If you also need a second delegate in the same round (e.g. translate the resulting brief to zh-TW with Gemini), then this becomes a multi-AI plan and the router applies.
 
 Check available CLIs:
 
@@ -69,7 +107,8 @@ python -c "from research_hub.auto import detect_llm_cli; print(detect_llm_cli())
 
 ## Guardrails
 
-- Do not delegate before the workflow is clear.
-- Do not fabricate citations or metadata.
-- Do not assume Gemini is Chinese-only; it can be used in English, but its strongest reason to choose it over Codex is language-heavy or long-context prose.
+- Do not produce a plan with a single task — that is a misuse; use the leaf skill directly.
+- Do not fabricate citations or metadata in either the plan or the per-task briefs.
+- Do not assume Gemini is Chinese-only; route by task character (long context, CJK prose, second-opinion review), not by language alone.
+- Do not overwrite `.coord/multi_ai_plan.md` of a different plan_id — append a new file `.coord/multi_ai_plan_<plan_id>.md` if the workspace already has an active plan.
 - Do not overwrite vault notes or delete clusters without explicit user approval.

--- a/src/research_hub/skills_data/research-hub-multi-ai/evals/evals.json
+++ b/src/research_hub/skills_data/research-hub-multi-ai/evals/evals.json
@@ -2,16 +2,24 @@
   "skill": "research-hub-multi-ai",
   "evals": [
     {
+      "prompt": "I need Codex to write the test scaffolding for src/util.py and Gemini to draft the zh-TW companion for docs/util.md, both this round.",
+      "expected_behavior": "Recognize this is a multi-delegate round (>=2 delegates): write `.coord/multi_ai_plan.md` with a task for codex (test scaffolding) and a task for gemini (zh-TW translation), each pointing to its own brief file. Do NOT execute either task in this skill — the leaves do that."
+    },
+    {
       "prompt": "Delegate this 200-line refactor to Codex.",
-      "expected_behavior": "Recognize this is a heavy code task: write a brief at `.ai/codex_task_*.md`, then `codex exec --full-auto -C <repo> ...` in background; review diff before committing."
+      "expected_behavior": "Recognize this is a single-delegate task: do NOT invoke this skill. Route to `codex-delegate` directly — write a `.ai/codex_task_*.md` brief and launch the wrapper. Producing a router plan for one task is misuse."
     },
     {
       "prompt": "Generate a Traditional Chinese summary of this 8000-word paper.",
-      "expected_behavior": "Recognize this is a CJK long-form task: defer to Gemini CLI via the gemini-delegate pattern; preserve technical terms; review for hallucination before posting."
+      "expected_behavior": "Recognize this is a single-delegate CJK task: do NOT invoke this skill. Route to `gemini-delegate` directly. The router only applies when this same round will also need a second delegate."
+    },
+    {
+      "prompt": "Run `research-hub auto \"agent-based modeling\" --with-crystals --llm-cli codex`.",
+      "expected_behavior": "Recognize this is a single-LLM research-hub CLI run: the `--llm-cli` flag is a research-hub feature, not a router decision. Do NOT produce a multi-AI plan. Just run the command (after verifying the CLI is installed)."
     },
     {
       "prompt": "Should you write this 30-line bug fix yourself or delegate?",
-      "expected_behavior": "Decide locally: <50 LOC + needs project context = Claude direct, no delegation. Reply with one sentence on why."
+      "expected_behavior": "Decide locally: <50 LOC + needs project context = Claude direct, no delegation. Do not invoke this skill. Reply with one sentence on why."
     }
   ]
 }

--- a/src/research_hub/skills_data/research-hub-multi-ai/references/multi_ai_plan_template.md
+++ b/src/research_hub/skills_data/research-hub-multi-ai/references/multi_ai_plan_template.md
@@ -1,0 +1,95 @@
+# `.coord/multi_ai_plan.md` Template
+
+Drop this template at `.coord/multi_ai_plan.md` (or `.coord/multi_ai_plan_<slug>.md` if a plan already lives at the default name) and fill in the fields. Do not invent fields — the schema is enforced by reconcilers.
+
+```yaml
+---
+plan_id: <short-slug-2026-05-09>
+created_utc: 2026-05-09T00:00:00Z
+goal: |
+  One paragraph. What does this multi-AI round accomplish that a single delegate cannot?
+  Why split now rather than sequence later?
+
+success_criteria:
+  - <observable check that the whole round succeeded — e.g. "tests pass and zh-TW companion exists">
+  - <second check if relevant>
+
+tasks:
+  - id: t1
+    agent: codex
+    brief_path: .ai/codex_task_t1.md
+    depends_on: []
+    success_criteria:
+      - <e.g. "pytest -q passes in tests/test_module.py">
+      - <e.g. "result.json status == success">
+
+  - id: t2
+    agent: gemini
+    brief_path: .ai/gemini_task_t2.md
+    depends_on: [t1]
+    success_criteria:
+      - <e.g. "docs/feature.zh-TW.md exists with same heading count as docs/feature.md">
+
+  - id: t3
+    agent: claude
+    brief_path: inline       # for Claude tasks, brief lives in this file
+    depends_on: [t1, t2]
+    success_criteria:
+      - <e.g. "PR description references both t1 and t2 outputs">
+
+risks:
+  - <known risk that Claude must watch for during reconciliation>
+
+reconciliation:
+  agent: claude
+  steps:
+    - Read each leaf's result.json and compare with success_criteria.
+    - On mismatch, append a fix-up task with a fresh id; do not mutate existing tasks.
+    - Once all tasks pass success_criteria, mark plan as done with a `done_utc` field.
+---
+
+# Brief: t3 (claude, inline)
+
+(Free-form per-task brief for tasks where `brief_path: inline`. For tasks with a real brief path, leave this section out — the leaf reads the brief from its own file.)
+
+## Context
+- ...
+
+## Goal
+- ...
+
+## Constraints
+- Stay within the success_criteria above.
+- Do not silently widen scope.
+
+## Acceptance
+- ...
+```
+
+## Field reference
+
+| Field | Required | Notes |
+|---|---|---|
+| `plan_id` | yes | Short slug, append date if multiple plans land same week |
+| `created_utc` | yes | ISO 8601 UTC |
+| `goal` | yes | One paragraph; this drives accept/reject judgment downstream |
+| `success_criteria` | yes | Round-level. Per-task criteria live under each task |
+| `tasks[].id` | yes | Unique within the plan; referenced in `depends_on` |
+| `tasks[].agent` | yes | One of `codex`, `gemini`, `claude` |
+| `tasks[].brief_path` | yes | Path to the task brief file. Use `inline` for Claude tasks whose brief lives below the YAML in this same file |
+| `tasks[].depends_on` | yes | List of task ids; can be empty |
+| `tasks[].success_criteria` | yes | Verifiable assertions or commands |
+| `risks` | optional | Free-form notes for reconciler |
+| `reconciliation` | optional | Defaults to `agent: claude` if absent |
+
+## Conventions
+
+- One plan per round of work. If the round expands, append `_v2` to the plan_id and create a sibling file rather than editing in place.
+- Briefs at `brief_path` follow the per-leaf-skill conventions (see `codex-delegate` and `gemini-delegate` for their respective brief shapes).
+- Every leaf must emit a machine-readable `result.json` so the reconciler can check `success_criteria` programmatically.
+
+## Anti-patterns
+
+- A plan with one task: use the leaf skill directly, skip the router.
+- A plan whose tasks all have the same agent and no dependencies: use the leaf's parallel-execution pattern, skip the router.
+- Mutating an existing task's `success_criteria` after a leaf finished: append a fix-up task instead.


### PR DESCRIPTION
## Summary
- Tighten the trigger so this skill fires ONLY when a round will need >=2 delegates (Codex + Gemini, multiple parallel Codex sessions, or mixed handoffs). For single-delegate work, route directly to `codex-delegate` / `gemini-delegate`.
- Define the router's only output artifact: `.coord/multi_ai_plan.md` with explicit YAML schema (plan_id, goal, success_criteria, tasks[], reconciliation).
- Add `references/multi_ai_plan_template.md` — paste-ready template + field reference + anti-patterns.
- Demote single-LLM `research-hub auto --llm-cli` content to a reference section (it's a CLI flag, not a router decision).
- Rewrite evals so the only positive case is multi-delegate; single-delegate / single-LLM / small-fix cases expect this skill NOT to fire.
- Mirror under `src/research_hub/skills_data/` synced.

## Why now
Companion PR [WenyuChiou/codex-delegate#1](https://github.com/WenyuChiou/codex-delegate/pull/1) makes `codex-delegate` an explicit leaf in router/leaves architecture. This PR completes the other half: the router. The downstream catalog (ai-research-skills) flagged the three-skill trigger overlap (codex-delegate, gemini-delegate, research-hub-multi-ai all matching "batch edits" / "CJK prose"). Tight router trigger removes the overlap.

## Test plan
- [x] Frontmatter description ~460 chars, well under 1024 limit.
- [x] Mirror at `src/research_hub/skills_data/research-hub-multi-ai/` byte-identical to source skill.
- [ ] Reviewer confirms evals match the new trigger model — old evals (single delegate to Codex / single CJK summary) now expected NOT to fire.
- [ ] Reviewer dry-runs the template against a real multi-delegate scenario and confirms the schema captures real plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)