### PR TITLE
feat(nlm): notebooklm login --wait-file — non-interactive login, no ENTER (PR-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,19 @@ graph rebuild (link out to the real tools instead)._
   CLI is deferred to a later follow-up — existing `quarantine restore`
   already recovers deferred entries.)
 
+### Added (PR-D)
+- **`notebooklm login --wait-file PATH` — non-interactive login (no
+  terminal/ENTER).** The upstream login blocks on `input("press
+  ENTER")`, which can't be driven headless/scripted. With `--wait-file`
+  you sign in in the browser then create PATH (`touch PATH`, or an
+  automation wrapper does it); research-hub polls for it and feeds the
+  newline that triggers the upstream session save. `--wait-timeout`
+  (default 300s) fails closed — on timeout the subprocess is terminated
+  and nothing is saved. Stale signal files are cleared first so a
+  leftover from a previous run can't auto-trigger before sign-in. This
+  formalizes (in Python, testable) the signal-pipe technique used to
+  recover the maintainer's expired session.
+
 ## v1.0.0 (PENDING — tag on/after 2026-05-24, post ≥1-week v0.95.0rc2 bake)
 
 > **Not yet released — staged on `release-prep/v1.0.0`.** The cut

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -6169,7 +6169,8 @@ def build_parser() -> argparse.ArgumentParser:
             "loads); (2) --import-from <other-vault> copies a logged-in session "
             "from another vault; (3) --from-browser [browser] imports cookies via "
             "rookiepy (requires the research-hub[browser-auth] extra; rookiepy has "
-            "no prebuilt wheel for Python 3.14)."
+            "no prebuilt wheel for Python 3.14); (4) --wait-file PATH — sign in "
+            "in the browser then create PATH (no terminal/ENTER; scriptable)."
         ),
         epilog=(
             "Examples:\n"
@@ -6191,6 +6192,23 @@ def build_parser() -> argparse.ArgumentParser:
         "--overwrite",
         action="store_true",
         help="With --import-from: replace the current vault's logged-in session if one exists.",
+    )
+    nlm_login.add_argument(
+        "--wait-file",
+        default=None,
+        metavar="PATH",
+        help="Non-interactive: instead of pressing ENTER, sign in in the "
+             "browser window then create this file (e.g. `touch PATH`, or an "
+             "automation wrapper does it). research-hub polls for it and "
+             "saves the session automatically. No terminal/ENTER needed.",
+    )
+    nlm_login.add_argument(
+        "--wait-timeout",
+        type=int,
+        default=300,
+        metavar="SECONDS",
+        help="With --wait-file: max seconds to wait for the signal file "
+             "before failing closed (default: 300; nothing is saved on timeout).",
     )
     nlm_login.add_argument(
         "--from-browser",
@@ -7498,6 +7516,8 @@ def _main_dispatch(args, parser) -> int:
         return _synthesize(cluster=args.cluster, graph_colors=args.graph_colors)
     if args.command == "notebooklm":
         if args.notebooklm_command == "login":
+            if args.wait_timeout != 300 and args.wait_file is None:
+                parser.error("--wait-timeout requires --wait-file")
             from pathlib import Path as _Path
 
             from research_hub._invocation import recommended_cli_invocation
@@ -7575,6 +7595,8 @@ def _main_dispatch(args, parser) -> int:
             return login_nlm(
                 session_dir,
                 state_file=default_state_file(cfg.research_hub_dir),
+                wait_file=args.wait_file,
+                wait_timeout=args.wait_timeout,
             )
         if args.notebooklm_command == "bundle":
             return _notebooklm_bundle(args.cluster, download_pdfs=args.download_pdfs)

--- a/src/research_hub/notebooklm/auth.py
+++ b/src/research_hub/notebooklm/auth.py
@@ -7,6 +7,7 @@ import inspect
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -55,17 +56,107 @@ def login_nlm(
     headless: bool = False,
     timeout_sec: int = 300,
     stable_hold_sec: int = 5,
+    wait_file: Path | None = None,
+    wait_timeout: int = 300,
 ) -> int:
-    """Open notebooklm-py's one-time login flow and save storage state."""
+    """Open notebooklm-py's one-time login flow and save storage state.
+
+    When *wait_file* is set the interactive ENTER gate is replaced by a
+    file signal (non-interactive); see ``_login_with_wait_file``.
+    """
     del headless, timeout_sec, stable_hold_sec
     target = Path(state_file) if state_file is not None else Path(user_data_dir)
     target.parent.mkdir(parents=True, exist_ok=True)
     cmd = [sys.executable, "-m", "notebooklm.notebooklm_cli", "login", "--storage", str(target)]
-    rc = subprocess.run(cmd, check=False).returncode
+    if wait_file is None:
+        rc = subprocess.run(cmd, check=False).returncode
+    else:
+        rc = _login_with_wait_file(cmd, Path(wait_file), int(wait_timeout), target)
     if rc == 0:
         # G3 P1 #2: tighten newly-created state.json permissions.
         _tighten_state_file_perms(target)
     return rc
+
+
+def _kill_proc(proc) -> None:
+    """terminate -> wait -> kill escalation (POSIX-safe; SIGTERM-ignoring
+    children would otherwise leak/zombie)."""
+    try:
+        proc.terminate()
+    except OSError:
+        return
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+
+def _login_with_wait_file(
+    cmd: list[str],
+    wait_file: Path,
+    wait_timeout: int,
+    state_file: Path,
+) -> int:
+    """Non-interactive login: replace the upstream `input("press ENTER")`
+    gate with a file signal. The user (or an automation wrapper) creates
+    *wait_file* once the NotebookLM homepage has loaded; we then write the
+    newline that triggers the upstream `context.storage_state(...)` save.
+    No terminal / ENTER needed. Fail-closed: if *wait_file* never appears
+    within *wait_timeout* seconds, the subprocess is killed and a
+    non-zero code is returned (nothing is saved)."""
+    # Never inherit a stale signal from a previous run.
+    try:
+        wait_file.unlink()
+    except OSError:
+        pass
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    deadline = time.monotonic() + max(1, wait_timeout)
+    try:
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                # upstream exited on its own (e.g. an error) pre-signal
+                return proc.returncode
+            if wait_file.exists():
+                try:
+                    if proc.stdin is not None:
+                        proc.stdin.write(b"\n")
+                        proc.stdin.flush()
+                        proc.stdin.close()
+                except OSError:
+                    pass
+                try:
+                    return proc.wait(timeout=120)
+                except subprocess.TimeoutExpired:
+                    # The newline was fed and upstream saves storage_state
+                    # BEFORE it exits, so the file may already be written
+                    # with loose perms even though we report failure.
+                    # Tighten defensively (G3 P1 #2 invariant) before
+                    # killing the slow-to-exit process.
+                    try:
+                        _tighten_state_file_perms(state_file)
+                    except Exception:  # noqa: BLE001 - best-effort
+                        pass
+                    _kill_proc(proc)
+                    return 1
+            time.sleep(1.0)
+        # signal never arrived -> fail-closed (nothing saved). Close
+        # stdin first so the upstream read sees a clean EOF.
+        try:
+            if proc.stdin is not None:
+                proc.stdin.close()
+        except OSError:
+            pass
+        _kill_proc(proc)
+        return 124
+    finally:
+        if proc.poll() is None:
+            try:
+                proc.terminate()
+            except OSError:
+                pass
 
 
 def check_session_health(state_file: Path) -> dict[str, Any]:

--- a/tests/test_v1_nlm_login_wait_file.py
+++ b/tests/test_v1_nlm_login_wait_file.py
@@ -1,0 +1,165 @@
+"""PR-D: `notebooklm login --wait-file` — non-interactive login.
+
+Replaces the upstream `input("press ENTER")` gate with a file signal:
+the user signs in in the browser then creates the wait-file (or an
+automation wrapper does); research-hub feeds the newline that triggers
+the upstream storage_state save. Fail-closed on timeout (nothing saved).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import research_hub.notebooklm.auth as auth
+from research_hub.notebooklm.auth import _login_with_wait_file
+
+
+class _Stdin:
+    """Capture stub that survives .close() (real BytesIO does not)."""
+    def __init__(self):
+        self.buf = b""
+    def write(self, b):
+        self.buf += b
+    def flush(self):
+        pass
+    def close(self):
+        pass
+    def getvalue(self):
+        return self.buf
+
+
+class _FakeProc:
+    def __init__(self, *, exits_with=None):
+        self.stdin = _Stdin()
+        self._exits_with = exits_with        # not None -> poll() returns it
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        if self.returncode is not None:        # already exited (real semantics)
+            return self.returncode
+        if self._exits_with is not None:
+            self.returncode = self._exits_with
+            return self._exits_with
+        return None
+
+    def wait(self, timeout=None):
+        self.returncode = 0
+        return 0
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(auth.time, "sleep", lambda *_a, **_k: None)
+
+
+def test_signal_file_triggers_save(tmp_path, monkeypatch):
+    wait_file = tmp_path / "ready"
+    proc = _FakeProc()
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+    # The fn clears any stale signal first, then polls. Simulate the user
+    # creating the file mid-loop: the (mocked) inter-poll sleep touches it.
+    monkeypatch.setattr(auth.time, "sleep",
+                        lambda *_a, **_k: wait_file.write_text("", encoding="utf-8"))
+
+    rc = _login_with_wait_file(["x"], wait_file, wait_timeout=30,
+                               state_file=tmp_path / "s")
+
+    assert rc == 0
+    assert proc.stdin.getvalue() == b"\n"          # ENTER fed programmatically
+    assert not proc.terminated
+
+
+def test_timeout_is_fail_closed(tmp_path, monkeypatch):
+    wait_file = tmp_path / "never"                  # never created
+    proc = _FakeProc()
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+    # deadline calc sees 1000; every subsequent check is past the
+    # deadline. Robust to extra monotonic() calls (no StopIteration).
+    seq = iter([1000.0, 1000.0])
+
+    def _clock():
+        try:
+            return next(seq)
+        except StopIteration:
+            return 9_999.0
+
+    monkeypatch.setattr(auth.time, "monotonic", _clock)
+
+    rc = _login_with_wait_file(["x"], wait_file, wait_timeout=5, state_file=tmp_path / "s")
+
+    assert rc == 124                                # fail-closed sentinel
+    assert proc.terminated
+    assert proc.stdin.getvalue() == b""             # nothing fed -> no save
+
+
+def test_upstream_self_exit_propagates(tmp_path, monkeypatch):
+    wait_file = tmp_path / "ready"
+    proc = _FakeProc(exits_with=3)                  # upstream errored pre-signal
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+
+    rc = _login_with_wait_file(["x"], wait_file, wait_timeout=30,
+                               state_file=tmp_path / "s")
+
+    assert rc == 3
+    assert proc.stdin.getvalue() == b""
+
+
+def test_stale_signal_is_cleared_first(tmp_path, monkeypatch):
+    """A leftover wait-file from a previous run must not auto-trigger
+    before the user has actually logged in."""
+    wait_file = tmp_path / "stale"
+    wait_file.write_text("old", encoding="utf-8")
+    unlinked = {"done": False}
+    real_unlink = Path.unlink
+
+    def tracking_unlink(self, *a, **k):
+        if self == wait_file:
+            unlinked["done"] = True
+        return real_unlink(self, *a, **k)
+
+    monkeypatch.setattr(Path, "unlink", tracking_unlink)
+    proc = _FakeProc(exits_with=0)
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+
+    _login_with_wait_file(["x"], wait_file, wait_timeout=5,
+                           state_file=tmp_path / "s")
+    assert unlinked["done"] is True                 # stale signal removed
+
+
+def test_post_signal_wait_timeout_tightens_and_fails(tmp_path, monkeypatch):
+    """Upstream saved storage_state but is slow to EXIT after the signal:
+    proc.wait() times out -> rc 1, BUT perms must still be tightened
+    (the file is on disk with default perms) and the proc killed."""
+    wait_file = tmp_path / "ready"
+    state_file = tmp_path / "state.json"
+
+    class _SlowProc(_FakeProc):
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired(cmd=["x"], timeout=timeout)
+
+    proc = _SlowProc()
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+    monkeypatch.setattr(auth.time, "sleep",
+                        lambda *_a, **_k: wait_file.write_text("", encoding="utf-8"))
+    tightened = {"called": False}
+    monkeypatch.setattr(auth, "_tighten_state_file_perms",
+                        lambda p: tightened.__setitem__("called", True))
+
+    rc = _login_with_wait_file(["x"], wait_file, wait_timeout=30,
+                               state_file=state_file)
+
+    assert rc == 1                                  # non-zero (fail)
+    assert proc.stdin.getvalue() == b"\n"           # signal WAS fed
+    assert tightened["called"] is True              # G3 P1 #2 upheld
+    assert proc.terminated                          # slow proc killed


### PR DESCRIPTION
## Why

Upstream `notebooklm` login blocks on `input("press ENTER")`;
research-hub shells out to it, so headless/scripted login was
impossible (the maintainer's expired session this cycle had to be
recovered with a hand-rolled signal-pipe). This formalizes that
mechanism in Python, testable.

## What

`notebooklm login --wait-file PATH [--wait-timeout N]`: spawn upstream
login with `stdin=PIPE`, clear stale signal, poll for PATH; when it
appears (user creates it post-sign-in, or an automation wrapper) feed
the newline that triggers the upstream `storage_state` save.
**Fail-closed:** PATH absent within `--wait-timeout` (default 300s) →
subprocess killed, non-zero, nothing saved. `wait_file=None` path is
byte-identical to before.

Lightweight by maintainer decision (the full auto-detect Playwright
driver was rejected as too large/fragile for marginal gain).

## Verification

- `code-reviewer`: **2 rounds** — R1 REQUEST CHANGES (C1 P1: perms not
  tightened when upstream slow-to-exit after save; C2 P1: that branch
  untested; W1–W3, S3) → all fixed → R2 **APPROVE**.
- Full suite **2715 passed, 0 failed**.
- `tests/test_v1_nlm_login_wait_file.py` (5 — incl. the C1-gating
  post-signal-timeout test). Backward compat of `login_nlm` confirmed
  across all call sites.

Final PR (D) of the safety-first follow-up series:
A=#44 gc honesty, B=#45 F6/F8, C=#46 deep-F7 defer, D=this. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)