### PR TITLE
lean refactor wave 2: 4 NEEDS-WORK skills (single bloated section each)

### DIFF
--- a/skills/notebooklm-brief-verifier/SKILL.md
+++ b/skills/notebooklm-brief-verifier/SKILL.md
@@ -91,48 +91,11 @@ If the user names a brief file directly, prefer that path over guessing.
 
 ## Output
 
-In-conversation report (no file written by default). Structure:
+In-conversation report (no file written by default). The report has 7 sections: source coverage, unsupported claims, cross-source contradictions, potential overgeneralizations, spot-checked claims, recommended follow-up NotebookLM prompts, and verdict (reliable for / use with caution for / do not cite without spot-check).
 
-```
-## NotebookLM brief verification report
+Full template + worked example: `references/report-template.md`.
 
-**Brief**: <path>
-**Bundle**: <cluster_slug> (<N> sources)
-
-### Source coverage
-- Cited in brief: <X> / <N>
-- Missed sources: <list of citation keys not mentioned>
-
-### Unsupported claims
-- "<claim text>" (line <N> of brief) — no clear source attribution
-- ...
-
-### Cross-source contradictions
-- "<claim A>" (cites Smith 2024) vs "<claim B>" (cites Jones 2023) —
-  appear to contradict; brief does not flag this
-- ...
-
-### Potential overgeneralizations
-- "Studies show..." — actually one paper, Smith 2024
-- ...
-
-### Spot-checked claims
-- "<load-bearing claim>" — reviewed Smith 2024 §3, **supported**
-- "<surprising claim>" — reviewed Jones 2023 abstract, **partially
-  supported** (specific to coastal basins, not generalizable)
-
-### Recommended follow-up NotebookLM prompts
-- "What does Smith 2024 say about <X> specifically? Cite directly."
-- "Compare Smith 2024's claim about <Y> with Jones 2023's findings."
-
-### Verdict
-- Reliable for: <broad takeaways, comparison framing>
-- Use with caution for: <specific numbers, generalizations>
-- Do not cite without spot-check: <list>
-```
-
-If the brief is well-attributed and bundle coverage is complete, the
-report is short — that's a feature, not a bug.
+If the brief is well-attributed and bundle coverage is complete, the report is short — that's a feature, not a bug.
 
 ## Token-saving behavior
 
@@ -153,3 +116,7 @@ report is short — that's a feature, not a bug.
   the actual source bundle.
 - Don't tell the user to ignore NLM. Tell them which parts to trust and
   which to spot-check.
+
+## See also
+
+- `references/report-template.md` — full 7-section verification report template

--- a/skills/notebooklm-brief-verifier/references/report-template.md
+++ b/skills/notebooklm-brief-verifier/references/report-template.md
@@ -1,0 +1,39 @@
+# NotebookLM brief verification report template
+
+In-conversation report. The skill writes this to chat (no file by default). If the brief is well-attributed and bundle coverage is complete, the report is short — that's a feature, not a bug.
+
+```
+## NotebookLM brief verification report
+
+**Brief**: <path>
+**Bundle**: <cluster_slug> (<N> sources)
+
+### Source coverage
+- Cited in brief: <X> / <N>
+- Missed sources: <list of citation keys not mentioned>
+
+### Unsupported claims
+- "<claim text>" (line <N> of brief) — no clear source attribution
+- ...
+
+### Cross-source contradictions
+- "<claim A>" (cites Smith 2024) vs "<claim B>" (cites Jones 2023) — appear to contradict; brief does not flag this
+- ...
+
+### Potential overgeneralizations
+- "Studies show..." — actually one paper, Smith 2024
+- ...
+
+### Spot-checked claims
+- "<load-bearing claim>" — reviewed Smith 2024 §3, **supported**
+- "<surprising claim>" — reviewed Jones 2023 abstract, **partially supported** (specific to coastal basins, not generalizable)
+
+### Recommended follow-up NotebookLM prompts
+- "What does Smith 2024 say about <X> specifically? Cite directly."
+- "Compare Smith 2024's claim about <Y> with Jones 2023's findings."
+
+### Verdict
+- Reliable for: <broad takeaways, comparison framing>
+- Use with caution for: <specific numbers, generalizations>
+- Do not cite without spot-check: <list>
+```

--- a/skills/paper-memory-builder/SKILL.md
+++ b/skills/paper-memory-builder/SKILL.md
@@ -52,73 +52,11 @@ In priority order:
 
 Write to `<project-root>/.paper/`:
 
-- `claims.yml` — every paper-level claim, with evidence pointers + status.
-- `figures.yml` — every figure inventory, with key numbers + supported
-  claims.
-- `revision_history.yml` — append-only log of revision rounds (when a
-  claim or figure changed, in which round, why). See
-  `references/revision_history_schema.md` for the schema and the
-  append-vs-overwrite rules.
+- `claims.yml` — every paper-level claim, with evidence pointers + status. Schema: `references/yaml-schemas.md`.
+- `figures.yml` — every figure inventory, with key numbers + supported claims. Schema: `references/yaml-schemas.md`.
+- `revision_history.yml` — append-only log of revision rounds. Schema + append-vs-overwrite rules: `references/revision_history_schema.md`.
 
-Do **not** touch `journal_format.md`, `reviewer_comments.md`, or
-`style_overrides.md` — those belong to `academic-writing-skills`.
-
-### `.paper/claims.yml` structure
-
-```yaml
-claims:
-  - id: C1
-    text: "Coupled ABM-CAT reduces flood-impact RMSE by 22%."
-    evidence_artifacts:
-      - "outputs/E2/calibration.csv"
-      - "outputs/E2/figure3.png"
-    figure_or_table: ["Fig3"]
-    status: "draft"          # draft | supported | rejected
-    risk: "Reviewer R2 may push back on calibration window."
-    sentence_in_manuscript: "...we observe a 22% reduction in RMSE..."
-```
-
-Required per claim: `id`, `text`, `status`. Numbering: `C1, C2, ...`
-contiguous; if you regenerate, preserve human-assigned IDs.
-
-### `.paper/figures.yml` structure
-
-```yaml
-figures:
-  - id: "Fig1"
-    file: "outputs/figures/Fig1_study_area.png"
-    panels: ["a) site map", "b) gauge locations"]
-    key_numbers: ["12 gauges", "1985-2024 record length"]
-    supports_claims: []
-    caption_in_manuscript: "Figure 1. Study area..."
-```
-
-Required per figure: `id`, `file`, `supports_claims` (may be `[]`).
-
-### `.paper/revision_history.yml` structure
-
-```yaml
-revisions:
-  - round: 1
-    date: "2026-04-15"
-    trigger: "Initial draft v1"
-    changed_claims: []          # all claims new
-    changed_figures: []
-    summary: "First complete draft."
-  - round: 2
-    date: "2026-05-02"
-    trigger: "Reviewer 2 round 1: doubt on calibration window"
-    changed_claims: ["C1", "C4"]
-    changed_figures: ["Fig3"]
-    summary: "Tightened calibration window claim, added robustness check (Fig S3), softened C4 claim wording."
-```
-
-Required per revision: `round`, `date`, `trigger`, `summary`.
-`changed_claims` and `changed_figures` may be `[]` for fresh drafts.
-
-**Append, do not overwrite.** Each new revision round appends a new
-list entry. Past rounds stay verbatim — they're the audit trail. The
-full schema is in `references/revision_history_schema.md`.
+Do **not** touch `journal_format.md`, `reviewer_comments.md`, or `style_overrides.md` — those belong to `academic-writing-skills`.
 
 ## Token-saving behavior
 
@@ -152,3 +90,8 @@ full schema is in `references/revision_history_schema.md`.
 - Don't write to `.research/` — that's the workspace layer, not the
   paper layer.
 - Don't extract claims from cited works — only from THIS paper.
+
+## See also
+
+- `references/yaml-schemas.md` — `.paper/claims.yml` and `.paper/figures.yml` schemas
+- `references/revision_history_schema.md` — `.paper/revision_history.yml` schema + append-only audit-trail rules

--- a/skills/paper-memory-builder/references/yaml-schemas.md
+++ b/skills/paper-memory-builder/references/yaml-schemas.md
@@ -1,0 +1,40 @@
+# `.paper/` YAML schemas
+
+Schemas for the two main outputs of `paper-memory-builder`. The third file (`revision_history.yml`) has its own dedicated schema doc at `revision_history_schema.md` because of the append-only audit-trail rules.
+
+## `.paper/claims.yml`
+
+```yaml
+claims:
+  - id: C1
+    text: "Coupled ABM-CAT reduces flood-impact RMSE by 22%."
+    evidence_artifacts:
+      - "outputs/E2/calibration.csv"
+      - "outputs/E2/figure3.png"
+    figure_or_table: ["Fig3"]
+    status: "draft"          # draft | supported | rejected
+    risk: "Reviewer R2 may push back on calibration window."
+    sentence_in_manuscript: "...we observe a 22% reduction in RMSE..."
+```
+
+**Required per claim:** `id`, `text`, `status`.
+
+**Numbering:** `C1, C2, ...` contiguous. If you regenerate, preserve human-assigned IDs — claim numbers are referenced by other tooling (`academic-writing-skills` pulls them by id).
+
+## `.paper/figures.yml`
+
+```yaml
+figures:
+  - id: "Fig1"
+    file: "outputs/figures/Fig1_study_area.png"
+    panels: ["a) site map", "b) gauge locations"]
+    key_numbers: ["12 gauges", "1985-2024 record length"]
+    supports_claims: []
+    caption_in_manuscript: "Figure 1. Study area..."
+```
+
+**Required per figure:** `id`, `file`, `supports_claims` (may be `[]`).
+
+## See also
+
+- `revision_history_schema.md` — schema + append-only rules for `revision_history.yml`.

--- a/skills/research-context-compressor/SKILL.md
+++ b/skills/research-context-compressor/SKILL.md
@@ -64,31 +64,7 @@ empty (see "What NOT to do"). Skim, do not deep-read.
 
 **An empty manifest field is better than an invented one.**
 
-### Example: humanities project with minimal scaffold
-
-A literature-review project with just `README.md` + `notes/` + a few
-draft markdown files will produce a manifest like:
-
-```yaml
-project_name: "late-ming-print-culture"
-research_area: "history of book publishing"
-research_question: ""             # left empty — README didn't state one
-current_stage: "discovery"
-primary_tools: []                 # no code project
-key_repositories: []
-data_sources: []                  # no data/ directory, intentional
-model_components: []
-main_entrypoints: []               # no scripts/ either
-important_outputs:                 # populated from notes/ + drafts/
-  - "notes/01-survey.md"
-  - "notes/02-method.md"
-  - "drafts/intro-v1.md"
-paper_or_deliverable: ""
-last_updated: "2026-04-26"
-```
-
-Empty fields are honest signals to the next AI session that this is
-a non-code project. They are not failures.
+For a worked humanities-project example with minimal scaffold (README + notes/ only, no code, no data/), see `references/example-humanities-project.md`. It illustrates the "empty fields are honest" rule.
 
 ## Outputs you must produce
 
@@ -155,3 +131,7 @@ After writing the files, print a 5-line summary:
   `.research/open_questions.md` instead.
 - Don't overclaim: if the project has no clear research question yet, leave
   `research_question` empty and add a question to `open_questions.md`.
+
+## See also
+
+- `references/example-humanities-project.md` — worked example for a non-code research project (minimal scaffold)

--- a/skills/research-context-compressor/references/example-humanities-project.md
+++ b/skills/research-context-compressor/references/example-humanities-project.md
@@ -1,0 +1,23 @@
+# Example: humanities project with minimal scaffold
+
+A literature-review project with just `README.md` + `notes/` + a few draft markdown files will produce a manifest like:
+
+```yaml
+project_name: "late-ming-print-culture"
+research_area: "history of book publishing"
+research_question: ""             # left empty — README didn't state one
+current_stage: "discovery"
+primary_tools: []                 # no code project
+key_repositories: []
+data_sources: []                  # no data/ directory, intentional
+model_components: []
+main_entrypoints: []              # no scripts/ either
+important_outputs:                # populated from notes/ + drafts/
+  - "notes/01-survey.md"
+  - "notes/02-method.md"
+  - "drafts/intro-v1.md"
+paper_or_deliverable: ""
+last_updated: "2026-04-26"
+```
+
+Empty fields are honest signals to the next AI session that this is a non-code project. They are not failures.

--- a/skills/zotero-library-curator/SKILL.md
+++ b/skills/zotero-library-curator/SKILL.md
@@ -85,82 +85,15 @@ In priority order:
 
 ## Audit checks
 
-For each request, pick the relevant subset:
+Five checks: duplicate DOI scan, orphan-tag scan, cross-collection cluster mismatch, tag hygiene report, collection bloat / sparsity. Pick the relevant subset for each user request.
 
-### Duplicate DOI scan
-
-- Group items by normalized DOI.
-- Report any DOI with > 1 Zotero item.
-- For each duplicate group, suggest which item to keep (the one with
-  more notes / tags / attachments) and which to merge or trash.
-
-### Orphan-tag scan
-
-For each item in a research-hub cluster:
-
-- Required tags (post v0.61): `research-hub`, `cluster/<slug>`,
-  optionally `category/<arxiv-cat>`, `type/<doc-type>`, `src/<backend>`.
-- Report items missing `research-hub` or `cluster/<slug>`.
-- Suggested fix: `research-hub zotero backfill --tags`.
-
-### Cross-collection cluster mismatch
-
-- For each item, compare `cluster/<slug>` tag vs Zotero collection
-  membership.
-- Report items whose tag and collection disagree.
-- Suggested fix: `research-hub clusters rebind --emit` then
-  `--apply`.
-
-### Tag hygiene report
-
-- Top 50 most-used tags + count.
-- Tags used < 3 times (potential typos).
-- Tags that look like near-duplicates (e.g. `agent-based-modelling` vs
-  `agent-based-modeling`).
-- Suggested fix: human review + manual rename via Zotero desktop or
-  `zotero-skills` batch update.
-
-### Collection bloat / sparsity
-
-- Collections with > 200 items (consider splitting).
-- Collections with < 3 items (consider merging or deleting).
-- Empty collections.
+Full check details + suggested fixes for each: `references/audit-checks.md`.
 
 ## Output discipline
 
-Always emit a **preview plan**, never apply. Structure:
+Always emit a **preview plan**, never apply. The report has 5 sections that map 1:1 onto the audit checks (skip a section if its check returned no findings) plus a "Suggested follow-ups" section listing concrete CLI commands for the user to run.
 
-```
-## Zotero curation report (read-only)
-
-**Library**: <library_id>  ·  **Items audited**: <N>
-
-### Duplicate DOIs (<count>)
-- 10.1234/abcd: 2 items (KEEP item ABC123, MERGE/TRASH XYZ456)
-- ...
-
-### Items missing required tags (<count>)
-- KEY1: missing [research-hub, cluster/foo]
-- ...
-
-### Cluster/collection mismatches (<count>)
-- KEY7: tagged cluster/foo but in collection bar
-- ...
-
-### Tag hygiene
-- Near-duplicate tag candidates: agent-based-modeling (47) vs agent-based-modelling (3)
-- Tags used once: ['hopf', 'sufficient', ...] (potential typos)
-
-### Collection bloat
-- "survey" collection has 237 items — consider splitting
-- "benchmarking" has 8 items — consider merging
-
-### Suggested follow-ups
-1. Run `research-hub zotero backfill --tags --notes` to fix the 12 missing-tag items
-2. Run `research-hub clusters rebind --emit` to review the 3 mismatches
-3. Manually rename the 2 tag near-duplicates in Zotero desktop
-4. Defer the bloat/sparsity questions to a human review session
-```
+Full report template: `references/report-template.md`.
 
 If the report has 0 issues, emit a single OK line and stop.
 
@@ -184,3 +117,8 @@ If the report has 0 issues, emit a single OK line and stop.
   to `research-hub zotero backfill --apply` or manual delete.
 - **Do NOT** redocument the zotero-skills CRUD primitives — link to
   them. The whole point of this skill is to be the **layer above**.
+
+## See also
+
+- `references/audit-checks.md` — full details for each of the 5 audit checks
+- `references/report-template.md` — full curation-report preview template

--- a/skills/zotero-library-curator/references/audit-checks.md
+++ b/skills/zotero-library-curator/references/audit-checks.md
@@ -1,0 +1,36 @@
+# Audit checks
+
+For each request, pick the relevant subset.
+
+## Duplicate DOI scan
+
+- Group items by normalized DOI.
+- Report any DOI with > 1 Zotero item.
+- For each duplicate group, suggest which item to keep (the one with more notes / tags / attachments) and which to merge or trash.
+
+## Orphan-tag scan
+
+For each item in a research-hub cluster:
+
+- Required tags (post v0.61): `research-hub`, `cluster/<slug>`, optionally `category/<arxiv-cat>`, `type/<doc-type>`, `src/<backend>`.
+- Report items missing `research-hub` or `cluster/<slug>`.
+- Suggested fix: `research-hub zotero backfill --tags`.
+
+## Cross-collection cluster mismatch
+
+- For each item, compare `cluster/<slug>` tag vs Zotero collection membership.
+- Report items whose tag and collection disagree.
+- Suggested fix: `research-hub clusters rebind --emit` then `--apply`.
+
+## Tag hygiene report
+
+- Top 50 most-used tags + count.
+- Tags used < 3 times (potential typos).
+- Tags that look like near-duplicates (e.g. `agent-based-modelling` vs `agent-based-modeling`).
+- Suggested fix: human review + manual rename via Zotero desktop or `zotero-skills` batch update.
+
+## Collection bloat / sparsity
+
+- Collections with > 200 items (consider splitting).
+- Collections with < 3 items (consider merging or deleting).
+- Empty collections.

--- a/skills/zotero-library-curator/references/report-template.md
+++ b/skills/zotero-library-curator/references/report-template.md
@@ -1,0 +1,37 @@
+# Zotero curation report template
+
+The skill always emits a **preview plan**, never applies. If the report has 0 issues, emit a single OK line and stop instead of using this template.
+
+```
+## Zotero curation report (read-only)
+
+**Library**: <library_id>  ·  **Items audited**: <N>
+
+### Duplicate DOIs (<count>)
+- 10.1234/abcd: 2 items (KEEP item ABC123, MERGE/TRASH XYZ456)
+- ...
+
+### Items missing required tags (<count>)
+- KEY1: missing [research-hub, cluster/foo]
+- ...
+
+### Cluster/collection mismatches (<count>)
+- KEY7: tagged cluster/foo but in collection bar
+- ...
+
+### Tag hygiene
+- Near-duplicate tag candidates: agent-based-modeling (47) vs agent-based-modelling (3)
+- Tags used once: ['hopf', 'sufficient', ...] (potential typos)
+
+### Collection bloat
+- "survey" collection has 237 items — consider splitting
+- "benchmarking" has 8 items — consider merging
+
+### Suggested follow-ups
+1. Run `research-hub zotero backfill --tags --notes` to fix the 12 missing-tag items
+2. Run `research-hub clusters rebind --emit` to review the 3 mismatches
+3. Manually rename the 2 tag near-duplicates in Zotero desktop
+4. Defer the bloat/sparsity questions to a human review session
+```
+
+The five report sections map 1:1 onto the five audit checks in `audit-checks.md`. Skip a section entirely if its check returned no findings.

--- a/src/research_hub/skills_data/notebooklm-brief-verifier/SKILL.md
+++ b/src/research_hub/skills_data/notebooklm-brief-verifier/SKILL.md
@@ -91,48 +91,11 @@ If the user names a brief file directly, prefer that path over guessing.
 
 ## Output
 
-In-conversation report (no file written by default). Structure:
+In-conversation report (no file written by default). The report has 7 sections: source coverage, unsupported claims, cross-source contradictions, potential overgeneralizations, spot-checked claims, recommended follow-up NotebookLM prompts, and verdict (reliable for / use with caution for / do not cite without spot-check).
 
-```
-## NotebookLM brief verification report
+Full template + worked example: `references/report-template.md`.
 
-**Brief**: <path>
-**Bundle**: <cluster_slug> (<N> sources)
-
-### Source coverage
-- Cited in brief: <X> / <N>
-- Missed sources: <list of citation keys not mentioned>
-
-### Unsupported claims
-- "<claim text>" (line <N> of brief) — no clear source attribution
-- ...
-
-### Cross-source contradictions
-- "<claim A>" (cites Smith 2024) vs "<claim B>" (cites Jones 2023) —
-  appear to contradict; brief does not flag this
-- ...
-
-### Potential overgeneralizations
-- "Studies show..." — actually one paper, Smith 2024
-- ...
-
-### Spot-checked claims
-- "<load-bearing claim>" — reviewed Smith 2024 §3, **supported**
-- "<surprising claim>" — reviewed Jones 2023 abstract, **partially
-  supported** (specific to coastal basins, not generalizable)
-
-### Recommended follow-up NotebookLM prompts
-- "What does Smith 2024 say about <X> specifically? Cite directly."
-- "Compare Smith 2024's claim about <Y> with Jones 2023's findings."
-
-### Verdict
-- Reliable for: <broad takeaways, comparison framing>
-- Use with caution for: <specific numbers, generalizations>
-- Do not cite without spot-check: <list>
-```
-
-If the brief is well-attributed and bundle coverage is complete, the
-report is short — that's a feature, not a bug.
+If the brief is well-attributed and bundle coverage is complete, the report is short — that's a feature, not a bug.
 
 ## Token-saving behavior
 
@@ -153,3 +116,7 @@ report is short — that's a feature, not a bug.
   the actual source bundle.
 - Don't tell the user to ignore NLM. Tell them which parts to trust and
   which to spot-check.
+
+## See also
+
+- `references/report-template.md` — full 7-section verification report template

--- a/src/research_hub/skills_data/notebooklm-brief-verifier/references/report-template.md
+++ b/src/research_hub/skills_data/notebooklm-brief-verifier/references/report-template.md
@@ -1,0 +1,39 @@
+# NotebookLM brief verification report template
+
+In-conversation report. The skill writes this to chat (no file by default). If the brief is well-attributed and bundle coverage is complete, the report is short — that's a feature, not a bug.
+
+```
+## NotebookLM brief verification report
+
+**Brief**: <path>
+**Bundle**: <cluster_slug> (<N> sources)
+
+### Source coverage
+- Cited in brief: <X> / <N>
+- Missed sources: <list of citation keys not mentioned>
+
+### Unsupported claims
+- "<claim text>" (line <N> of brief) — no clear source attribution
+- ...
+
+### Cross-source contradictions
+- "<claim A>" (cites Smith 2024) vs "<claim B>" (cites Jones 2023) — appear to contradict; brief does not flag this
+- ...
+
+### Potential overgeneralizations
+- "Studies show..." — actually one paper, Smith 2024
+- ...
+
+### Spot-checked claims
+- "<load-bearing claim>" — reviewed Smith 2024 §3, **supported**
+- "<surprising claim>" — reviewed Jones 2023 abstract, **partially supported** (specific to coastal basins, not generalizable)
+
+### Recommended follow-up NotebookLM prompts
+- "What does Smith 2024 say about <X> specifically? Cite directly."
+- "Compare Smith 2024's claim about <Y> with Jones 2023's findings."
+
+### Verdict
+- Reliable for: <broad takeaways, comparison framing>
+- Use with caution for: <specific numbers, generalizations>
+- Do not cite without spot-check: <list>
+```

--- a/src/research_hub/skills_data/paper-memory-builder/SKILL.md
+++ b/src/research_hub/skills_data/paper-memory-builder/SKILL.md
@@ -52,73 +52,11 @@ In priority order:
 
 Write to `<project-root>/.paper/`:
 
-- `claims.yml` — every paper-level claim, with evidence pointers + status.
-- `figures.yml` — every figure inventory, with key numbers + supported
-  claims.
-- `revision_history.yml` — append-only log of revision rounds (when a
-  claim or figure changed, in which round, why). See
-  `references/revision_history_schema.md` for the schema and the
-  append-vs-overwrite rules.
+- `claims.yml` — every paper-level claim, with evidence pointers + status. Schema: `references/yaml-schemas.md`.
+- `figures.yml` — every figure inventory, with key numbers + supported claims. Schema: `references/yaml-schemas.md`.
+- `revision_history.yml` — append-only log of revision rounds. Schema + append-vs-overwrite rules: `references/revision_history_schema.md`.
 
-Do **not** touch `journal_format.md`, `reviewer_comments.md`, or
-`style_overrides.md` — those belong to `academic-writing-skills`.
-
-### `.paper/claims.yml` structure
-
-```yaml
-claims:
-  - id: C1
-    text: "Coupled ABM-CAT reduces flood-impact RMSE by 22%."
-    evidence_artifacts:
-      - "outputs/E2/calibration.csv"
-      - "outputs/E2/figure3.png"
-    figure_or_table: ["Fig3"]
-    status: "draft"          # draft | supported | rejected
-    risk: "Reviewer R2 may push back on calibration window."
-    sentence_in_manuscript: "...we observe a 22% reduction in RMSE..."
-```
-
-Required per claim: `id`, `text`, `status`. Numbering: `C1, C2, ...`
-contiguous; if you regenerate, preserve human-assigned IDs.
-
-### `.paper/figures.yml` structure
-
-```yaml
-figures:
-  - id: "Fig1"
-    file: "outputs/figures/Fig1_study_area.png"
-    panels: ["a) site map", "b) gauge locations"]
-    key_numbers: ["12 gauges", "1985-2024 record length"]
-    supports_claims: []
-    caption_in_manuscript: "Figure 1. Study area..."
-```
-
-Required per figure: `id`, `file`, `supports_claims` (may be `[]`).
-
-### `.paper/revision_history.yml` structure
-
-```yaml
-revisions:
-  - round: 1
-    date: "2026-04-15"
-    trigger: "Initial draft v1"
-    changed_claims: []          # all claims new
-    changed_figures: []
-    summary: "First complete draft."
-  - round: 2
-    date: "2026-05-02"
-    trigger: "Reviewer 2 round 1: doubt on calibration window"
-    changed_claims: ["C1", "C4"]
-    changed_figures: ["Fig3"]
-    summary: "Tightened calibration window claim, added robustness check (Fig S3), softened C4 claim wording."
-```
-
-Required per revision: `round`, `date`, `trigger`, `summary`.
-`changed_claims` and `changed_figures` may be `[]` for fresh drafts.
-
-**Append, do not overwrite.** Each new revision round appends a new
-list entry. Past rounds stay verbatim — they're the audit trail. The
-full schema is in `references/revision_history_schema.md`.
+Do **not** touch `journal_format.md`, `reviewer_comments.md`, or `style_overrides.md` — those belong to `academic-writing-skills`.
 
 ## Token-saving behavior
 
@@ -152,3 +90,8 @@ full schema is in `references/revision_history_schema.md`.
 - Don't write to `.research/` — that's the workspace layer, not the
   paper layer.
 - Don't extract claims from cited works — only from THIS paper.
+
+## See also
+
+- `references/yaml-schemas.md` — `.paper/claims.yml` and `.paper/figures.yml` schemas
+- `references/revision_history_schema.md` — `.paper/revision_history.yml` schema + append-only audit-trail rules

--- a/src/research_hub/skills_data/paper-memory-builder/references/revision_history_schema.md
+++ b/src/research_hub/skills_data/paper-memory-builder/references/revision_history_schema.md
@@ -1,0 +1,114 @@
+# `.paper/revision_history.yml` — schema and rules
+
+## Why this file exists
+
+`.paper/claims.yml` and `.paper/figures.yml` are point-in-time
+snapshots of the manuscript's claim layer. After 3-6 revision rounds
+(reviewer 1 round 1, advisor comments round 1, reviewer 2 round 1,
+revision-and-resubmit, etc.) you lose the history of what changed
+when. `revision_history.yml` is the audit trail.
+
+## Schema
+
+```yaml
+revisions:
+  - round: <int, 1-indexed, monotonically increasing>
+    date: "<YYYY-MM-DD>"
+    trigger: "<one line: what triggered this round>"
+    changed_claims: ["<C-id>", ...]      # IDs from claims.yml; [] if fresh draft
+    changed_figures: ["<Fig-id>", ...]   # IDs from figures.yml; [] if no figure change
+    summary: "<one paragraph: substantive changes in this round>"
+    # Optional fields:
+    reviewer: "<Reviewer 2 round 1 / Advisor / Self-edit / Copyediting>"
+    sections_touched: ["Methods 2.3", "Results 3.1", "Fig 3 caption"]
+```
+
+### Required fields per revision entry
+
+- `round` — integer, starts at 1, increments by 1 per revision round.
+- `date` — ISO 8601 date.
+- `trigger` — one short line. Examples: `"Initial draft v1"`,
+  `"Reviewer 2 round 1: calibration window critique"`,
+  `"Advisor comments before submission"`.
+- `summary` — one paragraph in plain prose describing the
+  substantive changes. Not a diff; a human-readable digest.
+
+### Optional fields
+
+- `changed_claims` / `changed_figures` — IDs from `claims.yml` /
+  `figures.yml`. `[]` is valid for the first round (everything is
+  new) or rounds that only touch prose (no claim/figure changes).
+- `reviewer` — categorize source of comments.
+- `sections_touched` — which manuscript sections / figure captions
+  saw edits.
+
+## Rules
+
+### Append, never overwrite
+
+Past rounds are the audit trail. Each new round is a new list entry.
+Editing or deleting a past entry should require an explicit
+`# manually edited 2026-MM-DD by <name> because <reason>` comment
+right above the change.
+
+### Round numbering is paper-scoped, not journal-scoped
+
+If you submit to journal A, get rejected, then submit to journal B —
+keep numbering continuous across journals. The history reflects the
+manuscript's life, not the submission outcome.
+
+### When to create vs append
+
+- **Create the file** the first time `paper-memory-builder` runs on
+  this manuscript. Round 1 = initial draft.
+- **Append a new round** every time the trigger is "we are reacting
+  to feedback" — reviewer comments, advisor comments, copyediting
+  back from the journal.
+- **Don't append** for routine paper-memory-builder reruns where you
+  only refresh `claims.yml` from a slightly tweaked manuscript.
+  Save those for actual revision rounds.
+
+### Sync with `claims.yml` / `figures.yml`
+
+When `revision_history.yml` references a claim ID like `C4`, that ID
+must exist in `claims.yml` (current snapshot). If you delete a claim
+in a later round, keep the historical reference and add a status
+field `dropped` to the corresponding entry in `claims.yml`. Don't
+silently delete IDs.
+
+## Example: 3-round revision
+
+```yaml
+revisions:
+  - round: 1
+    date: "2026-04-15"
+    trigger: "Initial draft v1"
+    changed_claims: []
+    changed_figures: []
+    summary: "First complete draft. 9 claims, 8 main figures."
+  - round: 2
+    date: "2026-05-02"
+    trigger: "Advisor comments before submission"
+    changed_claims: ["C2", "C7"]
+    changed_figures: ["Fig5"]
+    reviewer: "Advisor"
+    sections_touched: ["Introduction", "Discussion 5.2", "Fig 5 caption"]
+    summary: "Sharpened C2 to specify the calibration window. Removed C7 (advisor said it was implicit in C5). Reworked Fig 5 caption to match prose."
+  - round: 3
+    date: "2026-06-18"
+    trigger: "Reviewer 2 round 1: pushback on ABM-CAT calibration window"
+    changed_claims: ["C1", "C4"]
+    changed_figures: ["Fig3"]
+    reviewer: "Reviewer 2 round 1"
+    sections_touched: ["Methods 2.3", "Results 3.1", "Supplementary S3"]
+    summary: "Added robustness check Fig S3 covering 1990-2024 window per Reviewer 2 R1. Softened C4 wording from 'demonstrates' to 'is consistent with'. Updated C1 RMSE number to reflect re-fit on extended window."
+```
+
+## What this enables
+
+Once `revision_history.yml` exists, `academic-writing-skills` can
+answer questions like:
+- "What changed since the last submission?"
+- "Did I address Reviewer 2 round 1's calibration concern?"
+- "Which figures have been touched in the last 2 rounds?"
+without re-reading the entire manuscript history.

--- a/src/research_hub/skills_data/paper-memory-builder/references/yaml-schemas.md
+++ b/src/research_hub/skills_data/paper-memory-builder/references/yaml-schemas.md
@@ -1,0 +1,40 @@
+# `.paper/` YAML schemas
+
+Schemas for the two main outputs of `paper-memory-builder`. The third file (`revision_history.yml`) has its own dedicated schema doc at `revision_history_schema.md` because of the append-only audit-trail rules.
+
+## `.paper/claims.yml`
+
+```yaml
+claims:
+  - id: C1
+    text: "Coupled ABM-CAT reduces flood-impact RMSE by 22%."
+    evidence_artifacts:
+      - "outputs/E2/calibration.csv"
+      - "outputs/E2/figure3.png"
+    figure_or_table: ["Fig3"]
+    status: "draft"          # draft | supported | rejected
+    risk: "Reviewer R2 may push back on calibration window."
+    sentence_in_manuscript: "...we observe a 22% reduction in RMSE..."
+```
+
+**Required per claim:** `id`, `text`, `status`.
+
+**Numbering:** `C1, C2, ...` contiguous. If you regenerate, preserve human-assigned IDs — claim numbers are referenced by other tooling (`academic-writing-skills` pulls them by id).
+
+## `.paper/figures.yml`
+
+```yaml
+figures:
+  - id: "Fig1"
+    file: "outputs/figures/Fig1_study_area.png"
+    panels: ["a) site map", "b) gauge locations"]
+    key_numbers: ["12 gauges", "1985-2024 record length"]
+    supports_claims: []
+    caption_in_manuscript: "Figure 1. Study area..."
+```
+
+**Required per figure:** `id`, `file`, `supports_claims` (may be `[]`).
+
+## See also
+
+- `revision_history_schema.md` — schema + append-only rules for `revision_history.yml`.

--- a/src/research_hub/skills_data/research-context-compressor/SKILL.md
+++ b/src/research_hub/skills_data/research-context-compressor/SKILL.md
@@ -64,31 +64,7 @@ empty (see "What NOT to do"). Skim, do not deep-read.
 
 **An empty manifest field is better than an invented one.**
 
-### Example: humanities project with minimal scaffold
-
-A literature-review project with just `README.md` + `notes/` + a few
-draft markdown files will produce a manifest like:
-
-```yaml
-project_name: "late-ming-print-culture"
-research_area: "history of book publishing"
-research_question: ""             # left empty — README didn't state one
-current_stage: "discovery"
-primary_tools: []                 # no code project
-key_repositories: []
-data_sources: []                  # no data/ directory, intentional
-model_components: []
-main_entrypoints: []               # no scripts/ either
-important_outputs:                 # populated from notes/ + drafts/
-  - "notes/01-survey.md"
-  - "notes/02-method.md"
-  - "drafts/intro-v1.md"
-paper_or_deliverable: ""
-last_updated: "2026-04-26"
-```
-
-Empty fields are honest signals to the next AI session that this is
-a non-code project. They are not failures.
+For a worked humanities-project example with minimal scaffold (README + notes/ only, no code, no data/), see `references/example-humanities-project.md`. It illustrates the "empty fields are honest" rule.
 
 ## Outputs you must produce
 
@@ -155,3 +131,7 @@ After writing the files, print a 5-line summary:
   `.research/open_questions.md` instead.
 - Don't overclaim: if the project has no clear research question yet, leave
   `research_question` empty and add a question to `open_questions.md`.
+
+## See also
+
+- `references/example-humanities-project.md` — worked example for a non-code research project (minimal scaffold)

--- a/src/research_hub/skills_data/research-context-compressor/references/example-humanities-project.md
+++ b/src/research_hub/skills_data/research-context-compressor/references/example-humanities-project.md
@@ -1,0 +1,23 @@
+# Example: humanities project with minimal scaffold
+
+A literature-review project with just `README.md` + `notes/` + a few draft markdown files will produce a manifest like:
+
+```yaml
+project_name: "late-ming-print-culture"
+research_area: "history of book publishing"
+research_question: ""             # left empty — README didn't state one
+current_stage: "discovery"
+primary_tools: []                 # no code project
+key_repositories: []
+data_sources: []                  # no data/ directory, intentional
+model_components: []
+main_entrypoints: []              # no scripts/ either
+important_outputs:                # populated from notes/ + drafts/
+  - "notes/01-survey.md"
+  - "notes/02-method.md"
+  - "drafts/intro-v1.md"
+paper_or_deliverable: ""
+last_updated: "2026-04-26"
+```
+
+Empty fields are honest signals to the next AI session that this is a non-code project. They are not failures.

--- a/src/research_hub/skills_data/zotero-library-curator/SKILL.md
+++ b/src/research_hub/skills_data/zotero-library-curator/SKILL.md
@@ -85,82 +85,15 @@ In priority order:
 
 ## Audit checks
 
-For each request, pick the relevant subset:
+Five checks: duplicate DOI scan, orphan-tag scan, cross-collection cluster mismatch, tag hygiene report, collection bloat / sparsity. Pick the relevant subset for each user request.
 
-### Duplicate DOI scan
-
-- Group items by normalized DOI.
-- Report any DOI with > 1 Zotero item.
-- For each duplicate group, suggest which item to keep (the one with
-  more notes / tags / attachments) and which to merge or trash.
-
-### Orphan-tag scan
-
-For each item in a research-hub cluster:
-
-- Required tags (post v0.61): `research-hub`, `cluster/<slug>`,
-  optionally `category/<arxiv-cat>`, `type/<doc-type>`, `src/<backend>`.
-- Report items missing `research-hub` or `cluster/<slug>`.
-- Suggested fix: `research-hub zotero backfill --tags`.
-
-### Cross-collection cluster mismatch
-
-- For each item, compare `cluster/<slug>` tag vs Zotero collection
-  membership.
-- Report items whose tag and collection disagree.
-- Suggested fix: `research-hub clusters rebind --emit` then
-  `--apply`.
-
-### Tag hygiene report
-
-- Top 50 most-used tags + count.
-- Tags used < 3 times (potential typos).
-- Tags that look like near-duplicates (e.g. `agent-based-modelling` vs
-  `agent-based-modeling`).
-- Suggested fix: human review + manual rename via Zotero desktop or
-  `zotero-skills` batch update.
-
-### Collection bloat / sparsity
-
-- Collections with > 200 items (consider splitting).
-- Collections with < 3 items (consider merging or deleting).
-- Empty collections.
+Full check details + suggested fixes for each: `references/audit-checks.md`.
 
 ## Output discipline
 
-Always emit a **preview plan**, never apply. Structure:
+Always emit a **preview plan**, never apply. The report has 5 sections that map 1:1 onto the audit checks (skip a section if its check returned no findings) plus a "Suggested follow-ups" section listing concrete CLI commands for the user to run.
 
-```
-## Zotero curation report (read-only)
-
-**Library**: <library_id>  ·  **Items audited**: <N>
-
-### Duplicate DOIs (<count>)
-- 10.1234/abcd: 2 items (KEEP item ABC123, MERGE/TRASH XYZ456)
-- ...
-
-### Items missing required tags (<count>)
-- KEY1: missing [research-hub, cluster/foo]
-- ...
-
-### Cluster/collection mismatches (<count>)
-- KEY7: tagged cluster/foo but in collection bar
-- ...
-
-### Tag hygiene
-- Near-duplicate tag candidates: agent-based-modeling (47) vs agent-based-modelling (3)
-- Tags used once: ['hopf', 'sufficient', ...] (potential typos)
-
-### Collection bloat
-- "survey" collection has 237 items — consider splitting
-- "benchmarking" has 8 items — consider merging
-
-### Suggested follow-ups
-1. Run `research-hub zotero backfill --tags --notes` to fix the 12 missing-tag items
-2. Run `research-hub clusters rebind --emit` to review the 3 mismatches
-3. Manually rename the 2 tag near-duplicates in Zotero desktop
-4. Defer the bloat/sparsity questions to a human review session
-```
+Full report template: `references/report-template.md`.
 
 If the report has 0 issues, emit a single OK line and stop.
 
@@ -184,3 +117,8 @@ If the report has 0 issues, emit a single OK line and stop.
   to `research-hub zotero backfill --apply` or manual delete.
 - **Do NOT** redocument the zotero-skills CRUD primitives — link to
   them. The whole point of this skill is to be the **layer above**.
+
+## See also
+
+- `references/audit-checks.md` — full details for each of the 5 audit checks
+- `references/report-template.md` — full curation-report preview template

--- a/src/research_hub/skills_data/zotero-library-curator/references/audit-checks.md
+++ b/src/research_hub/skills_data/zotero-library-curator/references/audit-checks.md
@@ -1,0 +1,36 @@
+# Audit checks
+
+For each request, pick the relevant subset.
+
+## Duplicate DOI scan
+
+- Group items by normalized DOI.
+- Report any DOI with > 1 Zotero item.
+- For each duplicate group, suggest which item to keep (the one with more notes / tags / attachments) and which to merge or trash.
+
+## Orphan-tag scan
+
+For each item in a research-hub cluster:
+
+- Required tags (post v0.61): `research-hub`, `cluster/<slug>`, optionally `category/<arxiv-cat>`, `type/<doc-type>`, `src/<backend>`.
+- Report items missing `research-hub` or `cluster/<slug>`.
+- Suggested fix: `research-hub zotero backfill --tags`.
+
+## Cross-collection cluster mismatch
+
+- For each item, compare `cluster/<slug>` tag vs Zotero collection membership.
+- Report items whose tag and collection disagree.
+- Suggested fix: `research-hub clusters rebind --emit` then `--apply`.
+
+## Tag hygiene report
+
+- Top 50 most-used tags + count.
+- Tags used < 3 times (potential typos).
+- Tags that look like near-duplicates (e.g. `agent-based-modelling` vs `agent-based-modeling`).
+- Suggested fix: human review + manual rename via Zotero desktop or `zotero-skills` batch update.
+
+## Collection bloat / sparsity
+
+- Collections with > 200 items (consider splitting).
+- Collections with < 3 items (consider merging or deleting).
+- Empty collections.

--- a/src/research_hub/skills_data/zotero-library-curator/references/report-template.md
+++ b/src/research_hub/skills_data/zotero-library-curator/references/report-template.md
@@ -1,0 +1,37 @@
+# Zotero curation report template
+
+The skill always emits a **preview plan**, never applies. If the report has 0 issues, emit a single OK line and stop instead of using this template.
+
+```
+## Zotero curation report (read-only)
+
+**Library**: <library_id>  ·  **Items audited**: <N>
+
+### Duplicate DOIs (<count>)
+- 10.1234/abcd: 2 items (KEEP item ABC123, MERGE/TRASH XYZ456)
+- ...
+
+### Items missing required tags (<count>)
+- KEY1: missing [research-hub, cluster/foo]
+- ...
+
+### Cluster/collection mismatches (<count>)
+- KEY7: tagged cluster/foo but in collection bar
+- ...
+
+### Tag hygiene
+- Near-duplicate tag candidates: agent-based-modeling (47) vs agent-based-modelling (3)
+- Tags used once: ['hopf', 'sufficient', ...] (potential typos)
+
+### Collection bloat
+- "survey" collection has 237 items — consider splitting
+- "benchmarking" has 8 items — consider merging
+
+### Suggested follow-ups
+1. Run `research-hub zotero backfill --tags --notes` to fix the 12 missing-tag items
+2. Run `research-hub clusters rebind --emit` to review the 3 mismatches
+3. Manually rename the 2 tag near-duplicates in Zotero desktop
+4. Defer the bloat/sparsity questions to a human review session
+```
+
+The five report sections map 1:1 onto the five audit checks in `audit-checks.md`. Skip a section entirely if its check returned no findings.


### PR DESCRIPTION
## Summary
The 4-agent research-hub audit flagged these as NEEDS-WORK candidates: each has a single bloated section that fits the progressive-disclosure pattern already shipped for [codex-delegate](https://github.com/WenyuChiou/codex-delegate), [gemini-delegate-skill](https://github.com/WenyuChiou/gemini-delegate-skill), [zotero-skills](https://github.com/WenyuChiou/zotero-skills/pull/1), and [research-design-helper](https://github.com/WenyuChiou/research-hub/pull/33). This PR bundles all four single-section extractions.

| Skill | Before | After | Δ | What moved |
|---|---|---|---|---|
| `paper-memory-builder` | 154 | 97 | −37% | 3 yaml schemas → `references/yaml-schemas.md` (claims/figures) + reused existing `revision_history_schema.md` |
| `notebooklm-brief-verifier` | 155 | 122 | −21% | 7-section verification report template → `references/report-template.md` |
| `research-context-compressor` | 157 | 137 | −13% | humanities-project worked example → `references/example-humanities-project.md` |
| `zotero-library-curator` | 186 | 124 | −33% | 5 audit checks → `references/audit-checks.md`; report preview template → `references/report-template.md` |

**Total: 652 → 480 lines** (−26% in SKILL.md sources; 172 lines moved to `references/` where they only load on demand).

## What changed
For each skill: replaced the bloated section with a brief prose overview + pointer to the new reference file, and added a `## See also` block at the end. Mirrors under `src/research_hub/skills_data/<skill>/` kept in sync (4 SKILL.md + 6 new references files = 10 mirror writes).

## Test plan
- [x] `pytest -q tests/test_v069_summarize.py tests/test_v073_parallel_summarize.py tests/test_v080_resummarize.py` → 23 passed (sanity, doc-only).
- [x] Each new `references/<file>.md` starts with `# Title` (top-level, not nested).
- [x] All `See also` links resolve to real sibling files.
- [ ] CI matrix (research-hub repo's existing 18-cell matrix) auto-runs on push.

## After this PR
All 5 BLOATED + NEEDS-WORK skills flagged by the audit are now refactored. Remaining queued items: `project_manifest.yml` field-rename reconciliation, v0.7x+ undocumented CLI features promotion, wrapper default `gpt-5.5` switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)