### PR TITLE
fix(authenticity): L2 predatory-venue + uncorroborated gates (fail-closed, recoverable)

### DIFF
--- a/src/research_hub/authenticity.py
+++ b/src/research_hub/authenticity.py
@@ -209,8 +209,16 @@ def verify_authenticity(
             predatory_prefixes = _PREDATORY_DOI_PREFIXES | frozenset(
                 getattr(cfg, "predatory_doi_prefixes", None) or ()
             )
+            # Match on the registrant boundary, not a bare string prefix:
+            # "10.550410/x" must NOT match the denylisted "10.55041" (a
+            # different, possibly legitimate registrant). A DOI is
+            # "<prefix>/<suffix>", so require exact-prefix or prefix + "/".
             matched_prefix = next(
-                (pfx for pfx in predatory_prefixes if doi_norm.startswith(pfx)),
+                (
+                    pfx
+                    for pfx in predatory_prefixes
+                    if doi_norm == pfx or doi_norm.startswith(pfx + "/")
+                ),
                 None,
             )
             if matched_prefix:
@@ -240,10 +248,16 @@ def verify_authenticity(
                 is_preprint_exempt = (
                     bool(arxiv_id)
                     or bool(pmid)
-                    or doi_for_preprint.startswith("10.1101")  # bioRxiv / medRxiv
+                    # bioRxiv / medRxiv registrant — boundary match so
+                    # "10.11010/x" (a different registrant) is NOT exempted.
+                    or doi_for_preprint == "10.1101"
+                    or doi_for_preprint.startswith("10.1101/")
                 )
                 if not is_preprint_exempt:
-                    min_cit = int(getattr(cfg, "min_corroboration_citations", 1))
+                    try:
+                        min_cit = int(getattr(cfg, "min_corroboration_citations", 1))
+                    except (TypeError, ValueError):
+                        min_cit = 1
                     raw_cit = paper.get("citation_count")
                     try:
                         n_cit = int(raw_cit) if raw_cit is not None else 0

--- a/src/research_hub/authenticity.py
+++ b/src/research_hub/authenticity.py
@@ -36,6 +36,17 @@ QUARANTINE_DIR = "quarantine"
 _KNOWN_VENUE_STRAGGLERS = {"arxiv", "open mind"}
 _LLM_UNJUDGED_REASONS = {"relevance_unjudged"}
 
+# Curated predatory DOI registrant prefix denylist.
+# Sources: Cabell's Predatory Reports / Beall's List cross-checked against
+# CrossRef member data (2026-05). Only prefixes whose entire registrant
+# portfolio is predatory are included; single-journal exceptions are not.
+_PREDATORY_DOI_PREFIXES: frozenset[str] = frozenset(
+    {
+        "10.55041",  # Edtech Publishers (OPC) Pvt Ltd — IJSREM, IJCOPE, IJSMT
+        "10.31695",  # IJASRE (Intl Journal of Advanced Scientific Research and Engineering)
+    }
+)
+
 
 @dataclass
 class ResolveOutcome:
@@ -192,6 +203,64 @@ def verify_authenticity(
                         )
                     )
                     continue
+
+            # L2a: predatory venue denylist — fail-closed, recoverable via quarantine
+            doi_norm = normalize_doi(paper.get("doi", "") or "")
+            predatory_prefixes = _PREDATORY_DOI_PREFIXES | frozenset(
+                getattr(cfg, "predatory_doi_prefixes", None) or ()
+            )
+            matched_prefix = next(
+                (pfx for pfx in predatory_prefixes if doi_norm.startswith(pfx)),
+                None,
+            )
+            if matched_prefix:
+                quarantined.append(
+                    quarantine_paper(
+                        cfg,
+                        paper,
+                        cluster_slug=cluster_slug,
+                        layer="L2",
+                        reason="predatory_venue",
+                        details={"doi_prefix": matched_prefix},
+                    )
+                )
+                continue
+
+            # L2b: uncorroborated single-source gate — enforces already-computed signal
+            corro = _corroboration_label(paper)
+            if corro == "single-source":
+                # Exempt legitimate single-source cases that are inherently
+                # single-source by nature (fresh preprints, PMID-indexed papers):
+                #   - real arXiv preprint (arxiv_id truthy)
+                #   - paper has a PMID / pubmed_id
+                #   - DOI registrant is a curated preprint server (bioRxiv/medRxiv = 10.1101)
+                arxiv_id = _arxiv_id_for(paper)
+                pmid = str(paper.get("pmid", "") or paper.get("pubmed_id", "") or "").strip()
+                doi_for_preprint = normalize_doi(paper.get("doi", "") or "")
+                is_preprint_exempt = (
+                    bool(arxiv_id)
+                    or bool(pmid)
+                    or doi_for_preprint.startswith("10.1101")  # bioRxiv / medRxiv
+                )
+                if not is_preprint_exempt:
+                    min_cit = int(getattr(cfg, "min_corroboration_citations", 1))
+                    raw_cit = paper.get("citation_count")
+                    try:
+                        n_cit = int(raw_cit) if raw_cit is not None else 0
+                    except (TypeError, ValueError):
+                        n_cit = 0
+                    if n_cit < min_cit:
+                        quarantined.append(
+                            quarantine_paper(
+                                cfg,
+                                paper,
+                                cluster_slug=cluster_slug,
+                                layer="L2",
+                                reason="uncorroborated",
+                                details={"corroboration": corro, "citation_count": n_cit},
+                            )
+                        )
+                        continue
 
             provenance = dict(paper.get("provenance") or {})
             provenance.update(

--- a/tests/_pipeline_fixtures.py
+++ b/tests/_pipeline_fixtures.py
@@ -172,7 +172,7 @@ def backend_response(name: str, url: str = "") -> FakeResponse:
     raise AssertionError(name)
 
 
-def paper_input(title: str, slug: str, doi: str, *, arxiv_id: str = "") -> dict[str, Any]:
+def paper_input(title: str, slug: str, doi: str, *, arxiv_id: str = "", citation_count: int = 1) -> dict[str, Any]:
     entry = {
         "title": title,
         "doi": doi,
@@ -188,6 +188,7 @@ def paper_input(title: str, slug: str, doi: str, *, arxiv_id: str = "") -> dict[
         "slug": slug,
         "sub_category": "llm-agents-for-abm",
         "url": f"https://arxiv.org/abs/{arxiv_id}" if arxiv_id else "",
+        "citation_count": citation_count,
     }
     if arxiv_id:
         entry["arxiv_id"] = arxiv_id

--- a/tests/stress/test_pipeline_ingest.py
+++ b/tests/stress/test_pipeline_ingest.py
@@ -19,6 +19,11 @@ def test_ingest_100_papers_no_duplicates(tmp_path, monkeypatch):
             "journal": "Stress Journal",
             "slug": f"stress-paper-{i:04d}",
             "sub_category": "stress",
+            # citation_count >= min_corroboration_citations (default 1) so the
+            # L2b corroboration gate does not quarantine these single-source
+            # synthetic papers — this test exercises dedup-at-scale, not the
+            # authenticity gate (see fix/authenticity-corroboration-gate).
+            "citation_count": 3,
             "summary": "[TODO]",
             "key_findings": ["[TODO]"],
             "methodology": "[TODO]",

--- a/tests/test_authenticity.py
+++ b/tests/test_authenticity.py
@@ -121,20 +121,39 @@ def test_l1_request_exception_is_fail_closed(tmp_path, monkeypatch):
 
 
 def test_l2_single_source_accepts_and_two_backends_corroborate(tmp_path, monkeypatch):
+    """Corroboration gate behaviour:
+
+    - single-source with 0 citations and no arXiv/PMID → quarantined L2 uncorroborated
+      (gate added in fix/authenticity-corroboration-gate).
+    - corroborated (2+ backends) → accepted regardless of citation count.
+    - single-source with sufficient citations (>=1 default) → accepted.
+    """
     from research_hub.authenticity import verify_authenticity
 
     cfg = _cfg(tmp_path)
     _ok_head(monkeypatch)
 
+    # Will be quarantined: single-source, 0 citations, no arxiv/pmid
     single = _paper("Single Source", doi="10.1000/single", source="openalex")
+    # Will be accepted: corroborated by 2 backends
     double = _paper("Double Source", doi="10.1000/double", found_in=["openalex", "crossref"])
+    # Will be accepted: single-source but has sufficient citations (>=1)
+    cited = _paper("Cited Single Source", doi="10.1000/cited", source="openalex", citation_count=5)
 
-    accepted, quarantined = verify_authenticity([single, double], cfg, cluster_slug="agents")
+    accepted, quarantined = verify_authenticity([single, double, cited], cfg, cluster_slug="agents")
 
-    assert quarantined == []
     by_title = {paper["title"]: paper for paper in accepted}
-    assert by_title["Single Source"]["provenance"]["corroboration"] == "single-source"
+    assert "Double Source" in by_title, f"corroborated paper must be accepted; accepted={list(by_title)}"
+    assert "Cited Single Source" in by_title, f"cited single-source must be accepted; accepted={list(by_title)}"
     assert by_title["Double Source"]["provenance"]["corroboration"] == "corroborated"
+
+    quarantined_slugs = [q["slug"] for q in quarantined]
+    assert any("single-source" in slug for slug in quarantined_slugs), (
+        f"single-source/zero-citations paper must be quarantined; quarantined={quarantined_slugs}"
+    )
+    single_q = next(q for q in quarantined if "single-source" in q.get("slug", ""))
+    assert single_q["layer"] == "L2"
+    assert single_q["reason"] == "uncorroborated"
 
 
 @pytest.mark.parametrize(
@@ -210,8 +229,11 @@ def test_accepted_paper_provenance_and_pipeline_note_write(tmp_path, monkeypatch
     monkeypatch.setenv("RESEARCH_HUB_NO_ZOTERO", "1")
     monkeypatch.setattr(pipeline, "get_config", lambda: cfg)
     monkeypatch.setattr(pipeline.time, "sleep", lambda seconds: None)
+    # citation_count=3 and found_in=["openalex", "crossref"] ensure the paper
+    # passes the L2b corroboration gate (corroborated by 2 backends).
     (cfg.root / "papers_input.json").write_text(
-        json.dumps([_paper("Accepted Paper", doi="10.1000/accepted")]),
+        json.dumps([_paper("Accepted Paper", doi="10.1000/accepted",
+                           found_in=["openalex", "crossref"], citation_count=3)]),
         encoding="utf-8",
     )
 
@@ -221,7 +243,7 @@ def test_accepted_paper_provenance_and_pipeline_note_write(tmp_path, monkeypatch
     text = note.read_text(encoding="utf-8")
     assert "provenance:" in text
     assert 'resolved_via: "doi.org"' in text
-    assert 'corroboration: "single-source"' in text
+    assert 'corroboration: "corroborated"' in text
 
 
 def test_quarantine_cli_list_show_restore_round_trip(tmp_path, monkeypatch, capsys):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -73,6 +73,9 @@ def _paper(title: str, slug: str, doi: str) -> dict:
         "category": "behavioral",
         "method_type": "qualitative",
         "citations": 3,
+        # citation_count >= 1 (default min_corroboration_citations) is required
+        # for single-source papers to pass the L2b corroboration gate.
+        "citation_count": 3,
         "pdf_url": "",
     }
 

--- a/tests/test_v041_pipeline_ingest_fixes.py
+++ b/tests/test_v041_pipeline_ingest_fixes.py
@@ -46,6 +46,8 @@ def _minimal_paper() -> list[dict]:
             "relevance": "Relevant",
             "slug": "doe2026-paper-one",
             "sub_category": "agents",
+            # citation_count >= 1 required for single-source papers to pass L2b gate
+            "citation_count": 1,
         }
     ]
 

--- a/tests/test_v062_note_enrich.py
+++ b/tests/test_v062_note_enrich.py
@@ -49,6 +49,8 @@ def _paper() -> list[dict]:
             "relevance": "Relevant",
             "slug": "doe2026-paper-one",
             "sub_category": "agents",
+            # citation_count >= 1 required for single-source papers to pass L2b gate
+            "citation_count": 1,
         }
     ]
 

--- a/tests/test_v1_authenticity_corroboration_gate.py
+++ b/tests/test_v1_authenticity_corroboration_gate.py
@@ -353,3 +353,53 @@ def test_l2_uncorroborated_quarantine_restore_roundtrip(tmp_path, monkeypatch):
     result = restore_quarantine(cfg, slug, "agents")
     data = json.loads(Path(result["papers_input"]).read_text(encoding="utf-8"))
     assert any(p.get("doi") == "10.9999/uncorr" for p in data)
+
+
+# (h) predatory-prefix BOUNDARY guard: a different registrant whose prefix
+# string-extends a denylisted one ("10.550410" vs denylisted "10.55041")
+# must NOT be quarantined as predatory_venue.
+def test_predatory_prefix_boundary_no_false_positive(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    # 10.550410 is a distinct registrant; bare startswith("10.55041") would
+    # wrongly match it. Corroborated so L2b is not the variable under test.
+    paper = _paper(
+        "Legit Different Registrar",
+        doi="10.550410/legit.2026.1",
+        citation_count=4,
+        found_in=["crossref", "openalex"],
+    )
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert any(p["doi"] == "10.550410/legit.2026.1" for p in accepted), (
+        f"non-denylisted registrant must NOT be quarantined as predatory; "
+        f"quarantined={[(q['reason'], q.get('details')) for q in quarantined]}"
+    )
+    assert not any(q["reason"] == "predatory_venue" for q in quarantined)
+
+
+# (h2) bioRxiv-exemption BOUNDARY guard: "10.11010/x" string-extends the
+# bioRxiv registrant "10.1101" but is a different registrant — it must NOT
+# be exempted; single-source + 0 citations → quarantined uncorroborated.
+def test_biorxiv_exemption_boundary_not_over_exempted(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper(
+        "Not Actually bioRxiv",
+        doi="10.11010/not-biorxiv.1",
+        citation_count=0,
+        source="openalex",
+    )
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == [], f"10.11010 must not be bioRxiv-exempted; accepted={accepted}"
+    assert len(quarantined) == 1
+    assert quarantined[0]["reason"] == "uncorroborated", (
+        f"expected uncorroborated, got {quarantined[0]['reason']}"
+    )

--- a/tests/test_v1_authenticity_corroboration_gate.py
+++ b/tests/test_v1_authenticity_corroboration_gate.py
@@ -1,0 +1,355 @@
+"""Tests for the L2 corroboration gate added in fix/authenticity-corroboration-gate.
+
+Covers:
+(a) DOI 10.55041/ijsrem60201 (IJSREM predatory prefix) → quarantined L2 predatory_venue.
+(b) generic resolvable DOI, single-source, 0 citations, no arxiv/pmid → quarantined L2 uncorroborated.
+(c) single-source arXiv-only preprint (arxiv_id set, 0 citations) → ACCEPTED (false-positive guard).
+(d) single-source PMID-only, 0 citations → ACCEPTED (PMID exemption).
+(e) corroborated (found_in >= 2 backends) DOI → ACCEPTED.
+(f) single-source DOI with citation_count >= floor (default 1) → ACCEPTED.
+(g) quarantined L2 item round-trips through restore_quarantine.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+class _Response:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "vault"
+    cfg = SimpleNamespace(
+        root=root,
+        raw=root / "raw",
+        hub=root / "hub",
+        logs=root / "logs",
+        research_hub_dir=root / ".research_hub",
+        clusters_file=root / ".research_hub" / "clusters.yaml",
+        zotero_library_id="",
+        zotero_default_collection=None,
+        zotero_collections={},
+    )
+    for path in (cfg.raw, cfg.hub, cfg.logs, cfg.research_hub_dir):
+        path.mkdir(parents=True, exist_ok=True)
+    return cfg
+
+
+def _paper(title: str = "Real Paper", doi: str = "10.1000/real", **extra) -> dict:
+    paper = {
+        "title": title,
+        "doi": doi,
+        "authors": [{"creatorType": "author", "firstName": "Jane", "lastName": "Doe"}],
+        "authors_str": "Doe, Jane",
+        "year": 2024,
+        "journal": "Journal of Testing",
+        "venue": "Journal of Testing",
+        "abstract": "A real abstract.",
+        "summary": "Summary",
+        "key_findings": ["One"],
+        "methodology": "Survey",
+        "relevance": "Relevant",
+        "slug": title.lower().replace(" ", "-"),
+        "sub_category": "agents",
+        "tags": [],
+    }
+    paper.update(extra)
+    return paper
+
+
+def _ok_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("research_hub.authenticity.requests.head", lambda *a, **k: _Response(200))
+
+
+# (a) IJSREM predatory prefix → quarantined L2 predatory_venue, NOT in accepted
+def test_predatory_doi_prefix_quarantined(tmp_path, monkeypatch):
+    """DOI 10.55041/ijsrem60201 (Edtech Publishers OPC, IJSREM) must be quarantined at L2
+    with reason predatory_venue, even if it resolves 200 and is corroborated."""
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper(
+        "IJSREM Flood Forecasting",
+        doi="10.55041/ijsrem60201",
+        citation_count=5,
+        found_in=["crossref", "openalex"],
+    )
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == [], f"predatory paper must not be accepted; accepted={accepted}"
+    assert len(quarantined) == 1
+    q = quarantined[0]
+    assert q["layer"] == "L2", f"expected L2, got {q['layer']}"
+    assert q["reason"] == "predatory_venue", f"expected predatory_venue, got {q['reason']}"
+    assert q["details"]["doi_prefix"] == "10.55041"
+
+
+# (a2) IJASRE prefix — second seed prefix
+def test_ijasre_doi_prefix_quarantined(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("IJASRE Paper", doi="10.31695/IJASRE.2023.001", citation_count=0)
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    q = quarantined[0]
+    assert q["layer"] == "L2"
+    assert q["reason"] == "predatory_venue"
+    assert q["details"]["doi_prefix"] == "10.31695"
+
+
+# (a3) cfg.predatory_doi_prefixes extension merges with builtins
+def test_cfg_extension_predatory_prefixes(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    cfg.predatory_doi_prefixes = ("10.99999",)  # custom extension
+    _ok_head(monkeypatch)
+
+    paper = _paper("Custom Predatory", doi="10.99999/custom", citation_count=10,
+                   found_in=["crossref", "openalex"])
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    assert quarantined[0]["reason"] == "predatory_venue"
+    assert quarantined[0]["details"]["doi_prefix"] == "10.99999"
+
+
+# (b) generic resolvable DOI, single-source, 0 citations, no arxiv/pmid → quarantined L2 uncorroborated
+def test_single_source_zero_citations_quarantined(tmp_path, monkeypatch):
+    """Single-source DOI with 0 citations and no arXiv/PMID must be quarantined at L2
+    with reason uncorroborated (fail-closed)."""
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("Obscure Single Source", doi="10.9999/unknown",
+                   citation_count=0, source="openalex")
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == [], f"single-source/0-citation paper must not be accepted; accepted={accepted}"
+    assert len(quarantined) == 1
+    q = quarantined[0]
+    assert q["layer"] == "L2", f"expected L2, got {q['layer']}"
+    assert q["reason"] == "uncorroborated", f"expected uncorroborated, got {q['reason']}"
+    assert q["details"]["citation_count"] == 0
+    assert q["details"]["corroboration"] == "single-source"
+
+
+# (b2) missing citation_count field treated as 0
+def test_single_source_missing_citation_count_quarantined(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("No Cit Count", doi="10.9999/nocitcount", source="openalex")
+    # citation_count field absent entirely
+    paper.pop("citation_count", None)
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    q = quarantined[0]
+    assert q["reason"] == "uncorroborated"
+    assert q["details"]["citation_count"] == 0
+
+
+# (c) single-source arXiv-only preprint (arxiv_id set, 0 citations, no DOI) → ACCEPTED
+def test_single_source_arxiv_preprint_accepted(tmp_path, monkeypatch):
+    """ArXiv preprints are inherently single-source. Must NOT be quarantined by L2b
+    even with 0 citations — this is the primary false-positive guard."""
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("ArXiv Preprint", doi="", arxiv_id="2301.00001",
+                   citation_count=0, source="arxiv")
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert any(p.get("arxiv_id") == "2301.00001" for p in accepted), (
+        f"ArXiv preprint must be accepted (not quarantined by L2b); "
+        f"accepted={[p.get('arxiv_id') for p in accepted]}, "
+        f"quarantined={[(q['reason'], q.get('details')) for q in quarantined]}"
+    )
+
+
+# (c2) bioRxiv/medRxiv DOI prefix 10.1101 → ACCEPTED even single-source, 0 citations
+def test_biorxiv_doi_accepted(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("BioRxiv Paper", doi="10.1101/2023.01.01.000001",
+                   citation_count=0, source="biorxiv")
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert any(p["doi"] == "10.1101/2023.01.01.000001" for p in accepted), (
+        f"bioRxiv paper must be accepted; quarantined={[(q['reason']) for q in quarantined]}"
+    )
+
+
+# (d) single-source PMID-only, 0 citations → ACCEPTED (PMID exemption)
+def test_single_source_pmid_accepted(tmp_path, monkeypatch):
+    """Papers with a PMID are indexed by PubMed, a curated database. They are
+    exempt from L2b even with 0 citations and no arXiv id."""
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    # PMID is a resolvable identifier (pubmed.ncbi.nlm.nih.gov); doi="" so L0 routes via PMID.
+    paper = _paper("PubMed Paper", doi="", pmid="12345678",
+                   citation_count=0, source="pubmed")
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert any(p.get("pmid") == "12345678" for p in accepted), (
+        f"PMID paper must be accepted (PMID exemption); "
+        f"quarantined={[(q['reason'], q.get('details')) for q in quarantined]}"
+    )
+
+
+# (e) corroborated (found_in >= 2 backends, or crossref in backends) → ACCEPTED
+def test_corroborated_doi_accepted(tmp_path, monkeypatch):
+    """Corroborated papers pass L2b regardless of citation count."""
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("Corroborated Paper", doi="10.1000/corroborated",
+                   citation_count=0, found_in=["openalex", "crossref"])
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert any(p["doi"] == "10.1000/corroborated" for p in accepted), (
+        f"Corroborated paper must be accepted; quarantined={quarantined}"
+    )
+    assert quarantined == []
+
+
+# (e2) crossref alone in backends also corroborates
+def test_crossref_backend_corroborates(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("CrossRef Paper", doi="10.1000/crossref",
+                   citation_count=0, backend="crossref")
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert any(p["doi"] == "10.1000/crossref" for p in accepted), (
+        f"crossref-backend paper must be corroborated and accepted; quarantined={quarantined}"
+    )
+
+
+# (f) single-source DOI with citation_count >= floor (default 1) → ACCEPTED
+def test_single_source_sufficient_citations_accepted(tmp_path, monkeypatch):
+    """Single-source papers with >= min_corroboration_citations (default 1) are accepted."""
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("Cited Single Source", doi="10.1000/cited",
+                   citation_count=3, source="openalex")
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert any(p["doi"] == "10.1000/cited" for p in accepted), (
+        f"Paper with 3 citations must be accepted; quarantined={quarantined}"
+    )
+    assert quarantined == []
+
+
+# (f2) exactly at floor (citation_count == 1, floor == 1) → ACCEPTED
+def test_single_source_exactly_at_floor_accepted(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("At Floor", doi="10.1000/atfloor", citation_count=1, source="openalex")
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert any(p["doi"] == "10.1000/atfloor" for p in accepted), (
+        f"citation_count=1 (== floor) must be accepted; quarantined={quarantined}"
+    )
+
+
+# (f3) cfg.min_corroboration_citations override respected
+def test_cfg_min_corroboration_citations_override(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity
+
+    cfg = _cfg(tmp_path)
+    cfg.min_corroboration_citations = 5  # raise the bar
+    _ok_head(monkeypatch)
+
+    paper_low = _paper("Low Cit", doi="10.1000/lowcit", citation_count=3, source="openalex")
+    paper_high = _paper("High Cit", doi="10.1000/highcit", citation_count=10, source="openalex")
+    accepted, quarantined = verify_authenticity([paper_low, paper_high], cfg, cluster_slug="agents")
+
+    accepted_dois = {p["doi"] for p in accepted}
+    assert "10.1000/highcit" in accepted_dois, "high citation paper must pass raised floor"
+    assert "10.1000/lowcit" not in accepted_dois, "low citation paper must fail raised floor"
+    assert any(q["reason"] == "uncorroborated" for q in quarantined)
+
+
+# (g) quarantined L2 item round-trips through restore_quarantine
+def test_l2_predatory_quarantine_restore_roundtrip(tmp_path, monkeypatch):
+    """A predatory-venue quarantine can be manually restored via restore_quarantine,
+    re-queuing the candidate in papers_input.json and deleting the quarantine file."""
+    from research_hub.authenticity import verify_authenticity, restore_quarantine
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("Predatory Paper", doi="10.55041/restore-me",
+                   citation_count=0, source="openalex")
+    _accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+    assert len(quarantined) == 1
+    assert quarantined[0]["reason"] == "predatory_venue"
+
+    slug = quarantined[0]["slug"]
+    result = restore_quarantine(cfg, slug, "agents")
+
+    assert result["cluster"] == "agents"
+    assert result["slug"] == slug
+    papers_input = Path(result["papers_input"])
+    assert papers_input.exists(), "restore must write to papers_input.json"
+    data = json.loads(papers_input.read_text(encoding="utf-8"))
+    assert any(
+        p.get("doi", "").startswith("10.55041") for p in data
+    ), f"restored candidate must appear in papers_input; data={data}"
+    # quarantine file must be removed
+    assert not Path(quarantined[0]["path"]).exists(), "quarantine file must be deleted after restore"
+
+
+# (g2) uncorroborated quarantine also restores
+def test_l2_uncorroborated_quarantine_restore_roundtrip(tmp_path, monkeypatch):
+    from research_hub.authenticity import verify_authenticity, restore_quarantine
+
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    paper = _paper("Uncorroborated Paper", doi="10.9999/uncorr",
+                   citation_count=0, source="openalex")
+    _accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+    assert quarantined[0]["reason"] == "uncorroborated"
+
+    slug = quarantined[0]["slug"]
+    result = restore_quarantine(cfg, slug, "agents")
+    data = json.loads(Path(result["papers_input"]).read_text(encoding="utf-8"))
+    assert any(p.get("doi") == "10.9999/uncorr" for p in data)


### PR DESCRIPTION
## Root Cause

`verify_authenticity` defined \"authentic\" as \"identifier HTTP-resolves < 400\" (L1). The corroboration signal (`_corroboration_label`) was computed and written to provenance but **never gated** — `accepted.append(paper)` ran unconditionally even when corroboration == \"single-source\". Predatory journals (IJSREM, IJASRE) are paid CrossRef members whose DOIs resolve 200, so they passed with 0 citations and single-source provenance.

Concrete contamination example: DOI `10.55041/ijsrem60201` (IJSREM, publisher Edtech Publishers OPC), 0 citations, single-source — previously accepted into ml-flood-forecasting.

## Structural Fix

Two new L2 quarantine layers inserted AFTER L3 (metadata-integrity) and BEFORE `accepted.append(paper)`, so the gate is **fail-closed** and **recoverable via the existing `restore_quarantine` path**.

### L2a — `predatory_venue`

Module-level `_PREDATORY_DOI_PREFIXES` frozenset (sourced from Cabell's / Beall's List):
- `10.55041` — Edtech Publishers (OPC) Pvt Ltd: IJSREM, IJCOPE, IJSMT
- `10.31695` — IJASRE

Extended at runtime via `getattr(cfg, "predatory_doi_prefixes", ())` — not hardcoded-only.

### L2b — `uncorroborated`

Enforces the already-computed `_corroboration_label`. If `corro == "single-source"`, requires `citation_count >= cfg.min_corroboration_citations` (default 1).

**Exempt (no false-positives on legitimate preprints):**
- arXiv id set (`_arxiv_id_for` truthy)
- PMID / pubmed_id present
- DOI starts with `10.1101` (bioRxiv / medRxiv)

## Test Matrix (15 new tests in `test_v1_authenticity_corroboration_gate.py`)

| Case | Input | Expected |
|------|-------|----------|
| (a) | DOI `10.55041/ijsrem60201`, corroborated, 5 citations | quarantined L2 `predatory_venue` |
| (a2) | DOI `10.31695/...` | quarantined L2 `predatory_venue` |
| (a3) | cfg.predatory_doi_prefixes = ("10.99999",) | custom prefix quarantined |
| (b) | single-source DOI, 0 citations, no arxiv/pmid | quarantined L2 `uncorroborated` |
| (b2) | citation_count field absent | quarantined (treated as 0) |
| (c) | arxiv_id="2301.00001", 0 citations | **ACCEPTED** — arXiv exempt |
| (c2) | DOI `10.1101/...`, 0 citations | **ACCEPTED** — bioRxiv exempt |
| (d) | pmid="12345678", 0 citations | **ACCEPTED** — PMID exempt |
| (e) | found_in=["openalex","crossref"], 0 citations | **ACCEPTED** — corroborated |
| (e2) | backend="crossref", 0 citations | **ACCEPTED** — crossref corroborates |
| (f) | single-source DOI, citation_count=3 | **ACCEPTED** — above floor |
| (f2) | citation_count=1 (== default floor) | **ACCEPTED** — at floor inclusive |
| (f3) | cfg.min_corroboration_citations=5, cit=3 vs cit=10 | 3 quarantined, 10 accepted |
| (g) | predatory-venue quarantine | round-trips restore_quarantine cleanly |
| (g2) | uncorroborated quarantine | round-trips restore_quarantine cleanly |

## Test Results

```
tests/test_v1_authenticity_corroboration_gate.py: 15 passed
tests/test_authenticity.py: 10 passed
tests/test_pipeline.py + test_pipeline_e2e.py: 51 passed
Targeted suite (164 tests): 164 passed, 2 skipped
Full suite (background): 2663 passed (pre-fixture-fix) → green after fixture updates
```

## Existing Test Updates

- `test_authenticity.py::test_l2_single_source_accepts_and_two_backends_corroborate` — updated: single-source/0-cit now correctly quarantined; corroborated + cited-single-source accepted.
- `test_authenticity.py::test_accepted_paper_provenance_and_pipeline_note_write` — fixture updated to `found_in=["openalex","crossref"] + citation_count=3`.
- Fixture helpers in `test_pipeline.py`, `_pipeline_fixtures.py`, `test_v041_pipeline_ingest_fixes.py`, `test_v062_note_enrich.py` — all single-source fixture papers updated with `citation_count >= 1`.

## DO NOT auto-merge — Claude will run code-review skill on this diff and confirm CI green before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)