### PR TITLE
catalog hygiene: --version ghost flag, paper trigger collision, experiment_matrix schema

### DIFF
--- a/docs/research-workspace-manifest.md
+++ b/docs/research-workspace-manifest.md
@@ -117,29 +117,44 @@ yet". `current_stage` is free-form but conventionally one of
 
 ## Schema: `.research/experiment_matrix.yml`
 
-Tracks every experiment a project has run. Append-only by convention.
+Tracks every experiment OR verification run a project has executed.
+Append-only by convention. Two row shapes are accepted: hypothesis-driven
+experiment rows (modelling work) and verification rows (skill / tooling
+validation). Pick whichever fits the project; mixing both shapes in one
+matrix is also fine.
 
 ```yaml
 experiments:
+  # Hypothesis-driven experiment row
   - id: "E1-baseline"
     hypothesis: "ABM without behavioral adaptation matches FEMA depth grids."
     method: "baseline ABM run, no adaptation layer"
     inputs: ["data/harvey/", "config/baseline.yaml"]
     outputs: ["outputs/E1/"]
-    status: "complete"                       # planned | running | complete | abandoned
+    status: "complete"
     finding: "RMSE 0.42 m vs FEMA. Acceptable baseline."
     notes: "see decisions.md 2026-02-14"
-  - id: "E2-coupled"
-    hypothesis: "Coupling reduces RMSE by >15%."
-    method: "ABM + CAT, daily exchange"
-    inputs: ["data/harvey/", "config/coupled.yaml"]
-    outputs: ["outputs/E2/"]
-    status: "running"
-    finding: ""
-    notes: ""
+
+  # Verification row (e.g. skill smoke test, tooling validation)
+  - id: "research-hub"
+    status: "pass"
+    tier: "T1"
+    method: "doctor health check + search 'agent-based modeling' --limit 3"
+    artifacts: "docs/verification.md (per-skill detail)"
+    last_run: "2026-04-25"
 ```
 
-**Required fields per row**: `id`, `hypothesis`, `status`.
+**Required fields per row:** `id`, `status`.
+
+**Optional fields:**
+
+- `hypothesis` — include for hypothesis-driven rows; omit for verification rows.
+- `method`, `inputs`, `outputs`, `finding`, `notes` — typical for experiment rows.
+- `tier` (T1 / T2 / T3), `artifacts`, `last_run` (YYYY-MM-DD) — typical for verification rows.
+
+**`status` enum:** `planned | running | complete | abandoned` for experiments;
+`pass | caveat | pending | not_yet | fail` for verification runs. Readers
+should treat any unknown value as informational rather than erroring.
 
 ## Schema: `.research/data_dictionary.yml`
 

--- a/skills/paper-memory-builder/SKILL.md
+++ b/skills/paper-memory-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-memory-builder
-description: Convert a paper draft + figures + Zotero metadata into reusable .paper/claims.yml and .paper/figures.yml files so the academic-writing-skills skill can do writing, revision, and audit passes without re-reading the manuscript every time. Use when the user asks to "build paper memory", "extract claims from this manuscript", or "prepare this paper for AI-assisted writing".
+description: Convert a paper draft + figures + Zotero metadata into reusable .paper/claims.yml and .paper/figures.yml files so the academic-writing-skills skill can do writing, revision, and audit passes without re-reading the manuscript every time. Use when the user asks to "build paper memory", "extract claims from this manuscript", or "prepare this paper for AI-assisted writing". NOT for summarizing cited papers in a literature cluster — that's `paper-summarize`. This skill is for the user's own manuscript draft only.
 ---
 
 # paper-memory-builder

--- a/skills/paper-summarize/SKILL.md
+++ b/skills/paper-summarize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-summarize
-description: After research-hub ingests a cluster of papers, fill the per-paper Key Findings + Methodology + Relevance sections in BOTH Obsidian markdown and the Zotero child note. Use when the user says "summarize this cluster's papers", "fill the TODO Findings", or "I just ran auto and don't know what these papers are about". Invokes `claude` / `codex` / `gemini` (whichever is on PATH) on each paper's abstract.
+description: After research-hub ingests a cluster of cited papers, fill the per-paper Key Findings + Methodology + Relevance sections in BOTH Obsidian markdown and the Zotero child note. Use when the user says "fill the TODO Key Findings/Methodology blocks left by research-hub auto", "I just ran auto and don't know what these papers are about", or "summarize the papers in cluster X". Invokes `claude` / `codex` / `gemini` (whichever is on PATH) on each paper's abstract. NOT for summarizing the user's own manuscript draft — that's `paper-memory-builder`. NOT for cluster-level briefs — that's `research-hub notebooklm generate`. This skill is per-cited-paper only.
 ---
 
 # paper-summarize

--- a/skills/research-hub-multi-ai/SKILL.md
+++ b/skills/research-hub-multi-ai/SKILL.md
@@ -28,10 +28,10 @@ If only one delegate is needed this round, **use the leaf skill directly**. Do n
 The router emits commands that go through the `research-hub` CLI in many cases. Before producing a plan, verify the CLI exists:
 
 ```bash
-research-hub --version
+research-hub doctor
 ```
 
-If `research-hub` is **not found**, the user installed only the Claude Code marketplace plugin. Stop and tell them:
+If that command is **not found** (vs. emitting a health report), the user installed only the Claude Code marketplace plugin. Stop and tell them:
 
 > This skill orchestrates `research-hub` CLI commands across multiple AIs, but the CLI itself isn't installed. Please run:
 >

--- a/skills/research-hub/SKILL.md
+++ b/skills/research-hub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-hub
-description: Operate research-hub workflows for literature discovery, source ingest, Zotero/Obsidian/NotebookLM organization, dashboard inspection, and vault maintenance. Use when the user asks to find papers, build a knowledge base, organize references, upload to NotebookLM, generate research briefs, inspect clusters, or maintain a research vault.
+description: Operate research-hub workflows for literature discovery, source ingest into Zotero/Obsidian/NotebookLM, dashboard inspection, and vault maintenance. Use when the user asks to find papers, build a knowledge base, ingest a folder of PDFs, upload to NotebookLM, generate research briefs, inspect clusters, or maintain a research vault. NOT for auditing or cleaning up an existing Zotero library — that's `zotero-library-curator` (read-only audit) plus `zotero-skills` (for CRUD).
 ---
 
 # research-hub
@@ -13,12 +13,12 @@ This skill drives the `research-hub` Python CLI. Before running any
 command from this skill, verify the CLI is installed:
 
 ```bash
-research-hub --version
+research-hub doctor
 ```
 
-If that command is **not found**, the user installed only the Claude
-Code marketplace plugin and is missing the Python CLI. Stop and tell
-them:
+If that command is **not found** (vs. emitting a health report), the
+user installed only the Claude Code marketplace plugin and is missing
+the Python CLI. Stop and tell them:
 
 > This skill needs the `research-hub` CLI. Please run:
 >

--- a/skills/research-project-orienter/SKILL.md
+++ b/skills/research-project-orienter/SKILL.md
@@ -76,7 +76,7 @@ Single message in this exact structure:
 - ...
 
 **Experiments** (<count>, by status):
-- <status>: <id> — <hypothesis (one line)>
+- <status>: <id> — <hypothesis or method, one line; "(no hypothesis)" if both absent>
 - ...
 
 **Main entrypoints**:

--- a/skills/zotero-library-curator/SKILL.md
+++ b/skills/zotero-library-curator/SKILL.md
@@ -30,7 +30,7 @@ two modes:
 Before running, verify at least one is present:
 
 ```bash
-research-hub --version 2>/dev/null  # if research-hub CLI installed
+research-hub doctor 2>/dev/null  # if research-hub CLI installed
 ls ~/.claude/skills/zotero-skills/SKILL.md 2>/dev/null  # if zotero-skills skill installed
 ```
 

--- a/src/research_hub/skills_data/paper-memory-builder/SKILL.md
+++ b/src/research_hub/skills_data/paper-memory-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-memory-builder
-description: Convert a paper draft + figures + Zotero metadata into reusable .paper/claims.yml and .paper/figures.yml files so the academic-writing-skills skill can do writing, revision, and audit passes without re-reading the manuscript every time. Use when the user asks to "build paper memory", "extract claims from this manuscript", or "prepare this paper for AI-assisted writing".
+description: Convert a paper draft + figures + Zotero metadata into reusable .paper/claims.yml and .paper/figures.yml files so the academic-writing-skills skill can do writing, revision, and audit passes without re-reading the manuscript every time. Use when the user asks to "build paper memory", "extract claims from this manuscript", or "prepare this paper for AI-assisted writing". NOT for summarizing cited papers in a literature cluster — that's `paper-summarize`. This skill is for the user's own manuscript draft only.
 ---
 
 # paper-memory-builder

--- a/src/research_hub/skills_data/paper-summarize/SKILL.md
+++ b/src/research_hub/skills_data/paper-summarize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-summarize
-description: After research-hub ingests a cluster of papers, fill the per-paper Key Findings + Methodology + Relevance sections in BOTH Obsidian markdown and the Zotero child note. Use when the user says "summarize this cluster's papers", "fill the TODO Findings", or "I just ran auto and don't know what these papers are about". Invokes `claude` / `codex` / `gemini` (whichever is on PATH) on each paper's abstract.
+description: After research-hub ingests a cluster of cited papers, fill the per-paper Key Findings + Methodology + Relevance sections in BOTH Obsidian markdown and the Zotero child note. Use when the user says "fill the TODO Key Findings/Methodology blocks left by research-hub auto", "I just ran auto and don't know what these papers are about", or "summarize the papers in cluster X". Invokes `claude` / `codex` / `gemini` (whichever is on PATH) on each paper's abstract. NOT for summarizing the user's own manuscript draft — that's `paper-memory-builder`. NOT for cluster-level briefs — that's `research-hub notebooklm generate`. This skill is per-cited-paper only.
 ---
 
 # paper-summarize

--- a/src/research_hub/skills_data/research-hub-multi-ai/SKILL.md
+++ b/src/research_hub/skills_data/research-hub-multi-ai/SKILL.md
@@ -28,10 +28,10 @@ If only one delegate is needed this round, **use the leaf skill directly**. Do n
 The router emits commands that go through the `research-hub` CLI in many cases. Before producing a plan, verify the CLI exists:
 
 ```bash
-research-hub --version
+research-hub doctor
 ```
 
-If `research-hub` is **not found**, the user installed only the Claude Code marketplace plugin. Stop and tell them:
+If that command is **not found** (vs. emitting a health report), the user installed only the Claude Code marketplace plugin. Stop and tell them:
 
 > This skill orchestrates `research-hub` CLI commands across multiple AIs, but the CLI itself isn't installed. Please run:
 >

--- a/src/research_hub/skills_data/research-hub/SKILL.md
+++ b/src/research_hub/skills_data/research-hub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-hub
-description: Operate research-hub workflows for literature discovery, source ingest, Zotero/Obsidian/NotebookLM organization, dashboard inspection, and vault maintenance. Use when the user asks to find papers, build a knowledge base, organize references, upload to NotebookLM, generate research briefs, inspect clusters, or maintain a research vault.
+description: Operate research-hub workflows for literature discovery, source ingest into Zotero/Obsidian/NotebookLM, dashboard inspection, and vault maintenance. Use when the user asks to find papers, build a knowledge base, ingest a folder of PDFs, upload to NotebookLM, generate research briefs, inspect clusters, or maintain a research vault. NOT for auditing or cleaning up an existing Zotero library — that's `zotero-library-curator` (read-only audit) plus `zotero-skills` (for CRUD).
 ---
 
 # research-hub
@@ -13,12 +13,12 @@ This skill drives the `research-hub` Python CLI. Before running any
 command from this skill, verify the CLI is installed:
 
 ```bash
-research-hub --version
+research-hub doctor
 ```
 
-If that command is **not found**, the user installed only the Claude
-Code marketplace plugin and is missing the Python CLI. Stop and tell
-them:
+If that command is **not found** (vs. emitting a health report), the
+user installed only the Claude Code marketplace plugin and is missing
+the Python CLI. Stop and tell them:
 
 > This skill needs the `research-hub` CLI. Please run:
 >

--- a/src/research_hub/skills_data/research-project-orienter/SKILL.md
+++ b/src/research_hub/skills_data/research-project-orienter/SKILL.md
@@ -76,7 +76,7 @@ Single message in this exact structure:
 - ...
 
 **Experiments** (<count>, by status):
-- <status>: <id> — <hypothesis (one line)>
+- <status>: <id> — <hypothesis or method, one line; "(no hypothesis)" if both absent>
 - ...
 
 **Main entrypoints**:

--- a/src/research_hub/skills_data/zotero-library-curator/SKILL.md
+++ b/src/research_hub/skills_data/zotero-library-curator/SKILL.md
@@ -30,7 +30,7 @@ two modes:
 Before running, verify at least one is present:
 
 ```bash
-research-hub --version 2>/dev/null  # if research-hub CLI installed
+research-hub doctor 2>/dev/null  # if research-hub CLI installed
 ls ~/.claude/skills/zotero-skills/SKILL.md 2>/dev/null  # if zotero-skills skill installed
 ```
 


### PR DESCRIPTION
## Summary
Four high-priority findings from a 4-agent research-hub audit. Doc-only PR; no code or test changes. Mirror under `src/research_hub/skills_data/` kept in sync.

### 1. `research-hub --version` ghost flag (3 sites)
The CLI had no `--version` flag in v0.81.0 (argparse errors with `unrecognized arguments`). Three SKILL.md files used it as the prerequisite gate, so every Claude session that touched these skills got a phantom "CLI not installed" message and bailed. Replace with `research-hub doctor` (exits 0 + prints health report on a healthy install).

- `skills/research-hub/SKILL.md:16`
- `skills/research-hub-multi-ai/SKILL.md:31`
- `skills/zotero-library-curator/SKILL.md:33`

### 2. `paper-memory-builder` ↔ `paper-summarize` trigger collision
Both fired on "summarize my paper" but cover orthogonal jobs:
- `paper-memory-builder` = the user's OWN draft → `.paper/claims.yml`
- `paper-summarize` = cited papers in a CLUSTER → Obsidian + Zotero per-paper notes

Add explicit "NOT for X — see Y" disambiguation to each frontmatter description. Also tighten `paper-summarize`'s lead trigger phrase from "summarize this cluster's papers" to "fill the TODO Key Findings/Methodology blocks left by `research-hub auto`" so it stops competing with `research-hub notebooklm generate` for cluster-level brief requests.

### 3. `research-hub` umbrella ↔ `zotero-library-curator` collision
`research-hub` description had "organize references" which competed with curator's audit/cleanup territory. Drop that phrase, replace "Zotero/Obsidian/NotebookLM organization" with "source ingest into Zotero/Obsidian/NotebookLM", and add a "NOT for auditing existing Zotero library — see `zotero-library-curator` + `zotero-skills`" line.

### 4. `experiment_matrix.yml` schema doc misalignment
`docs/research-workspace-manifest.md` said `hypothesis` was required and status enum was `{planned|running|complete|abandoned}`, but the actual writer (`research-context-compressor`) emits verification-style rows without `hypothesis` and with status values `{pass|caveat|pending|not_yet|fail}`. Pick option (b) update doc to match reality (option (a) update writer was higher risk). Schema block now:
- `hypothesis` demoted from required to optional with one-line note.
- `status` enum broadened to include both experiment and verification vocabularies; readers should treat unknown values as informational.
- `tier` / `artifacts` / `last_run` added as documented optional fields.
- Example shows both hypothesis-driven and verification-style rows.

Companion fix: `research-project-orienter/SKILL.md:79` template used `<hypothesis (one line)>` as if `hypothesis` was always present. Change to `<hypothesis or method, one line; "(no hypothesis)" if both absent>`.

## Test plan
- [x] `python -m pytest -q tests/test_v069_summarize.py tests/test_v073_parallel_summarize.py tests/test_v080_resummarize.py` → 23 passed (doc-only changes; sanity check).
- [x] `python -m research_hub --version` → errors with argparse `unrecognized arguments` (proves the phantom flag is real).
- [x] `python -m research_hub doctor` → emits multi-line health report (proves the replacement works).
- [x] All 6 source SKILL.md frontmatter descriptions ≤ 1024 chars (longest: paper-summarize 672 chars).
- [ ] CI matrix runs on push (research-hub repo already has its own).

## Side discovery (not in scope)
`gpt-5.5` works correctly on `codex-cli 0.128.0`. End-to-end test from `/tmp/codex55-test`:
```
codex exec --sandbox workspace-write -m gpt-5.5 "Just print HELLO_55 and stop." </dev/null
→ HELLO_55 (tokens used: 6,498)
```
The original `gpt-5.5` caveat from `codex-cli 0.121.0` is now fully resolved upstream. We do NOT switch the wrapper default in this PR — model upgrade is a separate decision deserving its own validation.

## Out of scope (deferred for future sessions)
- Lean refactor of `zotero-skills` (308 lines) and `research-design-helper` (189 lines).
- `project_manifest.yml` field-rename reconciliation (`data_sources`→`datasets`, etc.).
- Promote v0.7x+ undocumented CLI features (`fit-check`, `discover`, `synthesize`, `compose-draft`, etc.) into SKILL.md.
- Switch wrappers default to `gpt-5.5` (possible now but separate decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)