### PR TITLE
feat(nlm): F8 first-principles fix — content-priority source ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,22 @@ graph rebuild (link out to the real tools instead)._
   sources skipped → re-run with `--include-suspect-urls`) instead of
   pointing at the upstream API.
 
+### Added (F8 first-principles fix — content-priority ladder)
+- **NotebookLM bundles now upload the abstract as a text source when no
+  PDF is obtainable, instead of a paywalled URL.** First-principles
+  diagnosis: NLM needs *content*, not a URL — a paywalled publisher DOI
+  carries none. Local PDF (rung 1) and Unpaywall/OA PDF (rung 2, via
+  `fetch_paper_pdf`) already worked; the gap was rung 3. `bundle.py`
+  now: no PDF + (no URL or a `likely_error_page` paywall URL) + a real
+  `## Abstract` in the note → emits `action="text"` carrying the
+  abstract (title/DOI-prefixed); a *good* (non-suspect) URL is still
+  preferred (full text). `NotebookLMClient.upload_text` →
+  `sources.add_text`; `upload.py` dispatches `action="text"`;
+  `BundleReport.text_count`. Net: an all-paywall-URL cluster that
+  previously uploaded 0 sources now uploads the abstracts — real
+  content NotebookLM can synthesise. The conservative URL-quality gate
+  and `--include-suspect-urls` override (band-aid) are unchanged.
+
 ## v1.0.0 (PENDING — tag on/after 2026-05-24, post ≥1-week v0.95.0rc2 bake)
 
 > **Not yet released — staged on `release-prep/v1.0.0`.** The cut

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -3813,7 +3813,8 @@ def _notebooklm_bundle(cluster_slug: str, download_pdfs: bool = False) -> int:
     print(f"Bundle written to {report.bundle_dir}")
     print(
         f"Papers: {len(report.entries)} total "
-        f"({report.pdf_count} PDFs, {report.url_count} URLs, {report.skip_count} skipped)"
+        f"({report.pdf_count} PDFs, {report.url_count} URLs, "
+        f"{report.text_count} abstracts, {report.skip_count} skipped)"
     )
     return 0
 

--- a/src/research_hub/notebooklm/bundle.py
+++ b/src/research_hub/notebooklm/bundle.py
@@ -24,6 +24,7 @@ class BundleEntry:
     pdf_path: str = ""
     pdf_source: str = ""
     url: str = ""
+    text: str = ""
     skip_reason: str = ""
     url_quality: str = ""
     url_quality_reason: str = ""
@@ -44,6 +45,10 @@ class BundleReport:
     @property
     def url_count(self) -> int:
         return sum(1 for entry in self.entries if entry.action == "url")
+
+    @property
+    def text_count(self) -> int:
+        return sum(1 for entry in self.entries if entry.action == "text")
 
     @property
     def skip_count(self) -> int:
@@ -76,6 +81,34 @@ def _parse_note_metadata(md_path: Path) -> dict[str, str]:
             value = match.group(1).strip()
             meta[key] = _normalize_doi(value) if key == "doi" else value
     return meta
+
+
+def _extract_abstract(md_path: Path, meta: dict[str, str]) -> str:
+    """F8 content ladder rung 3: the paper's abstract as a self-describing
+    text source. Pulls the `## Abstract` section from the note body (the
+    abstract is not a frontmatter key). Returns "" if absent/placeholder
+    so the caller can fall through to the URL rung. Prefixed with
+    title/DOI so the NotebookLM text source is identifiable."""
+    try:
+        body = md_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    m = re.search(r"^##\s+Abstract\s*\n(.+?)(?=\n##|\Z)", body,
+                  re.MULTILINE | re.DOTALL)
+    if not m:
+        return ""
+    abstract = m.group(1).strip()
+    # Skip empty / TODO-placeholder abstracts (research-hub leaves these
+    # when summarize had no abstract — uploading them is noise).
+    if len(abstract) < 40 or abstract.lower().startswith(("[", "todo", "n/a")):
+        return ""
+    header = []
+    if meta.get("title"):
+        header.append(meta["title"])
+    if meta.get("doi"):
+        header.append(f"DOI: {meta['doi']}")
+    prefix = ("\n".join(header) + "\n\n") if header else ""
+    return (prefix + "Abstract\n" + abstract)[:8000]
 
 
 def _find_pdf_for_doi(
@@ -280,6 +313,23 @@ def bundle_cluster(
             report.entries.append(entry)
             continue
 
+        # F8 content ladder rung 3: no PDF (local or OA-fetched). Prefer
+        # the abstract as a copied-text source over a paywalled URL that
+        # NotebookLM can't read. A *good* URL (not likely_error_page —
+        # e.g. an open landing page with full text) is still better than
+        # an abstract, so only take the text rung when there is no URL or
+        # the URL is the suspect/paywall kind.
+        if not url or entry.url_quality == "likely_error_page":
+            abstract = _extract_abstract(note_path, meta)
+            if abstract:
+                entry.action = "text"
+                entry.text = abstract
+                if url:
+                    entry.url = url  # keep for provenance/manifest
+                    entry.skip_reason = "paywall URL -> abstract text used"
+                report.entries.append(entry)
+                continue
+
         if url:
             entry.action = "url"
             entry.url = url
@@ -306,6 +356,7 @@ def bundle_cluster(
                 "created_at": report.created_at,
                 "pdf_count": report.pdf_count,
                 "url_count": report.url_count,
+                "text_count": report.text_count,
                 "skip_count": report.skip_count,
                 "entries": [asdict(entry) for entry in report.entries],
             },
@@ -329,6 +380,7 @@ def bundle_cluster(
     else:
         print(f"  pdf: {report.pdf_count}")
     print(f"  url: {report.url_count}")
+    print(f"  text (abstract): {report.text_count}")
     print(f"  skip: {report.skip_count}")
     return report
 
@@ -341,7 +393,8 @@ def _render_readme(cluster, report: BundleReport) -> str:
         f"- Created at: {report.created_at}",
         (
             f"- Papers: {len(report.entries)} total "
-            f"({report.pdf_count} PDFs, {report.url_count} URLs, {report.skip_count} skipped)"
+            f"({report.pdf_count} PDFs, {report.url_count} URLs, "
+            f"{report.text_count} abstracts, {report.skip_count} skipped)"
         ),
         "",
         "## Upload to NotebookLM (manual fallback)",
@@ -368,7 +421,7 @@ def _render_readme(cluster, report: BundleReport) -> str:
     ]
     skipped = [entry for entry in report.entries if entry.action == "skip"]
     if not skipped:
-        lines.append("_None; every paper has either a PDF or a URL._")
+        lines.append("_None; every paper has a PDF, a URL, or an abstract text source._")
     else:
         for entry in skipped:
             lines.append(

--- a/src/research_hub/notebooklm/client.py
+++ b/src/research_hub/notebooklm/client.py
@@ -216,6 +216,8 @@ class NotebookLMClient:
         *,
         file_path: Path | None = None,
         url: str = "",
+        text: str = "",
+        title: str = "",
     ) -> UploadResult:
         async def _go():
             if file_path is not None:
@@ -227,18 +229,34 @@ class NotebookLMClient:
                 # this single bug, masked by 3-retry indiscriminate backoff
                 # in upload.py::_attempt_upload.
                 return await self._client.sources.add_file(notebook_id, file_path=str(file_path))
+            if text:
+                # F8 content ladder: when no PDF/OA is available, the
+                # abstract (already in the vault) is uploaded as a
+                # copied-text source — real content NotebookLM can use,
+                # vs a paywall URL it can't.
+                return await self._client.sources.add_text(
+                    notebook_id, title=title or "Untitled", content=text
+                )
             return await self._client.sources.add_url(notebook_id, url=url)
 
-        source_kind = "pdf" if file_path is not None else "url"
-        path_or_url = str(file_path) if file_path is not None else url
+        if file_path is not None:
+            source_kind, path_or_url = "pdf", str(file_path)
+        elif text:
+            source_kind, path_or_url = "text", (title or text[:60])
+        else:
+            source_kind, path_or_url = "url", url
         try:
             source = self._run(_go())
-            title = getattr(source, "title", "") or (file_path.name if file_path else url)
+            source_title = getattr(source, "title", "") or (
+                file_path.name if file_path is not None
+                else title if text          # F8: keep caller's paper title
+                else url
+            )
             return UploadResult(
                 source_kind=source_kind,
                 path_or_url=path_or_url,
                 success=True,
-                title=title,
+                title=source_title,
             )
         except _UpstreamError as exc:
             return UploadResult(source_kind=source_kind, path_or_url=path_or_url, error=str(exc))
@@ -256,6 +274,12 @@ class NotebookLMClient:
         if not notebook_id:
             raise NotebookLMError("upload_url requires an active notebook_id")
         return self.upload_source(notebook_id, url=url)
+
+    def upload_text(self, text: str, *, title: str = "") -> UploadResult:
+        notebook_id = getattr(self, "_active_notebook_id", "")
+        if not notebook_id:
+            raise NotebookLMError("upload_text requires an active notebook_id")
+        return self.upload_source(notebook_id, text=text, title=title)
 
     def set_active_notebook(self, notebook_id: str) -> None:
         self._active_notebook_id = notebook_id

--- a/src/research_hub/notebooklm/upload.py
+++ b/src/research_hub/notebooklm/upload.py
@@ -715,6 +715,12 @@ def _attempt_upload(
             result = client.upload_pdf(Path(entry["pdf_path"]))
         elif action == "url":
             result = client.upload_url(entry["url"])
+        elif action == "text":
+            # F8 content ladder: abstract uploaded as a copied-text
+            # source (real content) when no PDF/OA is available.
+            result = client.upload_text(
+                entry.get("text", ""), title=entry.get("title", "")
+            )
         else:
             _log_jsonl(log_path, {"kind": "upload_skip", "action": action, "key": key})
             return None

--- a/tests/test_v1_nlm_content_ladder.py
+++ b/tests/test_v1_nlm_content_ladder.py
@@ -1,0 +1,142 @@
+"""F8 first-principles fix: content-priority source ladder.
+
+NotebookLM needs content, not a URL. Ladder: local PDF -> Unpaywall OA
+PDF (both already worked) -> **abstract as a copied-text source** ->
+raw URL last. This file pins the new rung (abstract-text) + the
+client/upload plumbing for `action="text"`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from research_hub.notebooklm.bundle import _extract_abstract
+
+
+def _sync(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _StubCfg:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.raw = root / "raw"
+        self.logs = root / "logs"
+        self.research_hub_dir = root / ".research_hub"
+
+
+def _note(path: Path, *, doi: str, url: str = "", abstract: str = "",
+          title: str = "Paper", cluster: str = "alpha") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fm = ["---", f'title: "{title}"', f'doi: "{doi}"', f'url: "{url}"',
+          f'topic_cluster: "{cluster}"', "---", "", f"# {title}", ""]
+    if abstract is not None:
+        fm += ["## Abstract", "", abstract, "", "## Notes", "x"]
+    path.write_text("\n".join(fm), encoding="utf-8")
+
+
+# ---- _extract_abstract ----
+
+def test_extract_abstract_pulls_section(tmp_path):
+    p = tmp_path / "n.md"
+    _note(p, doi="10.1/x", title="Perovskite Study",
+          abstract="We report a 25% efficiency perovskite cell with a "
+                   "novel passivation layer improving stability markedly.")
+    out = _extract_abstract(p, {"title": "Perovskite Study", "doi": "10.1/x"})
+    assert "Perovskite Study" in out          # title header
+    assert "DOI: 10.1/x" in out
+    assert "passivation layer" in out          # the abstract body
+
+
+def test_extract_abstract_skips_placeholder(tmp_path):
+    p = tmp_path / "n.md"
+    _note(p, doi="10.1/x", abstract="[TODO: fill abstract]")
+    assert _extract_abstract(p, {}) == ""
+
+
+def test_extract_abstract_absent_section(tmp_path):
+    p = tmp_path / "n.md"
+    p.write_text("---\ntitle: x\n---\n# x\nno abstract heading here",
+                 encoding="utf-8")
+    assert _extract_abstract(p, {}) == ""
+
+
+# ---- bundle ladder: abstract-text rung ----
+
+def _bundle(tmp_path, *, url, abstract, probe_quality):
+    from research_hub.clusters import Cluster
+    from research_hub.notebooklm.bundle import bundle_cluster
+    from research_hub.notebooklm.url_quality import UrlQuality
+
+    cfg = _StubCfg(tmp_path)
+    cfg.raw.mkdir(parents=True)
+    cfg.research_hub_dir.mkdir(parents=True)
+    (cfg.root / "pdfs").mkdir()
+    _note(cfg.raw / "alpha" / "p.md", doi="10.1016/j.est.1", url=url,
+          abstract=abstract)
+    cluster = Cluster(slug="alpha", name="Alpha", obsidian_subfolder="alpha")
+    pr = UrlQuality(probe_quality, "r", "s")
+    with patch("research_hub.notebooklm.url_quality._probe_url", return_value=pr):
+        return bundle_cluster(cluster, cfg)
+
+
+def test_paywall_url_with_abstract_becomes_text(tmp_path):
+    rep = _bundle(tmp_path,
+                  url="https://doi.org/10.1016/j.est.1",
+                  abstract="A long real abstract about solid-state battery "
+                           "electrolyte interface stability and dendrites.",
+                  probe_quality="likely_error_page")
+    e = rep.entries[0]
+    assert e.action == "text"
+    assert "electrolyte interface" in e.text
+    assert rep.text_count == 1
+
+
+def test_good_url_still_preferred_over_abstract(tmp_path):
+    rep = _bundle(tmp_path,
+                  url="https://doi.org/10.1016/j.est.1",
+                  abstract="A long real abstract that should NOT be used "
+                           "because the URL probed OK (full content).",
+                  probe_quality="ok")
+    e = rep.entries[0]
+    assert e.action == "url"          # good url beats abstract (full text)
+
+
+def test_paywall_url_no_abstract_falls_to_url(tmp_path):
+    rep = _bundle(tmp_path,
+                  url="https://doi.org/10.1016/j.est.1",
+                  abstract="[TODO]",                 # no usable abstract
+                  probe_quality="likely_error_page")
+    e = rep.entries[0]
+    assert e.action == "url"          # unchanged conservative fallback
+
+
+# ---- client / upload plumbing for action="text" ----
+
+def test_client_upload_text_calls_add_text():
+    from research_hub.notebooklm.client import NotebookLMClient
+
+    c = NotebookLMClient.__new__(NotebookLMClient)
+    added = {}
+
+    class _Sources:
+        async def add_text(self, nb, *, title, content):
+            added.update(notebook=nb, title=title, content=content)
+            return SimpleNamespace(title=title)
+
+    c._client = SimpleNamespace(sources=_Sources())
+    c._run = _sync
+    c._active_notebook_id = "nb-1"
+
+    res = c.upload_text("ABSTRACT TEXT", title="My Paper")
+    assert added == {"notebook": "nb-1", "title": "My Paper",
+                     "content": "ABSTRACT TEXT"}
+    assert res.success is True
+    assert res.source_kind == "text"


### PR DESCRIPTION
## First principle

NotebookLM needs **content**, not a URL. A paywalled publisher DOI
carries none — the pipeline was choosing the worst carrier while
holding better ones. Rung 1 (local PDF) + rung 2 (Unpaywall/OA PDF via
`fetch_paper_pdf`, already invoked by `bundle_cluster(download_pdfs=
True)` which `auto` passes) already worked. The only gap was **rung 3:
abstract-as-text** — bundle fell straight from "no PDF" → "paywall URL".

## Change

- `bundle.py`: `_extract_abstract` (note `## Abstract` section, skips
  placeholders, title/DOI-prefixed, 8 000-char cap); ladder rung —
  no PDF + (no URL or `likely_error_page` paywall URL) + real abstract
  → `action="text"`; a *good* URL still wins (full text > abstract).
  `text_count` surfaced everywhere (manifest/console/README/CLI).
- `client.py`: `upload_source` text branch → `sources.add_text`;
  `upload_text` wrapper; keeps caller title in `UploadResult`.
- `upload.py`: `elif action == "text"` dispatch.

Net: an all-paywall-URL cluster that uploaded **0** sources now uploads
the **abstracts** — real content NotebookLM can synthesise. The
conservative URL-quality gate + `--include-suspect-urls` band-aid
(PR #48) are unchanged.

## Verification

- `code-reviewer`: **APPROVE**; W1/W2/W3/S1/S3 applied, S2 dropped
  (unreachable — `_pick_url` always synthesises a doi.org URL).
- Full suite **2725 passed, 0 failed** (stale pre-fix run's transient
  "1 failed" did not reproduce — recurring flake class).
- 7 new tests in `tests/test_v1_nlm_content_ladder.py`; all
  bundle/upload/client/auto suites stay green.

Closes the F8 root cause (first-principles). Final piece of the
research-hub reliability series. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)