### PR TITLE
fix(zotero-gc): suppress false orphan flag for key-drifted real collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ graph rebuild (link out to the real tools instead)._
   instead of a generic `pip install` hint that cannot succeed there.
 
 ### Fixed
+- `zotero gc` / `zotero mark-kept --all-orphans`: a real cluster
+  collection whose Zotero key drifted from its `cluster.zotero_collection_key`
+  binding (e.g. a Zotero-truncated date-prefixed name like
+  `20260518-machine-learning-flood-forecas`) is no longer mis-flagged as an
+  orphan candidate. New conservative, suppression-only name-normalization
+  match (`_normalize_collection_name` + bidirectional prefix match, min
+  12-char guard). No rebind/merge/delete-logic change; strictly fewer GC
+  candidates. PR-A's non-empty hard-skip remains as an independent safety
+  net.
 - **arXiv hits no longer leak past `--exclude-type preprint`.** The
   arXiv backend left `doc_type` empty, so the type filter silently
   missed every raw arXiv result (bioRxiv/chemRxiv already set it).

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -1725,13 +1725,24 @@ def _zotero_mark_kept(
         return 0
 
     if all_orphans:
+        from research_hub.clusters import slugify
         from research_hub.zotero.client import get_client
 
         registry = ClusterRegistry(cfg.clusters_file)
+        clusters = registry.list()
         vault_keys = {
             (cluster.zotero_collection_key or "").strip()
-            for cluster in registry.list()
+            for cluster in clusters
             if (cluster.zotero_collection_key or "").strip()
+        }
+        vault_name_slugs = {
+            slugify(cluster.name)
+            for cluster in clusters
+            if (cluster.name or "").strip()
+        } | {
+            (cluster.slug or "").strip()
+            for cluster in clusters
+            if (cluster.slug or "").strip()
         }
         zot = get_client()
         # respect_kept=False here so we re-detect the full orphan set
@@ -1743,6 +1754,7 @@ def _zotero_mark_kept(
             include_test_pattern=False,
             age_days=30,
             kept_keys=set(),
+            vault_name_slugs=vault_name_slugs,
         )
         # PR-A: include BOTH orphan reasons. A non-empty orphan
         # (`orphan-with-items(N)`) is exactly the real-data collection a
@@ -1906,6 +1918,7 @@ def _zotero_gc(
     respect_kept: bool = True,
 ) -> int:
     cfg = get_config()
+    from research_hub.clusters import slugify
     from research_hub.zotero.client import get_client
     from research_hub.zotero.gc import (
         delete_candidates,
@@ -1914,10 +1927,20 @@ def _zotero_gc(
     )
 
     registry = ClusterRegistry(cfg.clusters_file)
+    clusters = registry.list()
     vault_keys = {
         (cluster.zotero_collection_key or "").strip()
-        for cluster in registry.list()
+        for cluster in clusters
         if (cluster.zotero_collection_key or "").strip()
+    }
+    vault_name_slugs = {
+        slugify(cluster.name)
+        for cluster in clusters
+        if (cluster.name or "").strip()
+    } | {
+        (cluster.slug or "").strip()
+        for cluster in clusters
+        if (cluster.slug or "").strip()
     }
     kept_keys = load_kept_keys(cfg.research_hub_dir) if respect_kept else set()
     zot = get_client()
@@ -1927,6 +1950,7 @@ def _zotero_gc(
         include_test_pattern=not no_test_pattern,
         age_days=age_days,
         kept_keys=kept_keys,
+        vault_name_slugs=vault_name_slugs,
     )
     if not candidates:
         print("No Zotero GC candidates found.")

--- a/src/research_hub/zotero/gc.py
+++ b/src/research_hub/zotero/gc.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 import json
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -24,6 +25,56 @@ TEST_PATTERNS = [
     "Beta",
 ]
 DEFAULT_AGE_DAYS = 30
+
+# 4–8 leading date digits (YYYY..YYYYMMDD) + optional T/_-separated time
+# (HHMMSS, ≤6 digits) + a required separator. Deliberately NOT `\d*`
+# (unbounded) — a tight bound keeps non-date numeric prefixes (e.g. a Unix
+# timestamp) un-stripped, so such names stay LESS likely to be name-matched
+# and thus stay flagged (the safe over-flag→under-flag direction).
+_DATE_PREFIX_RE = re.compile(r"^\d{4,8}(?:[T_]\d{0,6})?[-_ ]+")
+_NAME_MATCH_MIN_LEN = 12
+
+
+def _normalize_collection_name(name: str) -> str:
+    """Strip a leading (possibly Zotero-truncated) date prefix then slugify.
+
+    e.g. '20260518-machine-learning-flood-forecas'
+         -> 'machine-learning-flood-forecas'
+    Reuses `research_hub.clusters.slugify` (imported lazily to avoid any
+    import cycle between zotero.gc and clusters).
+    """
+    from research_hub.clusters import slugify  # lazy: avoid import cycle
+
+    stripped = _DATE_PREFIX_RE.sub("", name or "")
+    return slugify(stripped)
+
+
+def _name_recognised(name: str, vault_name_slugs: set[str] | None) -> bool:
+    """True if the normalized collection name prefix-matches a known
+    cluster name/slug in BOTH directions (handles Zotero's name
+    truncation either way). Min length guard avoids coincidental short
+    matches.
+
+    Accepted conservative edge case: the bidirectional prefix match can
+    suppress a *genuine* orphan whose normalized name shares a long
+    (≥12-char) prefix with a real cluster slug. This is intentional —
+    over-flagging real data was the bug; an occasional harmless
+    under-flag (orphan left in Zotero, never deleted) is the safe
+    direction. ``delete_candidates``' non-empty hard-skip (PR-A) is the
+    independent second safety net.
+    """
+    if not vault_name_slugs:
+        return False
+    norm = _normalize_collection_name(name)
+    if len(norm) < _NAME_MATCH_MIN_LEN:
+        return False
+    for v in vault_name_slugs:
+        if (
+            len(v) >= _NAME_MATCH_MIN_LEN
+            and (norm.startswith(v) or v.startswith(norm))
+        ):
+            return True
+    return False
 
 
 @dataclass
@@ -97,8 +148,12 @@ def scan_zotero_for_gc(
     include_test_pattern: bool = True,
     age_days: int = DEFAULT_AGE_DAYS,
     kept_keys: set[str] | None = None,
+    vault_name_slugs: set[str] | None = None,
 ) -> list[GCCandidate]:
-    """Walk the Zotero web library and return collection delete candidates."""
+    """Walk the Zotero web library and return collection delete candidates.
+
+    ``vault_name_slugs`` suppresses orphan flags for name-recognised collections.
+    """
     cutoff = datetime.now(timezone.utc) - timedelta(days=age_days)
     out: list[GCCandidate] = []
     start = 0
@@ -133,6 +188,13 @@ def scan_zotero_for_gc(
                 if kept_keys and key in kept_keys:
                     # User explicitly marked this collection as kept; skip the
                     # orphan flag so it never appears as a gc candidate.
+                    pass
+                elif _name_recognised(name, vault_name_slugs):
+                    # Name-recognised: a real cluster collection whose key drifted
+                    # (e.g. Zotero-truncated date-prefixed name). Suppress the
+                    # orphan flag exactly like an explicit kept_keys entry. The
+                    # empty>Nd / test-pattern reasons above are unaffected, so an
+                    # empty recognised collection can still be flagged junk.
                     pass
                 elif num_items == 0 and num_collections == 0:
                     # Empty orphan — safe junk, eligible for --yes auto-GC

--- a/tests/test_v1_gc_name_normalization.py
+++ b/tests/test_v1_gc_name_normalization.py
@@ -1,0 +1,179 @@
+"""Conservative name-normalization suppresses false orphan flags only."""
+
+from __future__ import annotations
+
+import pytest
+
+from research_hub.clusters import slugify
+from research_hub.zotero.gc import scan_zotero_for_gc
+
+
+def _collection(
+    key,
+    name,
+    *,
+    num_items=0,
+    num_collections=0,
+    date_added="2025-01-01T00:00:00Z",
+) -> dict:
+    return {
+        "key": key,
+        "data": {"key": key, "name": name, "dateAdded": date_added},
+        "meta": {"numItems": num_items, "numCollections": num_collections},
+    }
+
+
+class _Zot:
+    def __init__(self, collections):
+        self._c = collections
+
+    def collections(self, *, limit=200, start=0):
+        return self._c[start:start + limit]
+
+
+def _vault_name_slugs() -> set[str]:
+    return {
+        slugify("Machine Learning Flood Forecasting"),
+        "ml-flood-forecasting",
+    }
+
+
+def test_exact_reported_truncated_date_prefixed_collection_is_not_orphan():
+    candidates = scan_zotero_for_gc(
+        _Zot([
+            _collection(
+                "ZZZORPHAN1",
+                "20260518-machine-learning-flood-forecas",
+                num_items=7,
+            )
+        ]),
+        vault_keys=set(),
+        kept_keys=None,
+        vault_name_slugs=_vault_name_slugs(),
+    )
+
+    assert not any(candidate.key == "ZZZORPHAN1" for candidate in candidates)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "20260517-machine-learning-flood-forecasting",
+        "20260518T093000-machine-learning-flood-forec",
+    ],
+)
+def test_date_prefix_variants_are_name_recognised(name):
+    candidates = scan_zotero_for_gc(
+        _Zot([_collection("ZZZORPHAN2", name, num_items=7)]),
+        vault_keys=set(),
+        kept_keys=None,
+        vault_name_slugs=_vault_name_slugs(),
+    )
+
+    assert not candidates
+
+
+def test_unrelated_non_empty_orphan_still_flagged():
+    candidates = scan_zotero_for_gc(
+        _Zot([_collection("UNRELATED1", "scratch-xyz", num_items=3)]),
+        vault_keys=set(),
+        kept_keys=None,
+        vault_name_slugs=_vault_name_slugs(),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].reasons == ["orphan-with-items(3)"]
+
+
+def test_empty_recognised_collection_keeps_empty_junk_reason_only():
+    candidates = scan_zotero_for_gc(
+        _Zot([
+            _collection(
+                "EMPTYRECOG1",
+                "20260518-machine-learning-flood-forecas",
+                num_items=0,
+                date_added="2020-01-01T00:00:00Z",
+            )
+        ]),
+        vault_keys=set(),
+        age_days=30,
+        kept_keys=None,
+        vault_name_slugs=_vault_name_slugs(),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].reasons == ["empty>30d"]
+    assert "orphan-from-vault" not in candidates[0].reasons
+
+
+def test_true_empty_unrecognised_orphan_still_has_yes_safety_reasons():
+    candidates = scan_zotero_for_gc(
+        _Zot([
+            _collection(
+                "EMPTYORPHAN1",
+                "qqqq-deleteme",
+                num_items=0,
+                date_added="2020-01-01T00:00:00Z",
+            )
+        ]),
+        vault_keys=set(),
+        age_days=30,
+        kept_keys=None,
+        vault_name_slugs=_vault_name_slugs(),
+    )
+
+    assert len(candidates) == 1
+    assert "empty>30d" in candidates[0].reasons
+    assert "orphan-from-vault" in candidates[0].reasons
+
+
+def test_non_date_long_digit_prefix_is_not_stripped_so_stays_orphan():
+    """W1: a non-date long numeric prefix (e.g. a Unix timestamp) must NOT
+    be stripped by _DATE_PREFIX_RE, so the name does not collapse onto a
+    cluster slug and the collection stays flagged (safe over->under-flag
+    direction)."""
+    candidates = scan_zotero_for_gc(
+        _Zot([
+            _collection(
+                "TS1",
+                "1234567890-machine-learning-flood-forecasting",
+                num_items=4,
+            )
+        ]),
+        vault_keys=set(),
+        kept_keys=None,
+        vault_name_slugs=_vault_name_slugs(),
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].reasons == ["orphan-with-items(4)"]
+
+
+def test_short_name_collision_does_not_suppress_orphan_reason():
+    candidates = scan_zotero_for_gc(
+        _Zot([_collection("SHORT1", "abc", num_items=2)]),
+        vault_keys=set(),
+        kept_keys=None,
+        vault_name_slugs={"abc"},
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].reasons == ["orphan-with-items(2)"]
+
+
+def test_none_vault_name_slugs_keeps_old_orphan_behaviour():
+    candidates = scan_zotero_for_gc(
+        _Zot([
+            _collection(
+                "OLDDEFAULT1",
+                "20260518-machine-learning-flood-forecas",
+                num_items=7,
+            )
+        ]),
+        vault_keys=set(),
+        kept_keys=None,
+        vault_name_slugs=None,
+    )
+
+    assert len(candidates) == 1
+    assert candidates[0].reasons == ["orphan-with-items(7)"]


### PR DESCRIPTION
## Problem

`scan_zotero_for_gc` flags a collection as an orphan whenever its Zotero
**key** is not a current `cluster.zotero_collection_key` binding. Real
research collections carry a Zotero-truncated date-prefixed name (e.g.
`20260518-machine-learning-flood-forecas`) whose key drifts from the live
binding, so **genuine non-empty collections were listed as orphan
candidates**. PR-A (#44) already made this *safe* (non-empty →
`orphan-with-items(N)`, never `--yes`-deleted, review-only); this PR
removes the **false flag itself**.

## Fix — conservative, suppression-only

No rebind/merge, no data touched, no delete-logic change, **no version bump**.

- **`zotero/gc.py`**: `_normalize_collection_name` (strip a *tight*
  date/datetime prefix — `^\d{4,8}(?:[T_]\d{0,6})?[-_ ]+` — then
  `slugify`) + `_name_recognised` (bidirectional prefix match, ≥12-char
  guard). New `vault_name_slugs` kw-only param on `scan_zotero_for_gc`
  adds **one `elif`** between the `kept_keys` skip and the empty/non-empty
  orphan branches → a name-recognised collection gets no orphan reason.
  The independent `empty>Nd` / `test-pattern` reasons are unaffected.
- **`cli.py`**: both call sites (`zotero gc`, `mark-kept --all-orphans`)
  build `vault_name_slugs = {slugify(c.name)} | {c.slug}` and pass it.

Worst case is a **harmless under-flag** (a genuine orphan whose name
coincidentally normalizes onto a cluster stays in Zotero, never deleted)
— the safe direction; over-flagging real data was the bug. PR-A's
non-empty hard-skip remains as an independent second safety net.

## Review & verification

- `code-reviewer` subagent → **APPROVE with warnings**. Applied: **W1**
  (tightened the date-prefix regex so unbounded non-date digit runs —
  e.g. a Unix timestamp — are not stripped, keeping such names flagged:
  the safe over→under-flag direction), **S4** (`slugify` import moved
  into the `all_orphans` block, matching the lazy-import rationale),
  **S2** (documented the accepted conservative under-flag edge case),
  plus a **W1 lock-in regression test**.
- New `tests/test_v1_gc_name_normalization.py` (9 cases): exact reported
  false-positive, date-prefix variants, unrelated-orphan-still-flagged,
  empty-recognised-still-`empty>Nd`, true-empty-orphan-keeps-`--yes`-
  safety, short-collision guard, `None` back-compat, non-date-digit-prefix
  stays orphan.
- Regression green: `test_v075_zotero_gc`, `test_v087_zotero_kept`,
  `test_v1_gc_nonempty_orphan_safety` (PR-A behaviour intact).
- **Full suite: 2734 passed, 24 skipped, 2 xfailed, 1 xpassed, 0 failed.**

## Non-goals

No rebind/merge of stale duplicate collections (separate, deferred). No
deletion-logic change. No version bump (not a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)