### PR TITLE
fix(authenticity): deep F7 — transient DOI failures defer, not quarantine (PR-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,27 @@ graph rebuild (link out to the real tools instead)._
   cause. (`notebooklm-py` was already pinned `<0.5.0`; this drift is
   server-side, so honest reporting is the only available remedy.)
 
+### Fixed (PR-C — deep F7)
+- **Transient DOI-resolution failures defer instead of being
+  fail-closed-quarantined as fraud.** PR-B's minimal F7 fix stopped the
+  *cache* poisoning but the authenticity gate still quarantined ANY
+  `not ok` at L1 — including `*_check_unavailable` (doi.org / Crossref
+  rate-limit or network blip after the bounded retry). A sustained
+  rate-limit window therefore still rejected valid papers, requiring
+  manual `quarantine restore`. Now the L1 branch splits by reason
+  family: transient → distinct `L1-deferred` layer (reported as
+  "deferred, retryable"; recovers on a later run / `quarantine
+  restore`); permanent (`*_unresolved`, 404/410, no-identifier,
+  predatory/metadata/fit/uncorroborated) → unchanged `L1` quarantine.
+  The paper is still held out of ingest in both cases (fail-closed —
+  the anti-fabrication L0–L5 guarantee is unchanged; a fabricated DOI
+  returns 404 → permanent → quarantined). `auto` now reports
+  `N quarantined, D deferred` distinctly, and an all-deferred run says
+  the papers were *not* rejected and how to retry, instead of
+  "quarantined". (An optional `quarantine retry-deferred` convenience
+  CLI is deferred to a later follow-up — existing `quarantine restore`
+  already recovers deferred entries.)
+
 ## v1.0.0 (PENDING — tag on/after 2026-05-24, post ≥1-week v0.95.0rc2 bake)
 
 > **Not yet released — staged on `release-prep/v1.0.0`.** The cut

--- a/docs/authenticity.md
+++ b/docs/authenticity.md
@@ -35,7 +35,7 @@ Zotero); L2 is a provenance *label*, not a gate.
 | Layer | Check | On fail |
 |---|---|---|
 | **L0** provenance | Has at least one identifier (DOI / arXiv / PMID / OpenAlex) | quarantine `no_identifier` |
-| **L1** resolution | `doi.org` HEAD (or arXiv/PMID resolver) returns `<400`. Network error / timeout is **fail-closed** — never assumed valid | quarantine `doi_unresolved` / `doi_check_unavailable` |
+| **L1** resolution | `doi.org` HEAD (real User-Agent, bounded retry) or arXiv/PMID resolver returns `<400`. Still **fail-closed** — never assumed valid | **permanent** (404/410 → `*_unresolved`): quarantine `L1`. **transient** (rate-limit/unreachable after retry → `*_check_unavailable`): layer `L1-deferred` — *not rejected*, recovers on re-run / `quarantine restore` |
 | **L2** corroboration | Cross-backend agreement on title/author/year | **label only** — single-source-but-resolvable is real and is **not** quarantined; recorded as `single-source` vs `corroborated` |
 | **L3** integrity | Authors not truncated/anonymous, no mojibake, plausible year, venue sanity | quarantine `metadata_invalid` |
 | **L4** relevance | `fit_check` LLM-judge score ≥ threshold. **Fail-closed:** no judge available ⇒ quarantine, never keep-all | quarantine `relevance_unjudged` / `low_relevance` |

--- a/src/research_hub/authenticity.py
+++ b/src/research_hub/authenticity.py
@@ -34,6 +34,15 @@ except ImportError:  # pragma: no cover - rapidfuzz is a declared dependency
 SCHEMA_VERSION = "1.0"
 DOI_RESOLVE_CACHE = "doi_resolve_cache.json"
 QUARANTINE_DIR = "quarantine"
+# PR-C (deep F7): a TRANSIENT identifier-resolution failure (doi.org /
+# Crossref rate-limit or network blip, after PR-B's bounded retry) is
+# NOT evidence the paper is fake. It is still held out of ingest
+# (fail-closed — we could not verify), but recorded under this distinct
+# layer so it is reported as "deferred (retryable)" rather than
+# "quarantined (rejected)", and recovers on a later run / `quarantine
+# restore` once the resolver is reachable. Permanent failures
+# (`*_unresolved`, 404/410) keep layer "L1" — anti-fabrication unchanged.
+DEFERRED_LAYER = "L1-deferred"
 _KNOWN_VENUE_STRAGGLERS = {"arxiv", "open mind"}
 _LLM_UNJUDGED_REASONS = {"relevance_unjudged"}
 
@@ -158,13 +167,17 @@ def verify_authenticity(
 
             outcome = _resolve_identifier(paper, cache, cache_path)
             if not outcome.ok:
+                reason = outcome.reason or "doi_unresolved"
+                # Transient (rate-limit / unreachable after retry) ->
+                # deferred-retryable; permanent (404/410, no id) -> L1.
+                layer = DEFERRED_LAYER if is_transient_reason(reason) else "L1"
                 quarantined.append(
                     quarantine_paper(
                         cfg,
                         paper,
                         cluster_slug=cluster_slug,
-                        layer="L1",
-                        reason=outcome.reason or "doi_unresolved",
+                        layer=layer,
+                        reason=reason,
                         details={
                             "status_code": outcome.status_code,
                             "url": outcome.url,
@@ -537,6 +550,18 @@ def _unavailable_reason_for(source: str) -> str:
     if source == "arxiv.org":
         return "arxiv_check_unavailable"
     return "identifier_check_unavailable"
+
+
+def is_transient_reason(reason: str) -> bool:
+    """True for a transient identifier-resolution failure (the
+    `*_check_unavailable` family emitted by ``_unavailable_reason_for``
+    when the resolver was rate-limited / unreachable AFTER PR-B's
+    bounded retry). Permanent failures (`*_unresolved`, `no_identifier`,
+    predatory/metadata/fit/uncorroborated) are NOT transient and stay
+    fail-closed-quarantined. Keyed on the canonical suffix so it stays
+    correct if new sources are added to ``_unavailable_reason_for``.
+    """
+    return reason.endswith("_check_unavailable")
 
 
 def _metadata_integrity_reason(paper: dict) -> str:

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -381,13 +381,16 @@ def auto_pipeline(
         written = len(list(raw_dir.glob("*.md"))) if raw_dir.exists() else 0
         report.papers_ingested = written
         try:
-            from research_hub.authenticity import list_quarantine
-            quarantined = len(list_quarantine(cfg, cluster=slug))
+            from research_hub.authenticity import DEFERRED_LAYER, list_quarantine
+            q_rows = list_quarantine(cfg, cluster=slug)
+            deferred = sum(1 for r in q_rows if r.get("layer") == DEFERRED_LAYER)
+            quarantined = len(q_rows) - deferred
         except Exception:
+            deferred = 0
             quarantined = 0
         detail = (
-            f"{written} written, {quarantined} quarantined "
-            f"(of {attempted} candidate(s)) in raw/{slug}/"
+            f"{written} written, {quarantined} quarantined, "
+            f"{deferred} deferred (of {attempted} candidate(s)) in raw/{slug}/"
         )
         # F6: candidates existed but the vault got nothing (all rejected
         # by fit-check / the fail-closed authenticity gate). Render the
@@ -403,11 +406,22 @@ def auto_pipeline(
         else:
             _step_log(report, "ingest", False, _elapsed(started, report),
                       detail + " -- nothing reached the vault", print_progress)
-            report.error = (
-                f"ingest wrote 0 papers ({quarantined} quarantined of "
-                f"{attempted}); inspect: research-hub quarantine list "
-                f"--cluster {slug}"
-            )
+            if deferred and not quarantined:
+                # Pure transient failure (doi.org / Crossref rate-limit):
+                # the papers are NOT rejected — retry once the resolver
+                # is reachable (re-run, or `quarantine restore`).
+                report.error = (
+                    f"ingest wrote 0 papers; {deferred} deferred "
+                    f"(transient resolver failure -- not rejected; retry: "
+                    f"re-run, or research-hub quarantine restore "
+                    f"<paper-slug> --cluster {slug})"
+                )
+            else:
+                report.error = (
+                    f"ingest wrote 0 papers ({quarantined} quarantined, "
+                    f"{deferred} deferred of {attempted}); inspect: "
+                    f"research-hub quarantine list --cluster {slug}"
+                )
     except Exception as exc:
         _step_log(report, "ingest", False, _elapsed(started, report), str(exc), print_progress)
         report.ok = False
@@ -705,21 +719,40 @@ def _print_next_steps(report: AutoReport, slug: str, cfg, *, do_crystals: bool) 
     try:
         from collections import Counter
 
-        from research_hub.authenticity import list_quarantine
+        from research_hub.authenticity import DEFERRED_LAYER, list_quarantine
 
         q_rows = list_quarantine(cfg, cluster=slug)
     except Exception as exc:  # best-effort UX affordance; never fatal
         q_rows = []
+        DEFERRED_LAYER = "L1-deferred"
         print(f"  [quarantine] summary unavailable for {slug} ({type(exc).__name__})")
     if q_rows:
-        by_reason = Counter((r.get("reason") or "unknown") for r in q_rows)
+        # PR-C: keep this footer consistent with the ingest step — show
+        # deferred (transient, retryable) distinctly from quarantined
+        # (rejected by the fail-closed gate), not lumped as "quarantined".
+        deferred_rows = [r for r in q_rows if r.get("layer") == DEFERRED_LAYER]
+        quar_rows = [r for r in q_rows if r.get("layer") != DEFERRED_LAYER]
         print()
-        print(
-            f"  [quarantine] {len(q_rows)} paper(s) currently quarantined for "
-            f"cluster {slug} (fail-closed authenticity gate; not in the vault):"
-        )
-        for reason, count in sorted(by_reason.items()):
-            print(f"    - {reason}: {count}")
+        if quar_rows:
+            print(
+                f"  [quarantine] {len(quar_rows)} paper(s) quarantined for "
+                f"cluster {slug} (fail-closed authenticity gate; not in the "
+                f"vault):"
+            )
+            for reason, count in sorted(
+                Counter((r.get("reason") or "unknown") for r in quar_rows).items()
+            ):
+                print(f"    - {reason}: {count}")
+        if deferred_rows:
+            print(
+                f"  [deferred] {len(deferred_rows)} paper(s) NOT rejected -- "
+                f"transient resolver failure (rate-limit/unreachable); "
+                f"retryable for cluster {slug}:"
+            )
+            for reason, count in sorted(
+                Counter((r.get("reason") or "unknown") for r in deferred_rows).items()
+            ):
+                print(f"    - {reason}: {count}")
         print("  Review / recover:")
         print(f"    research-hub quarantine list --cluster {slug}")
         print(f"    research-hub quarantine show <paper-slug> --cluster {slug}")

--- a/tests/test_v1_f7_defer_transient.py
+++ b/tests/test_v1_f7_defer_transient.py
@@ -1,0 +1,110 @@
+"""PR-C (deep F7): a TRANSIENT identifier-resolution failure (doi.org /
+Crossref rate-limit, after PR-B's bounded retry) is recorded under the
+distinct `L1-deferred` layer (reported as "deferred, retryable"), NOT
+the plain `L1` quarantine (reported as "rejected"). Permanent failures
+(404/410 -> `*_unresolved`) stay `L1` — the anti-fabrication guarantee
+is unchanged. In both cases the paper is still held out of ingest
+(fail-closed); only the classification/labelling differs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import research_hub.authenticity as auth
+from research_hub.authenticity import (
+    DEFERRED_LAYER,
+    is_transient_reason,
+    verify_authenticity,
+)
+
+
+class _Response:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "vault"
+    rh = root / ".research_hub"
+    rh.mkdir(parents=True)
+    return SimpleNamespace(research_hub_dir=rh)
+
+
+def _paper(doi: str = "10.1000/real") -> dict:
+    return {"title": "A Real Paper", "doi": doi, "abstract": "x" * 80}
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(auth.time, "sleep", lambda *_a, **_k: None)
+
+
+# ---- unit: classifier ----
+
+@pytest.mark.parametrize("reason,expected", [
+    ("doi_check_unavailable", True),
+    ("arxiv_check_unavailable", True),
+    ("identifier_check_unavailable", True),
+    ("doi_unresolved", False),
+    ("arxiv_unresolved", False),
+    ("no_identifier", False),
+    ("predatory_venue", False),
+    ("", False),
+])
+def test_is_transient_reason(reason, expected):
+    assert is_transient_reason(reason) is expected
+
+
+# ---- gate: transient -> deferred, permanent -> L1 ----
+
+def test_transient_418_is_deferred_not_quarantined(tmp_path, monkeypatch):
+    # doi.org 418 (anti-bot) persists through PR-B's bounded retry ->
+    # transient -> ok=False reason=doi_check_unavailable.
+    monkeypatch.setattr("research_hub.authenticity.requests.head",
+                        lambda *a, **k: _Response(418))
+    accepted, quarantined = verify_authenticity(
+        [_paper(doi="10.1109/access.2025.3548451")], _cfg(tmp_path),
+        cluster_slug="c",
+    )
+    assert accepted == []                       # still held out (fail-closed)
+    assert len(quarantined) == 1
+    assert quarantined[0]["layer"] == DEFERRED_LAYER
+    assert quarantined[0]["reason"] == "doi_check_unavailable"
+
+
+def test_permanent_404_stays_L1_quarantine(tmp_path, monkeypatch):
+    # Anti-fabrication regression guard: a genuine 404 is NOT transient
+    # and must remain a plain L1 quarantine, exactly as before PR-C.
+    monkeypatch.setattr("research_hub.authenticity.requests.head",
+                        lambda *a, **k: _Response(404))
+    accepted, quarantined = verify_authenticity(
+        [_paper(doi="10.9999/does-not-exist")], _cfg(tmp_path),
+        cluster_slug="c",
+    )
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["layer"] == "L1"
+    assert quarantined[0]["reason"] == "doi_unresolved"
+    assert quarantined[0]["layer"] != DEFERRED_LAYER
+
+
+def test_mixed_batch_splits_transient_and_permanent(tmp_path, monkeypatch):
+    """One transient (418) + one permanent (404) in the same batch:
+    both held out of ingest, but recorded under the correct layers."""
+    def fake_head(url, **kwargs):
+        return _Response(418 if "transient" in url else 404)
+
+    monkeypatch.setattr("research_hub.authenticity.requests.head", fake_head)
+    accepted, quarantined = verify_authenticity(
+        [_paper(doi="10.1/transient-blocked"),
+         _paper(doi="10.9/permanent-missing")],
+        _cfg(tmp_path), cluster_slug="c",
+    )
+    assert accepted == []
+    by_slug = {q["reason"]: q["layer"] for q in quarantined}
+    assert by_slug["doi_check_unavailable"] == DEFERRED_LAYER
+    assert by_slug["doi_unresolved"] == "L1"


### PR DESCRIPTION
## Why

PR-B's minimal F7 stopped DOI-resolve cache poisoning, but the
authenticity gate still quarantined ANY `not outcome.ok` at L1 —
including transient `*_check_unavailable` (doi.org/Crossref rate-limit
after the bounded retry). A sustained rate-limit window still rejected
**valid** papers, requiring manual `quarantine restore`.

## Changes

- `authenticity.py`: `DEFERRED_LAYER` + `is_transient_reason()`; L1
  branch routes **transient → `L1-deferred`** (not rejected, retryable),
  **permanent (`*_unresolved`/404/410) → `L1`** unchanged. Papers are
  still held out of ingest in both cases (fail-closed).
- `auto.py`: ingest detail + footer report `quarantined` vs `deferred`
  distinctly & consistently; all-deferred run says "not rejected; retry".
- `docs/authenticity.md` L1 row updated.

**Anti-fabrication preserved:** a fabricated DOI returns 404 → permanent
→ quarantined, never deferred, never accepted. No paper is accepted
that wasn't before — only the *label* of transient failures changes.

## Verification

- `code-reviewer` subagent: **APPROVE** — explicitly verified the
  anti-fabrication invariant is preserved; W1/W2/S2/S3 polish applied.
- Full suite **2710 passed, 0 failed**. L5 invariant + corroboration
  gate intact.
- New `tests/test_v1_f7_defer_transient.py` (incl. 404→L1
  anti-fabrication regression guard + mixed batch).

PR-C of the safety-first series. `quarantine retry-deferred` CLI
deferred to an optional follow-up (`quarantine restore` already
recovers). PR-D (auto-detect login) next. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)