### PR TITLE
fix(zotero): gc no longer presents non-empty real collections as deletable (PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,19 @@ graph rebuild (link out to the real tools instead)._
   `--timeout`, and the unused `login_interactive` /
   `login_interactive_cdp` aliases they delegated to.
 
+### Fixed (PR-A)
+- **`zotero gc` no longer presents non-empty real collections as
+  deletion candidates.** Any Zotero collection whose key was not a
+  *current* cluster binding was flagged `orphan-from-vault` — including
+  stale non-empty date-prefixed duplicate collections holding real
+  items. `delete_candidates` already hard-skipped non-empty collections
+  (so no data could actually be lost), but the **output falsely implied
+  a data-loss risk**, eroding trust in the tool. Now: non-empty orphans
+  get a distinct `orphan-with-items(N)` reason, are listed under a
+  separate "NON-EMPTY ORPHANS — review only; gc cannot delete these"
+  section, are never offered in the interactive prompt, and are
+  excluded from `--yes`. Empty/test junk GC is unchanged.
+
 ## v1.0.0 (PENDING — tag on/after 2026-05-24, post ≥1-week v0.95.0rc2 bake)
 
 > **Not yet released — staged on `release-prep/v1.0.0`.** The cut

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -1674,6 +1674,7 @@ def _zotero_mark_kept(
 
     cfg = get_config()
     from research_hub.zotero.gc import (
+        is_orphan_candidate,
         kept_file_path,
         load_kept_keys,
         lookup_collection_names_and_counts,
@@ -1743,7 +1744,12 @@ def _zotero_mark_kept(
             age_days=30,
             kept_keys=set(),
         )
-        new_keys = {c.key for c in candidates if "orphan-from-vault" in c.reasons}
+        # PR-A: include BOTH orphan reasons. A non-empty orphan
+        # (`orphan-with-items(N)`) is exactly the real-data collection a
+        # user most wants `--all-orphans` to protect from future gc noise;
+        # keying on the bare "orphan-from-vault" string would silently drop
+        # it now that the reason is split.
+        new_keys = {c.key for c in candidates if is_orphan_candidate(c)}
         merged = current | new_keys
         save_kept_keys(cfg.research_hub_dir, merged, note=note)
         added = len(merged) - len(current)
@@ -1926,33 +1932,68 @@ def _zotero_gc(
         print("No Zotero GC candidates found.")
         return 0
 
+    def _is_non_empty(c) -> bool:
+        return c.num_items > 0 or c.num_collections > 0
+
+    junk = [c for c in candidates if not _is_non_empty(c)]
+    non_empty = [c for c in candidates if _is_non_empty(c)]
+
+    def _print_rows(rows) -> None:
+        for candidate in rows:
+            print(
+                f"{candidate.key}\t{candidate.name}\t{candidate.num_items}\t"
+                f"{candidate.num_collections}\t{', '.join(candidate.reasons)}"
+            )
+
     print("key\tname\titems\tsubcollections\treasons")
-    for candidate in candidates:
+    _print_rows(junk)
+    if non_empty:
+        print("")
         print(
-            f"{candidate.key}\t{candidate.name}\t{candidate.num_items}\t"
-            f"{candidate.num_collections}\t{', '.join(candidate.reasons)}"
+            f"-- NON-EMPTY ORPHANS ({len(non_empty)}) -- review only; gc "
+            f"CANNOT delete these (hard-skipped at the delete layer). If "
+            f"they are stale duplicates, reconcile via cluster rebind/merge --"
         )
+        _print_rows(non_empty)
     if not apply:
         print("")
         print("Preview only. Re-run with --apply to delete candidates.")
         return 0
 
-    selected = list(candidates)
+    # `delete_candidates` already hard-skips any non-empty collection
+    # (gc.py). PR-A makes that pre-existing guarantee *honest* at the
+    # selection layer too: non-empty orphans are never even offered for
+    # deletion (no misleading "type name to delete" prompt that the
+    # delete layer would then refuse) — they are listed for review only.
+    # Reuse the partition computed above for the grouped display.
+    non_empty_skipped = len(non_empty)
+    deletable = junk
+
     if not yes:
         kept: list = []
-        for candidate in candidates:
-            answer = input(f"Delete {candidate.name} ({candidate.key})? [y/N] ").strip().lower()
+        for candidate in deletable:
+            answer = input(
+                f"Delete {candidate.name} ({candidate.key})? [y/N] "
+            ).strip().lower()
             if answer in {"y", "yes"}:
                 kept.append(candidate)
         selected = kept
     else:
+        # --yes auto-selects only safe junk: empty + test-pattern +
+        # orphan-from-vault, all three (on the already non-empty-filtered set).
         selected = [
             candidate
-            for candidate in candidates
+            for candidate in deletable
             if any(reason.startswith("empty>") for reason in candidate.reasons)
             and any(reason.startswith("test-pattern(") for reason in candidate.reasons)
             and "orphan-from-vault" in candidate.reasons
         ]
+    if non_empty_skipped:
+        print(
+            f"Skipped {non_empty_skipped} non-empty orphan(s) -- gc cannot "
+            f"delete these (hard-skipped at the delete layer). Reconcile via "
+            f"cluster rebind/merge if they are stale duplicates."
+        )
     results = delete_candidates(zot, selected)
     ok_count = sum(1 for status in results.values() if status == "ok")
     print(f"Deleted {ok_count}/{len(selected)} collection(s).")

--- a/src/research_hub/zotero/gc.py
+++ b/src/research_hub/zotero/gc.py
@@ -134,8 +134,17 @@ def scan_zotero_for_gc(
                     # User explicitly marked this collection as kept; skip the
                     # orphan flag so it never appears as a gc candidate.
                     pass
-                else:
+                elif num_items == 0 and num_collections == 0:
+                    # Empty orphan — safe junk, eligible for --yes auto-GC
+                    # (only together with empty>Nd + test-pattern).
                     reasons.append("orphan-from-vault")
+                else:
+                    # PR-A: a non-empty orphan holds real items/subcollections
+                    # (e.g. a stale date-prefixed duplicate from an earlier
+                    # pipeline run). It must NEVER be auto-deleted by --yes and
+                    # must require a strong, item-count-aware confirm. Distinct
+                    # reason keeps it out of the --yes (orphan-from-vault) set.
+                    reasons.append(f"orphan-with-items({num_items})")
 
             if reasons:
                 out.append(
@@ -188,6 +197,20 @@ def lookup_collection_names_and_counts(zot, keys: Iterable[str]) -> dict[str, di
             break
         start += 200
     return out
+
+
+def is_orphan_candidate(candidate: GCCandidate) -> bool:
+    """True if the candidate is an orphan (not bound to any cluster),
+    whether empty (`orphan-from-vault`) or non-empty
+    (`orphan-with-items(N)`). PR-A split the reason in two; any site that
+    used to key on ``"orphan-from-vault"`` to mean "is an orphan" (e.g.
+    ``mark-kept --all-orphans``) must use this so non-empty orphans —
+    exactly the real-data collections users most want to protect — are
+    not silently dropped.
+    """
+    return "orphan-from-vault" in candidate.reasons or any(
+        reason.startswith("orphan-with-items(") for reason in candidate.reasons
+    )
 
 
 def delete_candidates(zot, candidates: Iterable[GCCandidate]) -> dict[str, str]:

--- a/tests/test_v075_zotero_gc.py
+++ b/tests/test_v075_zotero_gc.py
@@ -72,13 +72,18 @@ def test_scan_zotero_for_gc_skips_recent_empty_collection():
     assert candidates == [GCCandidate(key="A1", name="fresh-empty", num_items=0, num_collections=0, date_added="2026-04-25T00:00:00Z", reasons=["orphan-from-vault"])]
 
 
-def test_scan_zotero_for_gc_marks_orphan_without_test_pattern():
+def test_scan_zotero_for_gc_marks_non_empty_orphan_distinctly():
+    # PR-A: a non-empty orphan (4 real items) must NOT be the plain
+    # `orphan-from-vault` reason (which --yes can auto-delete together with
+    # empty+test) — it gets the distinct `orphan-with-items(N)` reason so it
+    # is never auto-deleted and triggers a strong confirm.
     zot = _ZotCollections([_collection("A1", "survey", num_items=4)])
 
     candidates = scan_zotero_for_gc(zot, set())
 
     assert len(candidates) == 1
-    assert candidates[0].reasons == ["orphan-from-vault"]
+    assert candidates[0].reasons == ["orphan-with-items(4)"]
+    assert "orphan-from-vault" not in candidates[0].reasons
 
 
 def test_delete_candidates_returns_ok_and_error():

--- a/tests/test_v087_zotero_kept.py
+++ b/tests/test_v087_zotero_kept.py
@@ -74,7 +74,8 @@ def test_scan_with_kept_keys_excludes_them_from_orphan_results() -> None:
         ("KEEPME", "Risk perception", 44, 0),
         ("DROPME", "scratch-collection", 0, 0),
     ])
-    # Without kept_keys, both show up as orphan-from-vault
+    # Without kept_keys, both are orphans (KEEPME non-empty ->
+    # orphan-with-items(44); DROPME empty -> orphan-from-vault)
     candidates = scan_zotero_for_gc(zot, vault_keys=set())
     assert {c.key for c in candidates} == {"KEEPME", "DROPME"}
 

--- a/tests/test_v1_gc_nonempty_orphan_safety.py
+++ b/tests/test_v1_gc_nonempty_orphan_safety.py
@@ -1,0 +1,165 @@
+"""PR-A: `zotero gc` must never auto-delete (or one-keypress-delete) a
+non-empty orphan collection.
+
+Root cause: gc flagged ANY collection whose key is not a current cluster
+binding as `orphan-from-vault`, including stale non-empty date-prefixed
+duplicate collections holding real items — making the output falsely
+imply a data-loss risk (although `delete_candidates` already hard-skips
+non-empty collections, so none could actually be deleted). Fix:
+non-empty orphans get the distinct `orphan-with-items(N)` reason, are
+listed under a separate review-only section, are excluded from `--yes`,
+and are never offered in the interactive prompt at all. `mark-kept
+--all-orphans` still captures them (both orphan reasons).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from research_hub import cli
+from research_hub.clusters import ClusterRegistry
+from research_hub.zotero.gc import scan_zotero_for_gc
+
+
+def _collection(key, name, *, num_items=0, num_collections=0,
+                 date_added="2025-01-01T00:00:00Z") -> dict:
+    return {
+        "key": key,
+        "data": {"key": key, "name": name, "dateAdded": date_added},
+        "meta": {"numItems": num_items, "numCollections": num_collections},
+    }
+
+
+class _Zot:
+    def __init__(self, collections):
+        self._c = collections
+        self.deleted: list[str] = []
+
+    def collections(self, *, limit=200, start=0):
+        return self._c[start:start + limit]
+
+    def collection(self, key):
+        return {"key": key, "data": {"key": key}}
+
+    def delete_collection(self, coll):
+        self.deleted.append(coll["key"])
+        return {}
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "vault"
+    rh = root / ".research_hub"
+    (root / "raw").mkdir(parents=True)
+    rh.mkdir(parents=True)
+    return SimpleNamespace(
+        root=root, raw=root / "raw", hub=root / "hub",
+        research_hub_dir=rh, clusters_file=rh / "clusters.yaml",
+    )
+
+
+# ---- classification ----
+
+def test_empty_orphan_still_orphan_from_vault():
+    """Regression: safe junk path unchanged — empty orphan keeps the
+    `orphan-from-vault` reason so --yes can still GC real junk."""
+    zot = _Zot([_collection("E1", "old-empty")])
+    c = scan_zotero_for_gc(zot, set())
+    assert len(c) == 1
+    assert "orphan-from-vault" in c[0].reasons
+
+
+def test_non_empty_orphan_gets_distinct_reason():
+    zot = _Zot([_collection("N1", "20260518-flood-forecas", num_items=37)])
+    c = scan_zotero_for_gc(zot, set())
+    assert c[0].reasons == ["orphan-with-items(37)"]
+    assert "orphan-from-vault" not in c[0].reasons
+
+
+def test_orphan_with_only_subcollections_is_non_empty():
+    zot = _Zot([_collection("S1", "parent", num_items=0, num_collections=3)])
+    c = scan_zotero_for_gc(zot, set())
+    assert c[0].reasons == ["orphan-with-items(0)"]
+    assert "orphan-from-vault" not in c[0].reasons
+
+
+# ---- --yes never deletes a non-empty orphan ----
+
+def test_yes_excludes_non_empty_orphan(tmp_path, monkeypatch, capsys):
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="live", name="Live", slug="live")
+    registry.bind("live", zotero_collection_key="LIVE1", sync_zotero=False)
+    zot = _Zot([
+        _collection("DEL1", "test-topic"),                        # empty+test+orphan
+        _collection("BIG1", "20260518-flood", num_items=37),      # non-empty orphan
+    ])
+    monkeypatch.setattr(cli, "get_config", lambda: cfg)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: zot)
+
+    rc = cli.main(["zotero", "gc", "--apply", "--yes"])
+
+    assert rc == 0
+    assert zot.deleted == ["DEL1"]            # BIG1 never auto-deleted
+    out = capsys.readouterr().out
+    assert "Skipped 1 non-empty orphan" in out
+
+
+# ---- interactive: non-empty orphan is never offered for deletion ----
+
+def test_interactive_non_empty_never_offered(tmp_path, monkeypatch, capsys):
+    """A non-empty orphan is listed for review only — never prompted,
+    never deleted, regardless of what the user types. (delete_candidates
+    also hard-skips it, so even a forced selection is refused.)"""
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="live", name="Live", slug="live")
+    registry.bind("live", zotero_collection_key="LIVE1", sync_zotero=False)
+    zot = _Zot([_collection("BIG1", "20260518-flood", num_items=37)])
+    monkeypatch.setattr(cli, "get_config", lambda: cfg)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: zot)
+    # Even "yes" to every prompt cannot delete it (it is never prompted).
+    monkeypatch.setattr("builtins.input", lambda *_a, **_k: "yes")
+
+    assert cli.main(["zotero", "gc", "--apply"]) == 0
+    assert zot.deleted == []
+    assert "Skipped 1 non-empty orphan" in capsys.readouterr().out
+
+
+def test_mark_kept_all_orphans_captures_non_empty(tmp_path, monkeypatch):
+    """Regression for the cross-site contract break: splitting the orphan
+    reason must NOT make `mark-kept --all-orphans` silently drop
+    non-empty orphans (the real-data collections users most want kept)."""
+    from research_hub.zotero.gc import load_kept_keys
+
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="live", name="Live", slug="live")
+    registry.bind("live", zotero_collection_key="LIVE1", sync_zotero=False)
+    zot = _Zot([
+        _collection("EMPTY1", "old-empty"),                    # empty orphan
+        _collection("BIG1", "20260518-flood", num_items=37),   # non-empty orphan
+    ])
+    monkeypatch.setattr(cli, "get_config", lambda: cfg)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: zot)
+
+    assert cli.main(["zotero", "mark-kept", "--all-orphans"]) == 0
+    kept = load_kept_keys(cfg.research_hub_dir)
+    assert "BIG1" in kept          # the whole point — was silently dropped
+    assert "EMPTY1" in kept
+
+
+def test_interactive_empty_still_simple_yes(tmp_path, monkeypatch):
+    cfg = _cfg(tmp_path)
+    registry = ClusterRegistry(cfg.clusters_file)
+    registry.create(query="live", name="Live", slug="live")
+    registry.bind("live", zotero_collection_key="LIVE1", sync_zotero=False)
+    zot = _Zot([_collection("DEL1", "test-topic")])  # empty+test+orphan
+    monkeypatch.setattr(cli, "get_config", lambda: cfg)
+    monkeypatch.setattr("research_hub.zotero.client.get_client", lambda: zot)
+    monkeypatch.setattr("builtins.input", lambda *_a, **_k: "y")
+
+    assert cli.main(["zotero", "gc", "--apply"]) == 0
+    assert zot.deleted == ["DEL1"]            # empty junk still 1-key delete


### PR DESCRIPTION
## Why (honest framing)

While testing the merged pipeline, `zotero gc` listed stale non-empty
date-prefixed duplicate collections (37/20/17 real items) as
`orphan-from-vault` deletion candidates. **`delete_candidates` already
hard-skips any non-empty collection — no data could ever be lost.** The
defect was purely that the *output* falsely implied a data-loss risk,
eroding trust. This PR makes the output honest; it does not add safety
that was missing (it wasn't).

## Changes

- `gc.py`: orphan reason split — empty → `orphan-from-vault`
  (unchanged, `--yes`-eligible with empty>+test); non-empty →
  `orphan-with-items(N)`. New `is_orphan_candidate()` shared predicate.
- `cli.py _zotero_gc`: single reused partition; non-empty orphans under
  a separate "NON-EMPTY ORPHANS — review only; gc CANNOT delete these"
  section, never offered interactively, excluded from `--yes`.
  Empty/test junk GC byte-for-byte unchanged.
- `cli.py mark-kept --all-orphans`: keys on `is_orphan_candidate()` so
  non-empty orphans aren't silently dropped from the kept file
  (code-reviewer P0; regression-tested).

## Verification

- `code-reviewer` subagent: REQUEST CHANGES (2 P0) → fixed → re-review **APPROVE**.
- Full suite **2693 passed, 0 failed**.
- 7 new tests in `tests/test_v1_gc_nonempty_orphan_safety.py`; existing
  gc/kept tests updated (one assertion encoded the old bug).

Part of the safety-first follow-up series (PR-A). PR-B (F6+F8), PR-C
(deep F7), PR-D (auto-detect login) to follow. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)