### PR TITLE
fix: honest NLM auth + close gray-literature gate + F7 doi.org 418 unblock (F1–F5, F7-min)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@ graph rebuild (link out to the real tools instead)._
   re-probes session health *after* rotating cookies; a rotation that
   does not preserve a usable session (server-side re-auth) returns
   non-zero instead of exit 0.
+- **F7: doi.org anti-bot 418 no longer quarantines every valid paper.**
+  The authenticity gate's DOI resolver sent the default
+  `python-requests` User-Agent, which doi.org/Cloudflare answer with
+  HTTP 418 — read as `doi_unresolved` → **every** peer-reviewed paper
+  fail-closed-quarantined (reproduced: `accepted: 0; quarantined: 2`,
+  `DOIs accessible: 0`; the same DOI returns 200 with a real UA). Fix:
+  send a real `User-Agent`; classify 408/418/425/429/5xx + network
+  errors as *transient* (bounded retry + backoff, **not** cached as a
+  permanent miss, surfaced as `*_check_unavailable`); genuine 404/410
+  stay fail-closed `doi_unresolved` so the anti-fabrication guarantee
+  is unchanged. A 0/malformed status also fails closed.
 
 ### Removed
 - **Dead `notebooklm login` flags:** `--cdp`, `--chrome-binary`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,52 @@ UI scope is capped here by decision: the dashboard stays a thin
 status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
+### Added
+- **`--peer-reviewed` flag on `search` and `auto`.** Drops preprint
+  backends (arXiv/bioRxiv/chemRxiv/medRxiv), excludes gray doc types
+  (preprint/posted-content/report/book-chapter/paratext/dataset), and
+  floors corroboration. Closes the gap where `auto` ran search with
+  **zero** filtering and the one-shot pipeline could not express
+  "peer-reviewed only" (gray literature silently entered the vault).
+- **`doctor` check `nlm_auth_paths`.** Reports which NotebookLM
+  re-authentication paths actually work on this machine (interactive
+  vs `--from-browser`/rookiepy) and the exact command to run.
+
+### Changed
+- **`notebooklm login --help` rewritten to the three real paths.**
+  Previously advertised `--cdp / --from-chrome-profile /
+  --use-system-chrome / --timeout / --keep-open` as working modes;
+  they were silently no-ops (the underlying aliases `del`'d their
+  arguments). Help now states only: interactive default,
+  `--import-from`, `--from-browser`.
+- **`--from-browser` failure on Python ≥3.14 is now actionable.**
+  Detects the missing-rookiepy + no-prebuilt-wheel case and points to
+  the two paths that work (interactive in a terminal / `--import-from`)
+  instead of a generic `pip install` hint that cannot succeed there.
+
+### Fixed
+- **arXiv hits no longer leak past `--exclude-type preprint`.** The
+  arXiv backend left `doc_type` empty, so the type filter silently
+  missed every raw arXiv result (bioRxiv/chemRxiv already set it).
+  Now `doc_type="preprint"`.
+- **Self-heal commands are environment-correct.** New
+  `recommended_cli_invocation()` picks the `research-hub` console
+  script when on PATH, else the `python -m research_hub` module form.
+  Wired into the NLM preflight, `RequiresAuthRefresh`, keepalive task
+  resolution, and the auto-pipeline NLM-skip hint — these previously
+  hardcoded a console-script command that fails on source checkouts.
+- **`notebooklm keepalive` no longer reports false-green.** It now
+  re-probes session health *after* rotating cookies; a rotation that
+  does not preserve a usable session (server-side re-auth) returns
+  non-zero instead of exit 0.
+
+### Removed
+- **Dead `notebooklm login` flags:** `--cdp`, `--chrome-binary`,
+  `--use-system-chrome`, `--from-chrome-profile`,
+  `--chrome-profile-path`, `--chrome-profile-name`, `--keep-open`,
+  `--timeout`, and the unused `login_interactive` /
+  `login_interactive_cdp` aliases they delegated to.
+
 ## v1.0.0 (PENDING — tag on/after 2026-05-24, post ≥1-week v0.95.0rc2 bake)
 
 > **Not yet released — staged on `release-prep/v1.0.0`.** The cut

--- a/src/research_hub/_invocation.py
+++ b/src/research_hub/_invocation.py
@@ -1,0 +1,18 @@
+"""Helpers for printing runnable research-hub CLI commands."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+
+
+def recommended_cli_invocation() -> str:
+    """The command prefix that actually works in this environment:
+    the `research-hub` console script if on PATH, else the module form
+    `<python> -m research_hub` (works from a source checkout where the
+    console script was never installed or is not on PATH).
+    """
+    exe = shutil.which("research-hub")
+    if exe:
+        return "research-hub"
+    return f"{sys.executable} -m research_hub"

--- a/src/research_hub/authenticity.py
+++ b/src/research_hub/authenticity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 import unicodedata
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -392,6 +393,47 @@ def restore_quarantine(cfg, slug: str, cluster: str) -> dict:
     }
 
 
+# F7: doi.org / Cloudflare serve HTTP 418 to the default ``python-requests``
+# User-Agent (a bot fingerprint), which the gate previously read as
+# ``doi_unresolved`` and fail-closed-quarantined every valid paper. A real
+# UA makes the same DOI return 200/302. Empirically verified 2026-05-18.
+_DOI_RESOLVE_UA = "research-hub (+https://github.com/WenyuChiou/research-hub)"
+# Transient = "blocked / rate-limited / retry later", NOT "this DOI is fake".
+# 404/410 stay permanent so the anti-fabrication guarantee is preserved.
+_TRANSIENT_HTTP_STATUS = frozenset({408, 418, 425, 429, 500, 502, 503, 504})
+
+
+def _resolve_head_with_retry(url: str, *, attempts: int = 3) -> tuple[int | None, bool]:
+    """HEAD *url* with a real User-Agent and bounded backoff.
+
+    Returns ``(status_code, transient)``. ``transient`` is True when the
+    final attempt was a rate-limit / anti-bot / network failure
+    (HTTP 408/418/425/429/5xx or a RequestException) rather than a
+    definitive answer — the caller must NOT treat that as a fake DOI and
+    must NOT cache it as a permanent failure.
+    """
+    status_code: int | None = None
+    for attempt in range(attempts):
+        try:
+            response = requests.head(
+                url,
+                allow_redirects=True,
+                timeout=8,
+                headers={"User-Agent": _DOI_RESOLVE_UA},
+            )
+            status_code = int(getattr(response, "status_code", 0) or 0)
+            # `status_code and ...`: a 0/falsy code (malformed response) is
+            # NOT a definitive answer — fall through to retry, then transient,
+            # so it can never resolve to ok=True (fail-closed).
+            if status_code and status_code not in _TRANSIENT_HTTP_STATUS:
+                return status_code, False
+        except requests.RequestException:
+            status_code = None
+        if attempt < attempts - 1:
+            time.sleep(0.5 * (2 ** attempt))
+    return status_code, True
+
+
 def _resolve_identifier(paper: dict, cache: DoiResolveCache, cache_path: Path) -> ResolveOutcome:
     key_url_source = _identifier_key_url_source(paper)
     if key_url_source is None:
@@ -408,16 +450,23 @@ def _resolve_identifier(paper: dict, cache: DoiResolveCache, cache_path: Path) -
         return cached
 
     checked_at = _utc_now_iso()
-    try:
-        response = requests.head(url, allow_redirects=True, timeout=8)
-        status_code = int(getattr(response, "status_code", 0) or 0)
-        ok = status_code < 400
-        reason = "" if ok else _unresolved_reason_for(source)
-    except requests.RequestException:
-        status_code = None
-        ok = False
-        reason = _unavailable_reason_for(source)
+    status_code, transient = _resolve_head_with_retry(url)
+    if transient:
+        # F7: rate-limit / anti-bot / network blip — NOT evidence the DOI
+        # is fabricated. Surface as check-unavailable and do NOT cache, so
+        # a later run retries fresh instead of inheriting a poisoned miss.
+        return ResolveOutcome(
+            ok=False,
+            key=key,
+            resolved_via=source,
+            checked_at=checked_at,
+            status_code=status_code,
+            reason=_unavailable_reason_for(source),
+            url=url,
+        )
 
+    ok = status_code is not None and status_code < 400
+    reason = "" if ok else _unresolved_reason_for(source)
     outcome = ResolveOutcome(
         ok=ok,
         key=key,

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -17,6 +17,7 @@ from research_hub.clusters import ClusterRegistry, slugify
 from research_hub.config import get_config
 from research_hub.discover import _to_papers_input
 from research_hub.errors import MissingExternalTool
+from research_hub._invocation import recommended_cli_invocation
 from research_hub.notebooklm.bundle import bundle_cluster
 from research_hub.notebooklm.upload import (
     download_briefing_for_cluster,
@@ -25,7 +26,7 @@ from research_hub.notebooklm.upload import (
 )
 from research_hub.pipeline import run_pipeline
 from research_hub.search import search_papers
-from research_hub.search.fallback import FIELD_PRESETS
+from research_hub.search.fallback import FIELD_PRESETS, apply_peer_reviewed
 from research_hub.vault.graph_config import refresh_graph_from_vault
 
 
@@ -170,6 +171,7 @@ def auto_pipeline(
     zotero_batch_size: int = 50,
     with_pdfs: bool = False,
     with_summary: bool = False,
+    peer_reviewed: bool = False,
 ) -> AutoReport:
     """End-to-end ingest + optional NotebookLM publish.
 
@@ -244,8 +246,19 @@ def auto_pipeline(
 
     # Print plan if dry_run; do NOT execute remaining steps
     if dry_run:
+        backends, exclude_types, min_confidence = _resolve_search_options(
+            field=field,
+            peer_reviewed=peer_reviewed,
+        )
+        filter_note = ""
+        if peer_reviewed:
+            filter_note = (
+                f", exclude_types={','.join(exclude_types)}, "
+                f"min_confidence={min_confidence:g}"
+            )
         plan_lines = [
-            f"  search {topic!r} (max_papers={max_papers}, backends=arxiv+semantic_scholar)",
+            f"  search {topic!r} (max_papers={max_papers}, "
+            f"backends={'+'.join(backends)}{filter_note})",
         ]
         if do_fit_check:
             cli_for_plan = llm_cli or detect_llm_cli() or "(none on PATH — will skip)"
@@ -304,7 +317,12 @@ def auto_pipeline(
 
     # 3 + 4. Search ??papers_input.json
     try:
-        search_kwargs = {"max_papers": max_papers, "cluster_slug": slug}
+        search_kwargs = {
+            "max_papers": max_papers,
+            "cluster_slug": slug,
+        }
+        if peer_reviewed:
+            search_kwargs["peer_reviewed"] = True
         if field is not None:
             search_kwargs["field"] = field
         papers = _run_search(topic, **search_kwargs)
@@ -642,11 +660,12 @@ def _print_next_steps(report: AutoReport, slug: str, cfg, *, do_crystals: bool) 
     if report.brief_path:
         print(f"  Brief:      {report.brief_path}")
     if report.nlm_deferred:
-        print("  [NLM] skipped (check: research-hub notebooklm login). Resume with:")
-        print(f"    research-hub notebooklm bundle   --cluster {slug}")
-        print(f"    research-hub notebooklm upload   --cluster {slug}")
-        print(f"    research-hub notebooklm generate --cluster {slug} --type brief")
-        print(f"    research-hub notebooklm download --cluster {slug} --type brief")
+        inv = recommended_cli_invocation()
+        print(f"  [NLM] skipped (check: {inv} notebooklm login). Resume with:")
+        print(f"    {inv} notebooklm bundle   --cluster {slug}")
+        print(f"    {inv} notebooklm upload   --cluster {slug}")
+        print(f"    {inv} notebooklm generate --cluster {slug} --type brief")
+        print(f"    {inv} notebooklm download --cluster {slug} --type brief")
         if report.nlm_error:
             print(f"  Last NLM error: {report.nlm_error}")
     print()
@@ -957,16 +976,47 @@ def _elapsed(started: float, report: AutoReport) -> float:
     return time.time() - started
 
 
-def _run_search(topic: str, *, max_papers: int, cluster_slug: str, field: Optional[str] = None) -> list[dict]:
+def _resolve_search_options(
+    *,
+    field: Optional[str] = None,
+    peer_reviewed: bool = False,
+) -> tuple[tuple[str, ...], tuple[str, ...], float]:
+    backends = tuple(
+        FIELD_PRESETS[field] if field else ("arxiv", "semantic-scholar", "openalex", "crossref")
+    )
+    exclude_types: tuple[str, ...] = ()
+    min_confidence = 0.0
+    if peer_reviewed:
+        backends, exclude_types, min_confidence = apply_peer_reviewed(
+            backends,
+            exclude_types,
+            min_confidence,
+        )
+    return backends, exclude_types, min_confidence
+
+
+def _run_search(
+    topic: str,
+    *,
+    max_papers: int,
+    cluster_slug: str,
+    field: Optional[str] = None,
+    peer_reviewed: bool = False,
+) -> list[dict]:
     """Run arxiv + semantic_scholar search, return papers_input dicts."""       
 
 
     # v0.49.4: search arxiv + semantic-scholar + openalex + crossref so the
     # pipeline survives semantic-scholar rate-limiting and one-backend gaps.
-    backends = list(FIELD_PRESETS[field]) if field else ["arxiv", "semantic-scholar", "openalex", "crossref"]
+    backends, exclude_types, min_confidence = _resolve_search_options(
+        field=field,
+        peer_reviewed=peer_reviewed,
+    )
     results = search_papers(
         topic,
         backends=backends,
+        exclude_types=exclude_types,
+        min_confidence=min_confidence,
         limit=max_papers,
     )
     return _to_papers_input([asdict(r) for r in results], cluster_slug)

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 from contextlib import nullcontext, redirect_stdout
 import json
 import os
@@ -30,6 +31,7 @@ from research_hub.search.fallback import (
     DEFAULT_BACKENDS,
     FIELD_PRESETS,
     REGION_PRESETS,
+    apply_peer_reviewed,
     resolve_backends_for_field,
     resolve_backends_for_region,
 )
@@ -53,6 +55,12 @@ _CLI_DEPRECATED_ALIASES: dict[tuple[str, ...], tuple[str, str]] = {
     ("cleanup",): ("research-hub cleanup", "research-hub tidy"),
     ("label-bulk",): ("research-hub label-bulk", "research-hub paper bulk-relabel"),
 }
+
+_PEER_REVIEWED_HELP = (
+    "Peer-reviewed only: drop preprint backends, exclude preprint/report/dataset "
+    "doc types, require >=1-backend corroboration. Excludes gray literature "
+    "(arXiv/bioRxiv/Zenodo)."
+)
 
 
 def _cli_deprecated_alias(argv: list[str] | tuple[str, ...]) -> tuple[str, str] | None:
@@ -3732,8 +3740,10 @@ def _preflight_nlm_session(cfg, *, op_name: str) -> int | None:
     browser launches a 30-second deep-stack failure. Returns None when
     OK to proceed, or an exit code (1) with a one-line actionable hint
     printed to stderr when not."""
+    from research_hub._invocation import recommended_cli_invocation
     from research_hub.notebooklm.auth import default_state_file, require_session_health
 
+    inv = recommended_cli_invocation()
     state_file = default_state_file(cfg.research_hub_dir)
     try:
         require_session_health(state_file)
@@ -3741,7 +3751,7 @@ def _preflight_nlm_session(cfg, *, op_name: str) -> int | None:
         reason = str(exc).split(": ", 1)[1] if ": " in str(exc) else str(exc)
         print(
             f"[notebooklm {op_name}] session check failed: {reason}. "
-            "Run `research-hub notebooklm login` to sign in.",
+            f"Run `{inv} notebooklm login` to sign in.",
             file=sys.stderr,
         )
         return 1
@@ -4403,6 +4413,7 @@ def _auto(
     batch_label: str | None = None,
     with_pdfs: bool = False,
     with_summary: bool = False,
+    peer_reviewed: bool = False,
     emit_json: bool = False,
 ) -> int:
     from research_hub.auto import auto_pipeline
@@ -4450,6 +4461,7 @@ def _auto(
             "zotero_batch_size": zotero_batch_size,
             "llm_cli": llm_cli,
             "dry_run": dry_run,
+            "peer_reviewed": peer_reviewed,
             "print_progress": not emit_json,
         }
         if with_pdfs:
@@ -4815,6 +4827,11 @@ def build_parser() -> argparse.ArgumentParser:
     auto_parser.add_argument("--field", default=None,
                              choices=["cs", "bio", "med", "physics", "math", "social", "econ", "chem", "astro", "edu", "general"],
                              help="Field preset for backend selection")
+    auto_parser.add_argument(
+        "--peer-reviewed",
+        action="store_true",
+        help=_PEER_REVIEWED_HELP,
+    )
     auto_parser.add_argument("--no-nlm", action="store_true",
                              help="Skip NotebookLM bundle/upload/generate/download")
     auto_parser.add_argument("--with-crystals", action="store_true",
@@ -5377,6 +5394,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--exclude-type",
         default="",
         help="Comma-separated list of doc types to exclude (e.g. 'book-chapter,report,paratext')",
+    )
+    search_parser.add_argument(
+        "--peer-reviewed",
+        action="store_true",
+        help=_PEER_REVIEWED_HELP,
     )
     search_parser.add_argument(
         "--exclude",
@@ -6075,46 +6097,24 @@ def build_parser() -> argparse.ArgumentParser:
 
     nlm_parser = subparsers.add_parser("notebooklm", help="NotebookLM operations")
     nlm_sub = nlm_parser.add_subparsers(dest="notebooklm_command", required=True)
-    nlm_login = nlm_sub.add_parser("login", help="Interactive one-time Google sign-in")
-    nlm_login.add_argument(
-        "--cdp",
-        action="store_true",
-        help="CDP attach mode (RECOMMENDED): launches real Chrome as a subprocess with "
-             "--remote-debugging-port and has Playwright connect over CDP. Chrome never knows "
-             "it is being automated, so Google's bot check does not fire. Fixes the "
-             "'This browser or app may have security concerns' block.",
-    )
-    nlm_login.add_argument(
-        "--chrome-binary",
-        default=None,
-        help="Path to chrome.exe (CDP mode). Auto-detected if omitted.",
-    )
-    nlm_login.add_argument(
-        "--use-system-chrome",
-        action="store_true",
-        help="Launch the installed Chrome binary (channel=chrome) instead of bundled Chromium",
-    )
-    nlm_login.add_argument(
-        "--from-chrome-profile",
-        action="store_true",
-        help="Clone your existing Chrome profile (with Google auth cookies already present) into "
-             "the session dir so Google does not trigger bot detection. Chrome MUST be closed first.",
-    )
-    nlm_login.add_argument(
-        "--chrome-profile-path",
-        default=None,
-        help="Override the auto-detected Chrome user data dir (the folder containing 'Default')",
-    )
-    nlm_login.add_argument(
-        "--chrome-profile-name",
-        default="Default",
-        help="Which Chrome profile to clone (default: Default; try 'Profile 1' etc.)",
-    )
-    nlm_login.add_argument(
-        "--timeout",
-        type=int,
-        default=300,
-        help="Max seconds to wait for login (default: 300)",
+    nlm_login = nlm_sub.add_parser(
+        "login",
+        help="Authenticate NotebookLM",
+        description=(
+            "Authenticate NotebookLM. Three paths: (1) default interactive Google "
+            "sign-in in a real terminal (press ENTER when the NotebookLM homepage "
+            "loads); (2) --import-from <other-vault> copies a logged-in session "
+            "from another vault; (3) --from-browser [browser] imports cookies via "
+            "rookiepy (requires the research-hub[browser-auth] extra; rookiepy has "
+            "no prebuilt wheel for Python 3.14)."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  research-hub notebooklm login\n"
+            "  research-hub notebooklm login --import-from <other-vault>\n"
+            "  research-hub notebooklm login --from-browser chrome"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     nlm_login.add_argument(
         "--import-from",
@@ -6128,13 +6128,6 @@ def build_parser() -> argparse.ArgumentParser:
         "--overwrite",
         action="store_true",
         help="With --import-from: replace the current vault's logged-in session if one exists.",
-    )
-    nlm_login.add_argument(
-        "--keep-open",
-        action="store_true",
-        help="(CDP mode) Do NOT auto-close on login detection. Keeps Chrome open "
-             "so you can inspect the DOM with F12 DevTools. Press Enter in the "
-             "terminal when finished.",
     )
     nlm_login.add_argument(
         "--from-browser",
@@ -6868,6 +6861,7 @@ def _main_dispatch(args, parser) -> int:
             zotero_batch_size=args.zotero_batch_size,
             llm_cli=args.llm_cli,
             dry_run=args.dry_run,
+            peer_reviewed=args.peer_reviewed,
             append=args.append,
             force=args.force,
             show=args.show,
@@ -7241,6 +7235,13 @@ def _main_dispatch(args, parser) -> int:
         else:
             backends = DEFAULT_BACKENDS
         exclude_types = _parse_csv_terms(args.exclude_type)
+        min_confidence = args.min_confidence
+        if args.peer_reviewed:
+            backends, exclude_types, min_confidence = apply_peer_reviewed(
+                backends,
+                exclude_types,
+                min_confidence,
+            )
         exclude_terms = _parse_negative_terms(args.exclude)
         if args.enrich:
             candidates = ["-"] if args.query == "-" else [item.strip() for item in re.split(r"[\n,]+", args.query) if item.strip()]
@@ -7261,7 +7262,7 @@ def _main_dispatch(args, parser) -> int:
             backends=backends,
             exclude_types=exclude_types,
             exclude_terms=exclude_terms,
-            min_confidence=args.min_confidence,
+            min_confidence=min_confidence,
             rank_by=args.rank_by,
             backend_trace=args.backend_trace,
             emit_json=args.json,
@@ -7436,17 +7437,17 @@ def _main_dispatch(args, parser) -> int:
         if args.notebooklm_command == "login":
             from pathlib import Path as _Path
 
+            from research_hub._invocation import recommended_cli_invocation
             from research_hub.notebooklm.auth import (
                 default_session_dir,
                 default_state_file,
-                login_interactive,
-                login_interactive_cdp,
                 login_nlm,
             )
 
             cfg = get_config()
             session_dir = default_session_dir(cfg.research_hub_dir)
-            # Precedence: --import-from > --from-browser > interactive (--cdp / default)
+            inv = recommended_cli_invocation()
+            # Precedence: --import-from > --from-browser > interactive default.
             #
             # v0.70.1: --import-from short-circuits the interactive flow by
             # copying a logged-in session profile from another vault.
@@ -7483,34 +7484,34 @@ def _main_dispatch(args, parser) -> int:
                     print("[notebooklm login --from-browser] Login successful.")
                     print("Verify with: research-hub notebooklm keepalive")
                 else:
-                    print(
-                        "[notebooklm login --from-browser] FAILED (exit code "
-                        f"{rc}). If rookiepy is not installed, run:\n"
-                        "  pip install 'research-hub[browser-auth]'",
-                        file=sys.stderr,
-                    )
+                    version_info = sys.version_info
+                    if hasattr(version_info, "major"):
+                        version_tuple = (version_info.major, version_info.minor)
+                    else:
+                        version_tuple = (version_info[0], version_info[1])
+                    rookiepy_missing = importlib.util.find_spec("rookiepy") is None
+                    if rookiepy_missing and version_tuple >= (3, 14):
+                        print(
+                            "--from-browser needs rookiepy, which has no prebuilt wheel "
+                            f"for Python {version_tuple[0]}.{version_tuple[1]} "
+                            "(building it needs a Rust toolchain). Non-interactive "
+                            "cookie import is unavailable on this Python. Use one of: "
+                            f"(1) interactive login in a terminal: `{inv} notebooklm login` "
+                            "then press ENTER; (2) copy a logged-in session: "
+                            f"`{inv} notebooklm login --import-from <other-vault>`.",
+                            file=sys.stderr,
+                        )
+                    else:
+                        print(
+                            "[notebooklm login --from-browser] FAILED (exit code "
+                            f"{rc}). If rookiepy is not installed, run:\n"
+                            "  pip install 'research-hub[browser-auth]'",
+                            file=sys.stderr,
+                        )
                 return rc
-            if args.cdp:
-                return login_interactive_cdp(
-                    session_dir,
-                    timeout_sec=args.timeout,
-                    chrome_binary=args.chrome_binary,
-                    keep_open=args.keep_open,
-                )
-            chrome_path = _Path(args.chrome_profile_path) if args.chrome_profile_path else None
-            if not args.from_chrome_profile and not args.use_system_chrome and not chrome_path:
-                return login_nlm(
-                    session_dir,
-                    state_file=default_state_file(cfg.research_hub_dir),
-                    timeout_sec=args.timeout,
-                )
-            return login_interactive(
+            return login_nlm(
                 session_dir,
-                use_system_chrome=args.use_system_chrome,
-                timeout_sec=args.timeout,
-                from_chrome_profile=args.from_chrome_profile,
-                chrome_profile_path=chrome_path,
-                chrome_profile_name=args.chrome_profile_name,
+                state_file=default_state_file(cfg.research_hub_dir),
             )
         if args.notebooklm_command == "bundle":
             return _notebooklm_bundle(args.cluster, download_pdfs=args.download_pdfs)

--- a/src/research_hub/doctor.py
+++ b/src/research_hub/doctor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import re
@@ -774,6 +775,25 @@ def check_nlm_chrome_orphans() -> CheckResult:
     )
 
 
+def check_nlm_auth_paths() -> CheckResult:
+    """Report available NotebookLM re-authentication paths."""
+    from research_hub._invocation import recommended_cli_invocation
+
+    inv = recommended_cli_invocation()
+    interactive = f"{inv} notebooklm login"
+    if importlib.util.find_spec("rookiepy") is not None:
+        return CheckResult(
+            "nlm_auth_paths",
+            "OK",
+            f"interactive: {interactive}; --from-browser: available (rookiepy installed)",
+        )
+    return CheckResult(
+        "nlm_auth_paths",
+        "INFO",
+        f"interactive: {interactive}; --from-browser: unavailable (rookiepy not installed)",
+    )
+
+
 def run_doctor(*, strict: bool = False) -> list[CheckResult]:
     """Run all health checks and return results.
 
@@ -1174,6 +1194,11 @@ def run_doctor(*, strict: bool = False) -> list[CheckResult]:
                 remedy="pip install 'research-hub-pipeline[playwright]'",
             )
         )
+
+    try:
+        results.append(check_nlm_auth_paths())
+    except Exception as exc:
+        results.append(CheckResult("nlm_auth_paths", "INFO", f"Could not check: {exc}"))
 
     if cfg is not None:
         try:

--- a/src/research_hub/notebooklm/__init__.py
+++ b/src/research_hub/notebooklm/__init__.py
@@ -6,8 +6,6 @@ from research_hub.notebooklm.auth import (
     default_session_dir,
     default_state_file,
     import_session,
-    login_interactive,
-    login_interactive_cdp,
     login_nlm,
 )
 from research_hub.notebooklm.bundle import BundleReport, bundle_cluster
@@ -44,8 +42,6 @@ __all__ = [
     "download_briefing_for_cluster",
     "generate_artifact",
     "import_session",
-    "login_interactive",
-    "login_interactive_cdp",
     "login_nlm",
     "read_latest_briefing",
     "upload_cluster",

--- a/src/research_hub/notebooklm/auth.py
+++ b/src/research_hub/notebooklm/auth.py
@@ -68,44 +68,6 @@ def login_nlm(
     return rc
 
 
-def login_interactive_cdp(
-    user_data_dir: Path,
-    *,
-    timeout_sec: int = 300,
-    stable_hold_sec: int = 5,
-    chrome_binary: str | None = None,
-    keep_open: bool = False,
-) -> int:
-    """Alias kept for CLI back-compat. CDP is no longer used."""
-    del chrome_binary, keep_open
-    return login_nlm(
-        user_data_dir,
-        state_file=default_state_file(user_data_dir.parent.parent),
-        timeout_sec=timeout_sec,
-        stable_hold_sec=stable_hold_sec,
-    )
-
-
-def login_interactive(
-    user_data_dir: Path,
-    *,
-    use_system_chrome: bool = False,
-    timeout_sec: int = 300,
-    stable_hold_sec: int = 5,
-    from_chrome_profile: bool = False,
-    chrome_profile_path=None,
-    chrome_profile_name: str = "Default",
-) -> int:
-    """Alias kept for CLI back-compat."""
-    del use_system_chrome, from_chrome_profile, chrome_profile_path, chrome_profile_name
-    return login_nlm(
-        user_data_dir,
-        state_file=default_state_file(user_data_dir.parent.parent),
-        timeout_sec=timeout_sec,
-        stable_hold_sec=stable_hold_sec,
-    )
-
-
 def check_session_health(state_file: Path) -> dict[str, Any]:
     """Return ``ok``, ``reason``, and ``expires_at`` for a storage state."""
     state_file = Path(state_file)
@@ -127,10 +89,13 @@ def require_session_health(state_file: Path) -> None:
     if health.get("ok"):
         return
     reason = str(health.get("reason") or "auth invalid")
+    from research_hub._invocation import recommended_cli_invocation
+
+    command = f"{recommended_cli_invocation()} notebooklm login"
     raise RequiresAuthRefresh(
         service="NotebookLM",
-        fix_command="python -m research_hub notebooklm login",
-        message=f"NotebookLM session check failed: {reason}. Run: python -m research_hub notebooklm login",
+        fix_command=command,
+        message=f"NotebookLM session check failed: {reason}. Run: {command}",
     )
 
 
@@ -215,7 +180,7 @@ def login_from_browser(
     Requires ``rookiepy`` to be installed: ``pip install 'research-hub[browser-auth]'``.
 
     Precedence (in CLI dispatch):
-        --import-from > --from-browser > interactive (--cdp / default)
+        --import-from > --from-browser > interactive default
 
     Args:
         state_file: Path where the storage state JSON will be written.

--- a/src/research_hub/notebooklm/keepalive.py
+++ b/src/research_hub/notebooklm/keepalive.py
@@ -31,6 +31,8 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from research_hub._invocation import recommended_cli_invocation
+
 if TYPE_CHECKING:
     pass
 
@@ -101,7 +103,7 @@ def keepalive_once(cfg: Any) -> int:
     1. Resolve the state file from *cfg*.
     2. ``check_session_health`` — if the session is revoked, print an actionable
        WARN and return 1 (non-zero so schedulers surface the failure; never raise).
-    3. If healthy, call ``rotate_and_persist_session`` and return 0 on success.
+    3. If healthy, call ``rotate_and_persist_session`` and re-probe before success.
 
     Args:
         cfg: A ``HubConfig``-like object exposing ``research_hub_dir: Path``.
@@ -115,19 +117,32 @@ def keepalive_once(cfg: Any) -> int:
             default_state_file,
         )
 
+        inv = recommended_cli_invocation()
         state_file = default_state_file(cfg.research_hub_dir)
         health = check_session_health(state_file)
         if not health.get("ok"):
             reason = health.get("reason", "unknown")
             print(
                 f"[nlm-keepalive] WARN NLM session revoked server-side "
-                f"(reason: {reason}) — run: research-hub notebooklm login --from-browser",
+                f"(reason: {reason}) -- run: {inv} notebooklm login",
                 file=sys.stderr,
             )
             return 1
 
         ok = rotate_and_persist_session(state_file)
-        return 0 if ok else 1
+        if not ok:
+            return 1
+
+        post_health = check_session_health(state_file)
+        if not post_health.get("ok"):
+            print(
+                "[nlm-keepalive] WARN keepalive: cookies rotated but session is "
+                "no longer valid (likely server-side re-auth required); "
+                f"run {inv} notebooklm login",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
     except Exception as exc:  # noqa: BLE001
         print(
             f"[nlm-keepalive] WARN keepalive_once failed unexpectedly "
@@ -189,7 +204,7 @@ def _resolve_task_command(cfg: Any) -> tuple[str, Path | None]:
 
     Strategy
     --------
-    1. If ``shutil.which("research-hub")`` finds an installed console-script,
+    1. If the recommended invocation is the installed console-script,
        use it directly.  No wrapper file is needed.
     2. Otherwise (source checkout): derive the repo root from this module's
        location (``parents[3]``), validate it, write a ``.cmd`` wrapper that
@@ -205,8 +220,9 @@ def _resolve_task_command(cfg: Any) -> tuple[str, Path | None]:
         *wrapper_path_or_None* is the ``.cmd`` path that will be/was written,
         or ``None`` when the console-script path is used.
     """
-    console_script = shutil.which("research-hub")
-    if console_script:
+    invocation = recommended_cli_invocation()
+    if invocation == "research-hub":
+        console_script = shutil.which("research-hub") or "research-hub"
         # Installed path — run directly; no wrapper needed.
         task_cmd = f'"{console_script}" notebooklm keepalive'
         return task_cmd, None

--- a/src/research_hub/search/arxiv_backend.py
+++ b/src/research_hub/search/arxiv_backend.py
@@ -140,6 +140,7 @@ class ArxivBackend:
                 if name
             ],
             venue="arXiv",
+            doc_type="preprint",
             url=paper_url or "",
             citation_count=0,
             pdf_url=f"https://arxiv.org/pdf/{arxiv_id}.pdf",

--- a/src/research_hub/search/fallback.py
+++ b/src/research_hub/search/fallback.py
@@ -44,6 +44,15 @@ _BACKEND_REGISTRY: dict[str, type[SearchBackend]] = {
 }
 
 DEFAULT_BACKENDS = ("openalex", "arxiv", "semantic-scholar", "crossref", "dblp")
+PREPRINT_BACKENDS = ("arxiv", "biorxiv", "chemrxiv", "medrxiv")
+GRAY_DOC_TYPES = (
+    "preprint",
+    "posted-content",
+    "report",
+    "book-chapter",
+    "paratext",
+    "dataset",
+)
 
 FIELD_PRESETS: dict[str, tuple[str, ...]] = {
     "cs": ("openalex", "arxiv", "semantic-scholar", "dblp", "crossref"),
@@ -77,6 +86,24 @@ REGION_PRESETS: dict[str, tuple[str, ...]] = {
     "kr": ("openalex", "kci", "crossref"),
     "cjk": ("openalex", "cinii", "kci", "crossref"),
 }
+
+
+def apply_peer_reviewed(
+    backends: Sequence[str],
+    exclude_types: Sequence[str],
+    min_confidence: float,
+) -> tuple[tuple[str, ...], tuple[str, ...], float]:
+    """Return (backends, exclude_types, min_confidence) hardened to peer-reviewed-only.
+
+    Drops preprint-only backends, adds gray-literature doc types to
+    exclude_types, and floors min_confidence at 0.5.
+    """
+    backend_tuple = tuple(backends)
+    hardened_backends = tuple(
+        backend for backend in backend_tuple if backend not in PREPRINT_BACKENDS
+    ) or backend_tuple
+    hardened_exclude_types = tuple(dict.fromkeys((*exclude_types, *GRAY_DOC_TYPES)))
+    return hardened_backends, hardened_exclude_types, max(min_confidence, 0.5)
 
 
 def resolve_backends_for_field(field: str) -> tuple[str, ...]:

--- a/tests/test_cli_notebooklm.py
+++ b/tests/test_cli_notebooklm.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 # ---------------------------------------------------------------------------
 # Regression tests for the __main__ guard bug:
@@ -137,6 +139,27 @@ def test_notebooklm_login_does_not_silently_succeed_without_invoking_subprocess(
         "login_nlm was never called. The CLI returned exit 0 without invoking the "
         "upstream login subprocess — this is the silent-no-op regression."
     )
+
+
+def test_notebooklm_login_help_hides_dead_flags_keeps_real_paths(capsys):
+    from research_hub.cli import build_parser
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_parser().parse_args(["notebooklm", "login", "--help"])
+
+    assert exc_info.value.code == 0
+    help_text = capsys.readouterr().out
+    for removed in ("--cdp", "--from-chrome-profile", "--keep-open", "--timeout"):
+        assert removed not in help_text
+    assert "--import-from" in help_text
+    assert "--from-browser" in help_text
+
+
+def test_notebooklm_login_rejects_removed_cdp_flag():
+    from research_hub.cli import build_parser
+
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["notebooklm", "login", "--cdp"])
 
 
 def test_build_parser_accepts_notebooklm_upload_and_generate_flags():

--- a/tests/test_v046_auto.py
+++ b/tests/test_v046_auto.py
@@ -187,7 +187,8 @@ def test_auto_nlm_failure_does_not_abort_pipeline(mock_deps, capsys):
     mock_deps["registry_instance"].get.return_value = MagicMock()
     mock_deps["upload_cluster"].side_effect = RuntimeError("login expired")
 
-    with patch("research_hub.auto._run_crystal_step") as mock_crystals:
+    with patch("research_hub.auto._run_crystal_step") as mock_crystals, \
+         patch("research_hub.auto.recommended_cli_invocation", return_value="research-hub"):
         report = auto_pipeline(
             topic="NLM Deferred Topic",
             do_nlm=True,

--- a/tests/test_v070_1_nlm_session_management.py
+++ b/tests/test_v070_1_nlm_session_management.py
@@ -206,7 +206,7 @@ def test_preflight_nlm_session_returns_exit_code_when_not_logged_in(tmp_path, ca
     assert rc == 1
     captured = capsys.readouterr()
     assert "session check failed" in captured.err
-    assert "research-hub notebooklm login" in captured.err
+    assert "notebooklm login" in captured.err
 
 
 def test_preflight_nlm_session_returns_none_when_logged_in(tmp_path):

--- a/tests/test_v0950_nlm_keepalive_and_browser_login.py
+++ b/tests/test_v0950_nlm_keepalive_and_browser_login.py
@@ -36,7 +36,7 @@ Coverage plan:
        E1. bare --from-browser → args.from_browser=='auto', login_from_browser(browser=None)
        E2. --from-browser chrome → login_from_browser(browser='chrome')
        E3. rc propagated from login_from_browser
-       E4. --from-browser takes precedence over interactive branches
+       E4. --from-browser takes precedence over default interactive login
        E5. --import-from takes precedence over --from-browser
        E6. rookiepy-missing (rc!=0) → actionable message printed
 """
@@ -260,7 +260,46 @@ class TestKeepaliveOnce:
         assert "revoked" in captured.err or "WARN" in captured.err, (
             f"Expected WARN in stderr; got: {captured.err!r}"
         )
-        assert "login --from-browser" in captured.err
+        assert "notebooklm login" in captured.err
+
+    def test_post_rotation_probe_failure_warns_returns_nonzero(
+        self, tmp_path: Path, monkeypatch, capsys
+    ):
+        """B3: rotation success but post-probe not-ok returns non-zero and warns."""
+        cfg = _make_cfg(tmp_path)
+        sf = _write_state(tmp_path)
+        health_results = [
+            {"ok": True, "reason": "ok"},
+            {"ok": False, "reason": "auth invalid"},
+        ]
+        rotate_calls: list = []
+
+        import research_hub.notebooklm.auth as rh_auth
+        monkeypatch.setattr(
+            rh_auth,
+            "check_session_health",
+            lambda path: health_results.pop(0),
+        )
+        monkeypatch.setattr(
+            rh_auth,
+            "default_state_file",
+            lambda research_hub_dir: sf,
+        )
+
+        import research_hub.notebooklm.keepalive as ka_mod
+        monkeypatch.setattr(
+            ka_mod,
+            "rotate_and_persist_session",
+            lambda state_file: (rotate_calls.append(state_file), True)[1],
+        )
+
+        rc = ka_mod.keepalive_once(cfg)
+
+        assert rc != 0
+        assert rotate_calls == [sf]
+        captured = capsys.readouterr()
+        assert "cookies rotated" in captured.err
+        assert "notebooklm login" in captured.err
 
 
 # ---------------------------------------------------------------------------
@@ -752,17 +791,16 @@ class TestCLIFromBrowser:
 
         assert rc == 1
 
-    def test_from_browser_takes_precedence_over_interactive(
+    def test_from_browser_takes_precedence_over_interactive_default(
         self, tmp_path: Path, monkeypatch
     ):
-        """E4: --from-browser takes precedence over --cdp / default interactive path."""
+        """E4: --from-browser takes precedence over default interactive path."""
         cfg = _make_cfg(tmp_path)
         monkeypatch.setattr("research_hub.cli.get_config", lambda: cfg)
 
         import research_hub.notebooklm.auth as rh_auth
         from_browser_calls: list = []
         login_nlm_calls: list = []
-        login_cdp_calls: list = []
 
         monkeypatch.setattr(
             rh_auth,
@@ -774,19 +812,12 @@ class TestCLIFromBrowser:
             "login_nlm",
             lambda *a, **kw: (login_nlm_calls.append(True), 0)[1],
         )
-        monkeypatch.setattr(
-            rh_auth,
-            "login_interactive_cdp",
-            lambda *a, **kw: (login_cdp_calls.append(True), 0)[1],
-        )
 
         from research_hub import cli
-        # Even with --cdp, --from-browser should win
-        rc = cli.main(["notebooklm", "login", "--from-browser", "--cdp"])
+        rc = cli.main(["notebooklm", "login", "--from-browser"])
 
         assert from_browser_calls, "--from-browser must have been called"
         assert not login_nlm_calls, "login_nlm must NOT be called when --from-browser is set"
-        assert not login_cdp_calls, "login_cdp must NOT be called when --from-browser is set"
 
     def test_import_from_takes_precedence_over_from_browser(
         self, tmp_path: Path, monkeypatch

--- a/tests/test_v1_cli_invocation.py
+++ b/tests/test_v1_cli_invocation.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def test_recommended_cli_invocation_uses_module_form_when_console_missing(monkeypatch):
+    from research_hub._invocation import recommended_cli_invocation
+
+    monkeypatch.setattr("research_hub._invocation.shutil.which", lambda _name: None)
+
+    assert recommended_cli_invocation() == f"{sys.executable} -m research_hub"
+
+
+def test_recommended_cli_invocation_uses_console_script_when_present(monkeypatch):
+    from research_hub._invocation import recommended_cli_invocation
+
+    monkeypatch.setattr(
+        "research_hub._invocation.shutil.which",
+        lambda name: "/x/research-hub" if name == "research-hub" else None,
+    )
+
+    assert recommended_cli_invocation() == "research-hub"
+
+
+def test_requires_auth_refresh_uses_recommended_invocation(monkeypatch, tmp_path):
+    from research_hub.errors import RequiresAuthRefresh
+    from research_hub.notebooklm.auth import require_session_health
+
+    monkeypatch.setattr("research_hub._invocation.shutil.which", lambda _name: None)
+
+    with pytest.raises(RequiresAuthRefresh) as exc_info:
+        require_session_health(tmp_path / "missing-state.json")
+
+    command = exc_info.value.next_steps[0]
+    assert "notebooklm login" in command
+    assert not command.startswith("python -m research_hub")

--- a/tests/test_v1_f7_doi_resolver.py
+++ b/tests/test_v1_f7_doi_resolver.py
@@ -1,0 +1,94 @@
+"""F7 regression: DOI resolver must send a real User-Agent and must not
+fail-closed-quarantine (or cache) a valid paper on a transient
+rate-limit / anti-bot block.
+
+Root cause (verified 2026-05-18): the resolver used ``requests.head``
+with the default ``python-requests`` UA. doi.org / Cloudflare answer
+that bot fingerprint with HTTP 418, which the gate read as
+``doi_unresolved`` and fail-closed-quarantined EVERY valid paper. A real
+UA makes the same DOI return 200.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import research_hub.authenticity as auth
+from research_hub.authenticity import (
+    DoiResolveCache,
+    _resolve_head_with_retry,
+    _resolve_identifier,
+)
+
+
+class _Resp:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry backoff must not slow the suite."""
+    monkeypatch.setattr(auth.time, "sleep", lambda *_a, **_k: None)
+
+
+def test_resolver_sends_real_user_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict = {}
+
+    def fake_head(url, **kwargs):
+        seen.update(kwargs)
+        return _Resp(200)
+
+    monkeypatch.setattr(auth.requests, "head", fake_head)
+    status, transient = _resolve_head_with_retry("https://doi.org/10.1/x")
+    assert status == 200 and transient is False
+    ua = seen.get("headers", {}).get("User-Agent", "")
+    assert ua and "python-requests" not in ua  # the whole point of F7
+
+
+def test_http_418_is_transient_not_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(418))
+    status, transient = _resolve_head_with_retry("https://doi.org/10.1/x", attempts=2)
+    assert status == 418 and transient is True
+
+
+def test_404_stays_permanent_failclosed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(404))
+    status, transient = _resolve_head_with_retry("https://doi.org/10.1/x")
+    assert status == 404 and transient is False  # 404 != fake-bot block
+
+
+def test_transient_then_success_recovers(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = [_Resp(429), _Resp(429), _Resp(200)]
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: calls.pop(0))
+    status, transient = _resolve_head_with_retry("https://doi.org/10.1/x", attempts=3)
+    assert status == 200 and transient is False
+
+
+def test_transient_outcome_is_not_cached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 418 blip must NOT be cached as a permanent miss — a later run
+    (e.g. after the UA fix takes effect / rate-limit lifts) must retry."""
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(418))
+    cache_path = tmp_path / "doi_resolve_cache.json"
+    cache = DoiResolveCache.load(cache_path)
+    paper = {"doi": "10.1109/access.2025.3548451", "title": "valid IEEE paper"}
+    outcome = _resolve_identifier(paper, cache, cache_path)
+    assert outcome.ok is False
+    assert outcome.reason == "doi_check_unavailable"  # NOT doi_unresolved
+    # nothing persisted: a fresh cache load sees no entry for this key
+    assert DoiResolveCache.load(cache_path).get(outcome.key) is None
+
+
+def test_real_404_is_cached_and_failclosed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Anti-fabrication preserved: a genuine 404 is still ok=False,
+    reason=doi_unresolved, and cached."""
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(404))
+    cache_path = tmp_path / "doi_resolve_cache.json"
+    cache = DoiResolveCache.load(cache_path)
+    paper = {"doi": "10.9999/does-not-exist", "title": "fake"}
+    outcome = _resolve_identifier(paper, cache, cache_path)
+    assert outcome.ok is False
+    assert outcome.reason == "doi_unresolved"
+    assert DoiResolveCache.load(cache_path).get(outcome.key) is not None

--- a/tests/test_v1_peer_reviewed_filter.py
+++ b/tests/test_v1_peer_reviewed_filter.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from types import SimpleNamespace
+
+from research_hub.search._rank import apply_filters
+from research_hub.search.arxiv_backend import ArxivBackend
+from research_hub.search.base import SearchResult
+from research_hub.search.fallback import GRAY_DOC_TYPES, apply_peer_reviewed
+
+
+def test_arxiv_parse_entry_marks_preprint():
+    xml = """
+    <entry xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+      <id>http://arxiv.org/abs/2411.12345v1</id>
+      <published>2024-01-02T00:00:00Z</published>
+      <title>LLM agent benchmark</title>
+      <summary>Evaluation of agent systems</summary>
+      <author><name>Jane Doe</name></author>
+    </entry>
+    """
+    entry = ET.fromstring(xml)
+
+    result = ArxivBackend(delay_seconds=0)._parse_entry(entry)
+
+    assert result is not None
+    assert result.doc_type == "preprint"
+
+
+def test_apply_peer_reviewed_drops_preprint_backends_and_hardens_filters():
+    backends, exclude_types, min_confidence = apply_peer_reviewed(
+        ("arxiv", "openalex", "crossref"),
+        (),
+        0.0,
+    )
+
+    assert set(backends).isdisjoint({"arxiv", "biorxiv", "chemrxiv", "medrxiv"})
+    assert set(GRAY_DOC_TYPES).issubset(set(exclude_types))
+    assert min_confidence == 0.5
+
+
+def test_apply_peer_reviewed_keeps_original_when_all_backends_would_drop():
+    backends, exclude_types, min_confidence = apply_peer_reviewed(("arxiv",), (), 0.0)
+
+    assert backends == ("arxiv",)
+    assert set(GRAY_DOC_TYPES).issubset(set(exclude_types))
+    assert min_confidence == 0.5
+
+
+def test_apply_filters_drops_arxiv_preprint_when_excluded():
+    result = SearchResult(
+        title="Arxiv preprint",
+        arxiv_id="2411.12345",
+        source="arxiv",
+        doc_type="preprint",
+    )
+
+    assert apply_filters([result], exclude_types=("preprint",)) == []
+
+
+def test_cli_search_peer_reviewed_hardens_dispatch(monkeypatch):
+    from research_hub.cli import main
+
+    captured = {}
+
+    def fake_search(query, limit, verify=False, **kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("research_hub.cli.get_config", lambda: object())
+    monkeypatch.setattr("research_hub.cli._search", fake_search)
+
+    assert main(["search", "llm", "--backend", "arxiv,openalex", "--peer-reviewed"]) == 0
+
+    assert captured["backends"] == ("openalex",)
+    assert "preprint" in captured["exclude_types"]
+    assert captured["min_confidence"] == 0.5
+
+
+def test_auto_peer_reviewed_dry_run_plan_shows_hardened_backends(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    from research_hub import auto as auto_mod
+
+    cfg = SimpleNamespace(
+        clusters_file=tmp_path / "clusters.json",
+        research_hub_dir=tmp_path / ".research_hub",
+    )
+    cfg.research_hub_dir.mkdir()
+    registry = SimpleNamespace(get=lambda _slug: None)
+
+    monkeypatch.setattr(auto_mod, "get_config", lambda: cfg)
+    monkeypatch.setattr(auto_mod, "ClusterRegistry", lambda _path: registry)
+    monkeypatch.setattr(auto_mod, "detect_llm_cli", lambda: "claude")
+
+    report = auto_mod.auto_pipeline(
+        "llm agents",
+        dry_run=True,
+        peer_reviewed=True,
+        print_progress=True,
+        do_nlm=False,
+    )
+
+    assert report.ok
+    output = capsys.readouterr().out
+    assert "backends=semantic-scholar+openalex+crossref" in output
+    assert "arxiv+semantic-scholar" not in output


### PR DESCRIPTION
## Why

Pre-test audit of the fetch→Zotero→Obsidian→NotebookLM pipeline found
5 process flaws (F1–F5) blocking/undermining the "fetch correctly, no
gray literature, record everywhere" guarantee. The post-fix E2E sandbox
test then surfaced **F7** — a 1-line blocker that made ingest
non-functional under doi.org rate-limiting — folded in here (minimal)
per maintainer decision because it gated the project's core goal.

## What's in this PR

**F1** — removed 8 silently-no-op `notebooklm login` flags
(`--cdp/--from-chrome-profile/--use-system-chrome/--chrome-*/--keep-open/--timeout`)
+ dead aliases; honest 3-path help.
**F2** — actionable Python≥3.14 + rookiepy-missing message; new
`doctor` check `nlm_auth_paths`.
**F3** — `recommended_cli_invocation()`; self-heal commands now
environment-correct (console-script vs `python -m research_hub`),
wired into NLM preflight / `RequiresAuthRefresh` / keepalive / auto.
**F4** — `arxiv_backend` sets `doc_type="preprint"`; `apply_peer_reviewed()`
+ `--peer-reviewed` on `search` and `auto` (closes auto's zero-filter
gap). E2E: gray literature **7 → 0**.
**F5** — `keepalive` re-probes session health *after* rotation
(kills false-green).
**F7 (minimal)** — DOI resolver sent the default `python-requests` UA;
doi.org/Cloudflare answer 418 → gate read `doi_unresolved` →
fail-closed-quarantined **every** valid paper. Now sends a real UA;
408/418/425/429/5xx + network errors are transient (bounded retry,
not cached); genuine 404/410 stay fail-closed (anti-fabrication L0–L5
unchanged).

## Verification

- `code-reviewer` subagent: **APPROVE** ×2 (F1–F5 diff; F7 security path).
- pytest: F1–F5 → 2680 passed / 0 failed; F7 → 34/34 authenticity +
  L5 anti-fabrication gate intact; full-suite re-run in progress.
- **E2E 4-leg** (sandbox cluster, cleaned up): fetch peer-reviewed
  0-gray ✅ · Zotero 2 created ✅ · Obsidian 2 created ✅ ·
  NLM ⚠️ notebook created but **0 sources** — NotebookLM API drift in
  the upstream `notebooklm` package (**F8, external — not this PR**).

## Out of scope → tracked follow-up PR

F6 (auto's false `[OK] ingest N` count), deeper F7 (defer-queue vs
quarantine on sustained transient), F8 (NotebookLM upstream API drift),
auto-detect NLM login (no-ENTER). No version bump (not a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)