### PR TITLE
fix(auto,nlm): F6 honest ingest count + F8 0-source upload error (PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,26 @@ graph rebuild (link out to the real tools instead)._
   section, are never offered in the interactive prompt, and are
   excluded from `--yes`. Empty/test junk GC is unchanged.
 
+### Fixed (PR-B)
+- **F6: `auto` no longer prints `[OK] ingest N papers` when 0 were
+  written.** When every candidate was quarantined by the fail-closed
+  authenticity gate the raw dir was never created, the `exists()` guard
+  was skipped, and the tentative `len(papers)` count survived — the
+  pipeline reported a clean ingest of N papers while the vault got
+  nothing. The count is now authoritative (`0` when nothing written);
+  an all-quarantined ingest is reported as a failed step with an
+  actionable `quarantine list` hint, not `[OK]`. A 0-written /
+  0-quarantined result (e.g. empty search) keeps the lenient path with
+  an honest `N written, M quarantined (of K candidates)` message.
+- **F8: `notebooklm upload` no longer exits 0 when 0 sources were
+  transferred.** When NotebookLM's source API drifts under the pinned
+  `notebooklm-py` (e.g. `Sources data ... is not a list (NoneType)`)
+  the notebook is created but no sources land; the old code returned 0
+  because `fail_count == 0`. A non-dry-run upload that transfers,
+  caches, and prunes nothing is now a non-zero error naming the likely
+  cause. (`notebooklm-py` was already pinned `<0.5.0`; this drift is
+  server-side, so honest reporting is the only available remedy.)
+
 ## v1.0.0 (PENDING — tag on/after 2026-05-24, post ≥1-week v0.95.0rc2 bake)
 
 > **Not yet released — staged on `release-prep/v1.0.0`.** The cut

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -372,12 +372,42 @@ def auto_pipeline(
         rc = run_pipeline(**run_kwargs)
         if rc != 0:
             raise RuntimeError("pipeline returned exit code " + str(rc))        
-        # Count actual ingested files (anything in raw/<slug>/ now)
+        # F6: the count must be authoritative. Previously, when EVERY
+        # candidate was quarantined the raw dir was never created, the
+        # `exists()` guard was skipped, and the tentative `len(papers)`
+        # survived -> `[OK] ingest N papers` printed despite 0 written.
         raw_dir = cfg.raw / slug
-        if raw_dir.exists():
-            report.papers_ingested = len(list(raw_dir.glob("*.md")))
-        _step_log(report, "ingest", True, _elapsed(started, report),
-                  f"{report.papers_ingested} papers in raw/{slug}/", print_progress)
+        attempted = report.papers_ingested  # tentative len(papers)
+        written = len(list(raw_dir.glob("*.md"))) if raw_dir.exists() else 0
+        report.papers_ingested = written
+        try:
+            from research_hub.authenticity import list_quarantine
+            quarantined = len(list_quarantine(cfg, cluster=slug))
+        except Exception:
+            quarantined = 0
+        detail = (
+            f"{written} written, {quarantined} quarantined "
+            f"(of {attempted} candidate(s)) in raw/{slug}/"
+        )
+        # F6: candidates existed but the vault got nothing (all rejected
+        # by fit-check / the fail-closed authenticity gate). Render the
+        # ingest step as [FAIL] with an honest count + actionable hint so
+        # it can never read as `[OK] ingest N papers` again. We do NOT
+        # flip report.ok / abort: quarantine-of-all is the safety gate
+        # working as designed, not an orchestration crash, and the
+        # end-of-run quarantine summary (more actionable) still prints.
+        ingest_ok = not (written == 0 and attempted > 0)
+        if ingest_ok:
+            _step_log(report, "ingest", True, _elapsed(started, report),
+                      detail, print_progress)
+        else:
+            _step_log(report, "ingest", False, _elapsed(started, report),
+                      detail + " -- nothing reached the vault", print_progress)
+            report.error = (
+                f"ingest wrote 0 papers ({quarantined} quarantined of "
+                f"{attempted}); inspect: research-hub quarantine list "
+                f"--cluster {slug}"
+            )
     except Exception as exc:
         _step_log(report, "ingest", False, _elapsed(started, report), str(exc), print_progress)
         report.ok = False

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -3876,6 +3876,28 @@ def _nlm_upload(
         print(f"  [{status}] {result.source_kind}: {result.path_or_url}")
         if result.error:
             print(f"       {result.error}")
+    # F8: a non-dry-run upload that transferred, cached, and pruned
+    # *nothing* is not a success. This is the symptom of NotebookLM's
+    # source API drifting under the pinned upstream `notebooklm-py`
+    # (e.g. "Sources data ... is not a list (NoneType)") — the notebook
+    # gets created but 0 sources land, and the old code returned 0.
+    if (
+        not report.dry_run
+        and report.fail_count == 0
+        and report.success_count == 0
+        and report.skipped_already_uploaded == 0
+        and not report.over_cap_skipped
+    ):
+        print(
+            "ERROR: 0 sources uploaded, cached, or pruned. Either the "
+            "cluster bundle was empty, or NotebookLM's source API changed "
+            "and the pinned `notebooklm-py` could not transfer sources "
+            "(see any 'Sources data ... is not a list' warning above). "
+            "The notebook may exist but holds no sources -- not a clean "
+            "upload.",
+            file=sys.stderr,
+        )
+        return 1
     return 0 if report.fail_count == 0 else 1
 
 

--- a/src/research_hub/mcp_server.py
+++ b/src/research_hub/mcp_server.py
@@ -2544,7 +2544,14 @@ def auto_research_topic(
             "brief_path": str(report.brief_path) if report.brief_path else None,
             "total_duration_sec": report.total_duration_sec,
             "steps": [{"name": s.name, "ok": s.ok, "detail": s.detail} for s in report.steps],
-            "error": report.error if not report.ok else "",
+            # PR-B: surface report.error unconditionally. Path B keeps
+            # report.ok=True on an all-quarantined run (the safety gate
+            # working) but sets report.error with the quarantine hint;
+            # gating on `not report.ok` hid that from MCP agent callers,
+            # who would see {ok:true, papers_ingested:0, error:""} —
+            # indistinguishable from a clean 0-result. report.error is ""
+            # on genuinely clean runs, so this is safe.
+            "error": report.error,
         }
     except Exception as exc:
         return {"ok": False, "error": str(exc)}

--- a/tests/test_v047_mcp_lazy.py
+++ b/tests/test_v047_mcp_lazy.py
@@ -62,6 +62,35 @@ def test_auto_research_topic_failure(monkeypatch):
     assert "0 papers" in result["error"]
 
 
+def test_auto_research_topic_all_quarantined_surfaces_error(monkeypatch):
+    """PR-B path B: an all-quarantined run keeps ok=True (safety gate
+    working) but MUST surface report.error to MCP agent callers — gating
+    the error field on `not ok` hid the quarantine warning, making it
+    indistinguishable from a clean 0-result."""
+    from research_hub import mcp_server as m
+    from research_hub.auto import AutoReport, AutoStepResult
+
+    monkeypatch.setattr(
+        "research_hub.auto.auto_pipeline",
+        lambda topic, **kw: AutoReport(
+            cluster_slug="x", cluster_created=True, ok=True,
+            papers_ingested=0,
+            error=("ingest wrote 0 papers (2 quarantined of 2); inspect: "
+                   "research-hub quarantine list --cluster x"),
+            steps=[AutoStepResult(name="ingest", ok=False,
+                                  detail="0 written, 2 quarantined")],
+        ),
+    )
+    from tests._mcp_helpers import _get_mcp_tool
+
+    tool = _get_mcp_tool(m.mcp, "auto_research_topic")
+    result = tool.fn(topic="all quarantined topic")
+    assert result["ok"] is True
+    assert result["papers_ingested"] == 0
+    assert "quarantine list" in result["error"]      # the PR-B fix
+    assert result["steps"][0]["ok"] is False
+
+
 def test_cleanup_garbage_dry_run(monkeypatch):
     from research_hub import mcp_server as m
 

--- a/tests/test_v070_auto_fit_check.py
+++ b/tests/test_v070_auto_fit_check.py
@@ -242,7 +242,10 @@ def test_auto_pipeline_runs_fit_check_by_default(mock_auto_deps, monkeypatch):
     )
 
     assert report.ok
-    assert report.papers_ingested == 1  # filtered down from 3
+    # PR-B: authoritative count — run_pipeline mocked (writes 0 files) so
+    # papers_ingested is 0. The fit-check 3->1 filtering is asserted via
+    # the fit_check step below, not via this (now write-truthful) counter.
+    assert report.papers_ingested == 0
     fit_steps = [s for s in report.steps if s.name == "fit_check"]
     assert len(fit_steps) == 1
     assert "kept 1/3" in fit_steps[0].detail
@@ -262,7 +265,9 @@ def test_auto_pipeline_skips_fit_check_when_disabled(mock_auto_deps, monkeypatch
     )
 
     assert report.ok
-    assert report.papers_ingested == 2
+    # PR-B: authoritative count. run_pipeline is mocked so it writes no
+    # files -> 0 written (was the old buggy tentative len(papers)==2).
+    assert report.papers_ingested == 0
     assert all(s.name != "fit_check" for s in report.steps)
     assert invoked == []  # LLM never invoked
 
@@ -297,6 +302,8 @@ def test_auto_pipeline_fit_check_threshold_param_propagates(mock_auto_deps, monk
         "topic", do_nlm=False, fit_check_threshold=2, print_progress=False,
     )
 
-    assert report.papers_ingested == 2
+    # PR-B: authoritative count. run_pipeline is mocked so it writes no
+    # files -> 0 written (was the old buggy tentative len(papers)==2).
+    assert report.papers_ingested == 0
     fit_step = [s for s in report.steps if s.name == "fit_check"][0]
     assert "threshold=2" in fit_step.detail

--- a/tests/test_v1_ingest_nlm_reporting_honesty.py
+++ b/tests/test_v1_ingest_nlm_reporting_honesty.py
@@ -1,0 +1,138 @@
+"""PR-B regression: ingest + NLM upload must report honestly.
+
+F6: `auto` printed `[OK] ingest N papers` when EVERY candidate was
+quarantined (raw dir never created -> the `exists()` guard skipped ->
+the tentative `len(papers)` count survived). Now the count is
+authoritative and a 0-written ingest is NOT rendered as a clean step.
+
+F8: `notebooklm upload` returned exit 0 when the NotebookLM source API
+drifted and 0 sources were transferred/cached/pruned (notebook created
+but empty). Now that is a non-zero error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from research_hub.auto import auto_pipeline
+from research_hub.notebooklm.upload import UploadReport, UploadResult
+
+
+# --------------------------------------------------------------------------
+# F6 — honest ingest count
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def auto_env(tmp_path):
+    """auto_pipeline with a REAL raw dir so the F6 count logic runs for
+    real, and list_quarantine/run_pipeline/_run_search mocked."""
+    raw = tmp_path / "raw"
+    raw.mkdir()
+    cfg = MagicMock()
+    cfg.raw = raw
+    cfg.root = tmp_path
+    cfg.research_hub_dir = tmp_path / ".research_hub"
+    with patch("research_hub.auto.get_config", return_value=cfg), \
+         patch("research_hub.auto.ClusterRegistry") as reg, \
+         patch("research_hub.auto.run_pipeline", return_value=0), \
+         patch("research_hub.auto._run_search",
+               return_value=[{"title": "P1"}, {"title": "P2"}]), \
+         patch("research_hub.auto._run_fit_check_step",
+               side_effect=lambda cfg, papers, *a, **k: papers), \
+         patch("research_hub.auto.detect_llm_cli", return_value="claude"), \
+         patch("research_hub.authenticity.list_quarantine") as lq:
+        reg.return_value = MagicMock()
+        yield SimpleNamespace(cfg=cfg, raw=raw, list_quarantine=lq, registry=reg)
+
+
+def _ingest_step(report):
+    return next(s for s in report.steps if s.name == "ingest")
+
+
+def test_f6_all_quarantined_is_not_ok(auto_env):
+    # raw dir stays empty (run_pipeline mocked, writes nothing) and both
+    # candidates are "quarantined".
+    auto_env.list_quarantine.return_value = [{"slug": "p1"}, {"slug": "p2"}]
+
+    report = auto_pipeline(topic="t", do_nlm=False, do_fit_check=False,
+                           print_progress=False)
+
+    assert report.papers_ingested == 0          # NOT the tentative 2
+    step = _ingest_step(report)
+    assert step.ok is False                      # renders [FAIL], not [OK]
+    assert "0 written" in step.detail
+    assert "2 quarantined" in step.detail
+    assert "quarantine list" in (report.error or "")
+    # path B: quarantine-of-all is the safety gate working, not an
+    # orchestration crash — report.ok is intentionally NOT flipped so
+    # the end-of-run quarantine summary still runs.
+    assert report.ok is True
+
+
+def test_f6_partial_write_counts_truthfully(auto_env):
+    # one paper actually written, one quarantined
+    (auto_env.raw / "t").mkdir(parents=True)
+    (auto_env.raw / "t" / "p1.md").write_text("x", encoding="utf-8")
+    auto_env.list_quarantine.return_value = [{"slug": "p2"}]
+
+    report = auto_pipeline(topic="t", do_nlm=False, do_fit_check=False,
+                           print_progress=False)
+
+    assert report.papers_ingested == 1
+    step = _ingest_step(report)
+    assert step.ok is True
+    assert "1 written" in step.detail
+    assert "1 quarantined" in step.detail
+
+
+# --------------------------------------------------------------------------
+# F8 — NLM upload that transfers nothing is not a success
+# --------------------------------------------------------------------------
+
+def _run_nlm_upload(monkeypatch, report: UploadReport):
+    from research_hub import cli
+
+    monkeypatch.setattr(cli, "get_config", lambda: MagicMock())
+    monkeypatch.setattr(cli, "ClusterRegistry", lambda *_a, **_k: MagicMock(
+        get=lambda *_: MagicMock()))
+    monkeypatch.setattr(
+        "research_hub.notebooklm.upload.upload_cluster",
+        lambda *a, **k: report,
+    )
+    monkeypatch.setattr(
+        "research_hub.notebooklm.upload.check_cluster_capacity",
+        lambda *a, **k: None,
+    )
+    # bypass the NLM session preflight (F3) — not under test here
+    monkeypatch.setattr(cli, "_preflight_nlm_session", lambda *a, **k: None)
+    return cli._nlm_upload(
+        "c", dry_run=False, headless=True, create_if_missing=True,
+    )
+
+
+def test_f8_nothing_transferred_is_error(monkeypatch, capsys):
+    report = UploadReport(cluster_slug="c", notebook_url="http://nb",
+                          uploaded=[], skipped_already_uploaded=0)
+    rc = _run_nlm_upload(monkeypatch, report)
+    assert rc == 1
+    assert "0 sources uploaded" in capsys.readouterr().err
+
+
+def test_f8_real_upload_still_succeeds(monkeypatch):
+    report = UploadReport(
+        cluster_slug="c",
+        uploaded=[UploadResult(success=True, source_kind="url",
+                               path_or_url="http://x")],
+    )
+    assert _run_nlm_upload(monkeypatch, report) == 0
+
+
+def test_f8_cache_only_upload_is_success(monkeypatch):
+    # nothing newly uploaded but everything was already cached -> fine
+    report = UploadReport(cluster_slug="c", uploaded=[],
+                          skipped_already_uploaded=3)
+    assert _run_nlm_upload(monkeypatch, report) == 0


### PR DESCRIPTION
## Why

Two reporting-honesty defects found during the post-merge E2E test.

**F6** — `auto` printed `[OK] ingest N papers` when every candidate was
quarantined (all-quarantined → raw dir never created → `exists()` guard
skipped → tentative `len(papers)` survived). **F8** — `notebooklm
upload` returned exit 0 when NotebookLM's source API drifted and 0
sources transferred (notebook created but empty).

## Changes

- **F6** (`auto.py`): authoritative `papers_ingested` (filesystem
  truth, 0 when nothing written); ingest step renders `[FAIL] N
  written, M quarantined (of K)` + actionable `quarantine list` hint.
  Path B: does NOT flip `report.ok`/abort (quarantine-of-all is the
  safety gate working; the quarantine summary still prints).
- **F8** (`cli.py _nlm_upload`): a non-dry-run upload that transfers,
  caches, and prunes nothing is now a non-zero error naming the cause.
- **MCP contract** (`mcp_server.py`): `error` surfaced unconditionally
  so agent callers see the quarantine hint under path B (was hidden).

## Verification

- `code-reviewer` subagent: **3 rounds** — 2× REQUEST CHANGES (prior
  fix re-broke 6 tests → redesigned to path B; F8 `fail_count` guard;
  MCP P1) → all resolved → approvable.
- Full suite **2699 passed, 0 failed**.
- New `tests/test_v1_ingest_nlm_reporting_honesty.py` + MCP path test;
  `test_v070_auto_fit_check` assertions corrected (encoded old bug).

PR-B of the safety-first follow-up series. PR-C (deep F7 defer), PR-D
(auto-detect login) to follow. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)