### PR TITLE
fix(nlm): F8 real diagnosis — --include-suspect-urls via auto + honest message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,9 @@ graph rebuild (link out to the real tools instead)._
   0-quarantined result (e.g. empty search) keeps the lenient path with
   an honest `N written, M quarantined (of K candidates)` message.
 - **F8: `notebooklm upload` no longer exits 0 when 0 sources were
-  transferred.** When NotebookLM's source API drifts under the pinned
+  transferred.** _(Root cause later revised — the common cause is the
+  URL-quality skip, not the upstream API; see the "Fixed (F8 real fix)"
+  entry above.)_ When NotebookLM's source API drifts under the pinned
   `notebooklm-py` (e.g. `Sources data ... is not a list (NoneType)`)
   the notebook is created but no sources land; the old code returned 0
   because `fail_count == 0`. A non-dry-run upload that transfers,
@@ -144,6 +146,23 @@ graph rebuild (link out to the real tools instead)._
   leftover from a previous run can't auto-trigger before sign-in. This
   formalizes (in Python, testable) the signal-pipe technique used to
   recover the maintainer's expired session.
+
+### Fixed (F8 real fix)
+- **`auto` can now actually upload publisher-URL clusters to
+  NotebookLM.** Diagnosed 2026-05-19: an all-URL cluster (DOIs →
+  ScienceDirect/Elsevier) uploaded 0 sources because every entry was
+  `likely_error_page` (our local probe can't read the anti-bot wall)
+  and the conservative URL-quality gate skipped them all — and `auto`
+  called `upload_cluster` positionally with no way to override, so
+  there was no path to rescue it through the pipeline. The earlier F8
+  message also mis-blamed a NotebookLM API change (the
+  `SourcesAPI.list ... NoneType` warning was a red herring — listing an
+  empty new notebook). The conservative skip is intentional design and
+  is **unchanged**; instead `--include-suspect-urls` is now exposed on
+  `auto` and threaded `auto → auto_pipeline → upload_cluster`, and the
+  0-sources error message now lists the real likely cause first (URL
+  sources skipped → re-run with `--include-suspect-urls`) instead of
+  pointing at the upstream API.
 
 ## v1.0.0 (PENDING — tag on/after 2026-05-24, post ≥1-week v0.95.0rc2 bake)
 

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -172,6 +172,7 @@ def auto_pipeline(
     with_pdfs: bool = False,
     with_summary: bool = False,
     peer_reviewed: bool = False,
+    include_suspect_urls: bool = False,
 ) -> AutoReport:
     """End-to-end ingest + optional NotebookLM publish.
 
@@ -452,7 +453,10 @@ def auto_pipeline(
                   f"{bundle_report.pdf_count} PDFs", print_progress)
 
         nlm_step = "nlm.upload"
-        upload_report = upload_cluster(cluster, cfg, headless=False)
+        upload_report = upload_cluster(
+            cluster, cfg, headless=False,
+            include_suspect_urls=include_suspect_urls,
+        )
         report.nlm_uploaded = upload_report.success_count
         report.notebook_url = upload_report.notebook_url
         _step_log(report, "nlm.upload", True, _elapsed(started, report),        

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -3877,10 +3877,11 @@ def _nlm_upload(
         if result.error:
             print(f"       {result.error}")
     # F8: a non-dry-run upload that transferred, cached, and pruned
-    # *nothing* is not a success. This is the symptom of NotebookLM's
-    # source API drifting under the pinned upstream `notebooklm-py`
-    # (e.g. "Sources data ... is not a list (NoneType)") — the notebook
-    # gets created but 0 sources land, and the old code returned 0.
+    # *nothing* is not a success. Most common real cause (diagnosed
+    # 2026-05-19): every URL source was skipped by the URL-quality
+    # pre-check (`failed_no_abstract` on publisher/anti-bot pages) — see
+    # `upload_skip_error_page` events. Less common: empty bundle, or an
+    # actual upstream `notebooklm-py` API drift. List causes honestly.
     if (
         not report.dry_run
         and report.fail_count == 0
@@ -3889,12 +3890,12 @@ def _nlm_upload(
         and not report.over_cap_skipped
     ):
         print(
-            "ERROR: 0 sources uploaded, cached, or pruned. Either the "
-            "cluster bundle was empty, or NotebookLM's source API changed "
-            "and the pinned `notebooklm-py` could not transfer sources "
-            "(see any 'Sources data ... is not a list' warning above). "
-            "The notebook may exist but holds no sources -- not a clean "
-            "upload.",
+            "ERROR: 0 sources uploaded, cached, or pruned. Likely causes "
+            "(check the upload log above): (1) all URL sources skipped by "
+            "the URL-quality pre-check -- re-run with --include-suspect-urls; "
+            "(2) the cluster bundle was empty; (3) an upstream notebooklm-py "
+            "API drift ('Sources data ... is not a list'). The notebook may "
+            "exist but holds no sources -- not a clean upload.",
             file=sys.stderr,
         )
         return 1
@@ -4477,6 +4478,7 @@ def _auto(
     with_pdfs: bool = False,
     with_summary: bool = False,
     peer_reviewed: bool = False,
+    include_suspect_urls: bool = False,
     emit_json: bool = False,
 ) -> int:
     from research_hub.auto import auto_pipeline
@@ -4525,6 +4527,7 @@ def _auto(
             "llm_cli": llm_cli,
             "dry_run": dry_run,
             "peer_reviewed": peer_reviewed,
+            "include_suspect_urls": include_suspect_urls,
             "print_progress": not emit_json,
         }
         if with_pdfs:
@@ -4894,6 +4897,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--peer-reviewed",
         action="store_true",
         help=_PEER_REVIEWED_HELP,
+    )
+    auto_parser.add_argument(
+        "--include-suspect-urls",
+        action="store_true",
+        help="Upload URL sources even if the URL-quality pre-check flags "
+             "them likely_error_page (e.g. publisher/anti-bot pages our "
+             "local probe can't read). NotebookLM fetches URLs server-side, "
+             "so this rescues clusters that would otherwise upload 0 sources "
+             "(F8). Use this when an `auto` run reports the 0-sources "
+             "upload error. Default conservative skip is unchanged.",
     )
     auto_parser.add_argument("--no-nlm", action="store_true",
                              help="Skip NotebookLM bundle/upload/generate/download")
@@ -6943,6 +6956,7 @@ def _main_dispatch(args, parser) -> int:
             llm_cli=args.llm_cli,
             dry_run=args.dry_run,
             peer_reviewed=args.peer_reviewed,
+            include_suspect_urls=args.include_suspect_urls,
             append=args.append,
             force=args.force,
             show=args.show,

--- a/tests/test_v1_f8_doi_url_quality.py
+++ b/tests/test_v1_f8_doi_url_quality.py
@@ -1,0 +1,60 @@
+"""F8 real fix (diagnosed 2026-05-19).
+
+Root cause: an all-URL cluster (perovskite DOIs -> ScienceDirect)
+uploaded 0 sources because every entry was `likely_error_page` (our
+local probe can't read the publisher anti-bot wall). The conservative
+URL-quality skip is the maintainers' DELIBERATE, tested design
+(`test_v0950_url_quality_guard::test_upload_skips_likely_error_page_no_pdf`)
+and is left unchanged. `upload_cluster(include_suspect_urls=True)` is
+also already tested there. The ONLY gap was: `auto` (the pipeline the
+user actually runs) never exposed / threaded the override — it called
+`upload_cluster(cluster, cfg, headless=False)` positionally — so there
+was no way to rescue an all-suspect cluster through the pipeline.
+
+These tests pin exactly that new surface (the override is now
+reachable from `auto`); upload_cluster behaviour itself is covered by
+the pre-existing v0950 suite and not duplicated here.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_auto_parser_exposes_include_suspect_urls():
+    from research_hub.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(
+        ["auto", "some topic", "--include-suspect-urls"]
+    )
+    assert args.include_suspect_urls is True
+
+
+def test_auto_parser_include_suspect_urls_default_false():
+    from research_hub.cli import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(["auto", "some topic"])
+    assert args.include_suspect_urls is False
+
+
+def test_auto_pipeline_threads_include_suspect_urls_to_upload():
+    """`auto_pipeline` must accept the flag AND hand it to
+    `upload_cluster` (it previously called upload_cluster positionally
+    without it, so the pipeline could never override the skip)."""
+    import research_hub.auto as auto_mod
+
+    sig = inspect.signature(auto_mod.auto_pipeline)
+    assert "include_suspect_urls" in sig.parameters
+    assert sig.parameters["include_suspect_urls"].default is False
+
+    # the upload call site forwards the kwarg (guards against a
+    # regression back to the positional `upload_cluster(cluster, cfg,
+    # headless=False)` that caused F8).
+    # TODO(F8): source-text guard is brittle (false-negative if the
+    # call is refactored through a local var). Replace with a
+    # mock-based kwarg assertion using the test_v046_auto mock_deps
+    # fixture before v1.0.0 ships.
+    src = inspect.getsource(auto_mod.auto_pipeline)
+    assert "include_suspect_urls=include_suspect_urls" in src


### PR DESCRIPTION
## Diagnosis (from nlm-debug-20260518T234557Z.jsonl)

The "0 sources / NotebookLM API changed" failure was a **misdiagnosis**.
Real cause: the URL-quality pre-check skipped every DOI→publisher URL
(`likely_error_page`/`failed_no_abstract`; ScienceDirect anti-bot wall
our local probe can't read). The `SourcesAPI.list ... NoneType` warning
was a red herring (listing an empty new notebook).

The conservative skip is the maintainers' **deliberate, tested** design
(`test_v0950::test_upload_skips_likely_error_page_no_pdf`) — left
**unchanged** (`url_quality.py` + `upload.py` byte-identical to master;
two over-broad attempts were reverted after the suite rejected them).
The real gap: `auto` called `upload_cluster` positionally with **no way
to pass the existing `include_suspect_urls` override**.

## Change (scoped)

- `cli.py`: `--include-suspect-urls` on the `auto` subparser, threaded
  `_main_dispatch → _auto → auto_kwargs`; 0-sources error reworded to
  the real cause first (not the upstream API).
- `auto.py`: `auto_pipeline(include_suspect_urls=…)` → forwarded to
  `upload_cluster`.
- Default conservative behaviour unchanged.

## Verification

- `code-reviewer`: **APPROVE** (reverts byte-confirmed; threading
  verified end-to-end; default unchanged; message accurate).
- Full suite re-run **2718 passed, 0 failed** (a prior run's transient
  "1 failed" did not reproduce — same flake class as before).

**This is the mitigation.** The first-principles fix (content-priority
ladder: local PDF → Unpaywall OA PDF → abstract as NLM `add_text` →
raw URL) is a tracked follow-up; the ingredients all exist in-repo but
bundle/upload only emit pdf|url today. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)