### PR TITLE
fix(authenticity,ss-search): F7 completion — anti-bot HEAD defers + SS-key latin-1 guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ graph rebuild (link out to the real tools instead)._
   permanent miss, surfaced as `*_check_unavailable`); genuine 404/410
   stay fail-closed `doi_unresolved` so the anti-fabrication guarantee
   is unchanged. A 0/malformed status also fails closed.
+- **F7 completion: access-blocked resolver statuses defer.** DOI HEAD
+  statuses other than resolved 2xx/3xx or definitive 404/410
+  non-registration (for example 401/403/406/451 anti-bot walls) now
+  route to `doi_check_unavailable` / `L1-deferred` instead of permanent
+  `doi_unresolved` / `L1` quarantine.
+- **Semantic Scholar API keys are validated before use.** A
+  non-latin-1 `SEMANTIC_SCHOLAR_API_KEY` now emits a clear warning and
+  is ignored so the backend queries anonymously instead of crashing while
+  requests encodes the `x-api-key` header.
 
 ### Removed
 - **Dead `notebooklm login` flags:** `--cdp`, `--chrome-binary`,

--- a/src/research_hub/authenticity.py
+++ b/src/research_hub/authenticity.py
@@ -406,24 +406,28 @@ def restore_quarantine(cfg, slug: str, cluster: str) -> dict:
     }
 
 
-# F7: doi.org / Cloudflare serve HTTP 418 to the default ``python-requests``
-# User-Agent (a bot fingerprint), which the gate previously read as
-# ``doi_unresolved`` and fail-closed-quarantined every valid paper. A real
-# UA makes the same DOI return 200/302. Empirically verified 2026-05-18.
+# F7: resolver HEAD failures are only fabrication evidence when the
+# registry gives a definitive non-registration answer (HTTP 404/410).
+# Anti-bot/access/rate-limit failures (401/403/406/418/429/451/5xx) and
+# network errors are deferred as ``*_check_unavailable``. Empirically
+# verified against doi.org / Cloudflare blocks on 2026-05-18.
 _DOI_RESOLVE_UA = "research-hub (+https://github.com/WenyuChiou/research-hub)"
-# Transient = "blocked / rate-limited / retry later", NOT "this DOI is fake".
-# 404/410 stay permanent so the anti-fabrication guarantee is preserved.
-_TRANSIENT_HTTP_STATUS = frozenset({408, 418, 425, 429, 500, 502, 503, 504})
+# Only definitive non-registration (HTTP 404/410) fails closed as
+# `*_unresolved`; every other resolver HEAD failure -- anti-bot
+# 401/403/406/418/451, rate-limit 429, 5xx, network error -- defers as
+# `*_check_unavailable`. Anti-fabrication guarantee = 404/410 + the L2
+# corroboration layer; both unchanged.
+_DEFINITIVE_NOTFOUND_HTTP_STATUS = frozenset({404, 410})
 
 
 def _resolve_head_with_retry(url: str, *, attempts: int = 3) -> tuple[int | None, bool]:
     """HEAD *url* with a real User-Agent and bounded backoff.
 
     Returns ``(status_code, transient)``. ``transient`` is True when the
-    final attempt was a rate-limit / anti-bot / network failure
-    (HTTP 408/418/425/429/5xx or a RequestException) rather than a
-    definitive answer — the caller must NOT treat that as a fake DOI and
-    must NOT cache it as a permanent failure.
+    final attempt was an access / anti-bot / rate-limit / network
+    failure rather than a definitive answer. Only 2xx/3xx and HTTP
+    404/410 are definitive; every other status must NOT be treated as a
+    fake DOI and must NOT be cached as a permanent failure.
     """
     status_code: int | None = None
     for attempt in range(attempts):
@@ -435,10 +439,9 @@ def _resolve_head_with_retry(url: str, *, attempts: int = 3) -> tuple[int | None
                 headers={"User-Agent": _DOI_RESOLVE_UA},
             )
             status_code = int(getattr(response, "status_code", 0) or 0)
-            # `status_code and ...`: a 0/falsy code (malformed response) is
-            # NOT a definitive answer — fall through to retry, then transient,
-            # so it can never resolve to ok=True (fail-closed).
-            if status_code and status_code not in _TRANSIENT_HTTP_STATUS:
+            if status_code and status_code < 400:
+                return status_code, False
+            if status_code in _DEFINITIVE_NOTFOUND_HTTP_STATUS:
                 return status_code, False
         except requests.RequestException:
             status_code = None
@@ -883,4 +886,3 @@ def _int_or_none(value: Any) -> int | None:
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-

--- a/src/research_hub/search/semantic_scholar.py
+++ b/src/research_hub/search/semantic_scholar.py
@@ -73,6 +73,17 @@ class SemanticScholarClient:
         # Also normalize an explicit api_key=" " arg the same way
         elif isinstance(api_key, str):
             api_key = api_key.strip() or None
+        if isinstance(api_key, str):
+            try:
+                api_key.encode("latin-1")
+            except UnicodeEncodeError:
+                logger.warning(
+                    "%s is not ASCII/latin-1 (looks like a placeholder or "
+                    "mojibake); ignoring it and querying Semantic Scholar "
+                    "anonymously.",
+                    SEMANTIC_SCHOLAR_API_KEY_ENV,
+                )
+                api_key = None
         self.api_key = api_key
         # Authenticated clients can poll faster; cap the throttle so a
         # key-holder doesn't waste the rate budget.

--- a/tests/test_v1_f7_doi_resolver.py
+++ b/tests/test_v1_f7_doi_resolver.py
@@ -12,20 +12,34 @@ UA makes the same DOI return 200.
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import research_hub.authenticity as auth
 from research_hub.authenticity import (
+    DEFERRED_LAYER,
     DoiResolveCache,
     _resolve_head_with_retry,
     _resolve_identifier,
+    verify_authenticity,
 )
 
 
 class _Resp:
     def __init__(self, status_code: int) -> None:
         self.status_code = status_code
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "vault"
+    rh = root / ".research_hub"
+    rh.mkdir(parents=True)
+    return SimpleNamespace(research_hub_dir=rh)
+
+
+def _paper(doi: str = "10.1000/real") -> dict:
+    return {"title": "A Real Paper", "doi": doi, "abstract": "x" * 80}
 
 
 @pytest.fixture(autouse=True)
@@ -54,10 +68,50 @@ def test_http_418_is_transient_not_unresolved(monkeypatch: pytest.MonkeyPatch) -
     assert status == 418 and transient is True
 
 
-def test_404_stays_permanent_failclosed(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(404))
+@pytest.mark.parametrize("status_code", [401, 403, 451])
+def test_antibot_access_statuses_defer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+) -> None:
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(status_code))
+
+    status, transient = _resolve_head_with_retry("https://doi.org/10.1/x", attempts=2)
+    assert status == status_code and transient is True
+
+    cache_path = tmp_path / "doi_resolve_cache.json"
+    cache = DoiResolveCache.load(cache_path)
+    outcome = _resolve_identifier(_paper(), cache, cache_path)
+    assert outcome.ok is False
+    assert outcome.reason == "doi_check_unavailable"
+    assert DoiResolveCache.load(cache_path).get(outcome.key) is None
+
+
+def test_http_403_verification_is_l1_deferred(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(403))
+    accepted, quarantined = verify_authenticity(
+        [_paper(doi="10.1111/jfr3.70039")],
+        _cfg(tmp_path),
+        cluster_slug="c",
+    )
+
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["layer"] == DEFERRED_LAYER
+    assert quarantined[0]["reason"] == "doi_check_unavailable"
+
+
+@pytest.mark.parametrize("status_code", [404, 410])
+def test_notfound_statuses_stay_permanent_failclosed(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+) -> None:
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(status_code))
     status, transient = _resolve_head_with_retry("https://doi.org/10.1/x")
-    assert status == 404 and transient is False  # 404 != fake-bot block
+    assert status == status_code and transient is False  # not an anti-bot block
 
 
 def test_transient_then_success_recovers(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -65,6 +119,21 @@ def test_transient_then_success_recovers(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(auth.requests, "head", lambda *a, **k: calls.pop(0))
     status, transient = _resolve_head_with_retry("https://doi.org/10.1/x", attempts=3)
     assert status == 200 and transient is False
+
+
+def test_5xx_stays_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(500))
+    status, transient = _resolve_head_with_retry("https://doi.org/10.1/x", attempts=2)
+    assert status == 500 and transient is True
+
+
+def test_request_exception_stays_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_head(*_args, **_kwargs):
+        raise auth.requests.RequestException("timeout")
+
+    monkeypatch.setattr(auth.requests, "head", fake_head)
+    status, transient = _resolve_head_with_retry("https://doi.org/10.1/x", attempts=2)
+    assert status is None and transient is True
 
 
 def test_transient_outcome_is_not_cached(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -92,3 +161,21 @@ def test_real_404_is_cached_and_failclosed(tmp_path: Path, monkeypatch: pytest.M
     assert outcome.ok is False
     assert outcome.reason == "doi_unresolved"
     assert DoiResolveCache.load(cache_path).get(outcome.key) is not None
+
+
+def test_fabricated_404_stays_l1_end_to_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(404))
+    accepted, quarantined = verify_authenticity(
+        [_paper(doi="10.9999/does-not-exist")],
+        _cfg(tmp_path),
+        cluster_slug="c",
+    )
+
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["layer"] == "L1"
+    assert quarantined[0]["reason"] == "doi_unresolved"
+    assert quarantined[0]["layer"] != DEFERRED_LAYER

--- a/tests/test_v1_ss_key_validation.py
+++ b/tests/test_v1_ss_key_validation.py
@@ -1,0 +1,65 @@
+"""Regression tests for Semantic Scholar API-key normalization."""
+
+from __future__ import annotations
+
+import logging
+
+from research_hub.search.semantic_scholar import SemanticScholarClient
+
+
+def test_non_latin1_env_api_key_is_ignored(monkeypatch, caplog) -> None:
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "\u96ff\ueea0?_SS_API_KEY")
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="research_hub.search.semantic_scholar",
+    ):
+        client = SemanticScholarClient()
+
+    assert client.api_key is None
+    assert client._headers() == {}
+    assert "SEMANTIC_SCHOLAR_API_KEY is not ASCII/latin-1" in caplog.text
+    assert "querying Semantic Scholar anonymously" in caplog.text
+
+
+def test_valid_ascii_env_api_key_is_sent(monkeypatch) -> None:
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "valid-key-123")
+
+    client = SemanticScholarClient()
+
+    assert client.api_key == "valid-key-123"
+    assert client._headers()["x-api-key"] == "valid-key-123"
+
+
+def test_whitespace_only_env_api_key_is_anonymous(monkeypatch) -> None:
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "  \t  ")
+
+    client = SemanticScholarClient()
+
+    assert client.api_key is None
+    assert client._headers() == {}
+
+
+def test_unset_env_api_key_is_anonymous(monkeypatch) -> None:
+    monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+
+    client = SemanticScholarClient()
+
+    assert client.api_key is None
+    assert client._headers() == {}
+
+
+def test_non_latin1_explicit_arg_api_key_is_ignored(monkeypatch, caplog) -> None:
+    """Direct constructor arg path (not env): non-latin-1 key must also
+    be ignored with a warning, not crash when requests encodes headers."""
+    monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="research_hub.search.semantic_scholar",
+    ):
+        client = SemanticScholarClient(api_key="雿bad")
+
+    assert client.api_key is None
+    assert client._headers() == {}
+    assert "SEMANTIC_SCHOLAR_API_KEY is not ASCII/latin-1" in caplog.text


### PR DESCRIPTION
## Problem (live evidence, reproduced 3×)

Fresh-vault `auto "machine learning flood forecasting" --peer-reviewed --no-nlm` ingested **0 papers** — every candidate fail-closed-quarantined:

- `miiro2025` DOI `10.1111/jfr3.70039` (real Wiley *J. Flood Risk Mgmt*): live `_resolve_head_with_retry` → `status=403, transient=False` deterministically. → `doi_unresolved` / `L1` quarantine. **Root cause: 403 ∉ the old `_TRANSIENT_HTTP_STATUS`** → a publisher anti-bot Forbidden on a **valid** DOI was misclassified as "DOI does not resolve."
- non-ASCII `SEMANTIC_SCHOLAR_API_KEY` → `'latin-1' codec can't encode` UnicodeEncodeError in `_headers()`, SS backend silently dies (0 results, no clear message).

F7's documented thesis ("anti-bot block is not fabrication") was incompletely applied — only 418 was deferred; 401/403/406/451 still fail-closed-quarantined valid DOIs.

## Fix — conservative, suppression-of-false-fail-closed only

**No version bump** (not a release). No acceptance path widened. Deferring is NOT accepting (`L1-deferred` papers don't enter the vault).

### `authenticity.py`
- New `_DEFINITIVE_NOTFOUND_HTTP_STATUS = frozenset({404, 410})`.
- `_resolve_head_with_retry` per-attempt classification rewritten: only resolved success (`status < 400`) and definitive non-existence (404/410) early-return as **non-transient**; every other status (anti-bot 401/403/406/418/451, rate-limit 429, 5xx) AND `RequestException` AND `0`/malformed falls through to retry → eventually returns transient.
- Result: `verify_authenticity` routes anti-bot HEAD failures to `DEFERRED_LAYER` (`L1-deferred` / `doi_check_unavailable`, NOT cached as a permanent miss). Definitive 404/410 keep their fail-closed `doi_unresolved` / `L1` behaviour — **anti-fabrication guarantee structurally unchanged**.
- Removed the now-unreferenced `_TRANSIENT_HTTP_STATUS` constant (code-reviewer required follow-up).
- Updated comment block; `_resolve_identifier` / `verify_authenticity` / `is_transient_reason` / `_unavailable_reason_for` / `_unresolved_reason_for` not touched.

### `semantic_scholar.py`
- After the existing strip/normalize, `api_key.encode("latin-1")` validation; on `UnicodeEncodeError` log a clear warning via the module logger and treat as anonymous (api_key = None) so SS queries proceed unauthenticated instead of crashing.
- Whitespace-only → None (v0.88.15) and env / explicit-arg paths preserved.

### Tests
- F7: parametrized 401/403/451 defer (incl. end-to-end `verify_authenticity` 403 → `L1-deferred` / `doi_check_unavailable`); parametrized 404/410 stay fail-closed `doi_unresolved` (fabrication guard); 5xx transient; `RequestException` transient.
- SS-key (new file): non-latin-1 env / valid ASCII / whitespace-only / unset / non-latin-1 direct constructor arg → all behave correctly.
- L5 invariant CI gate (`tests/test_authenticity_l5_invariant.py`) green.
- **Full suite: 2747 passed, 24 skipped, 2 xfailed, 1 xpassed, 0 failed.**

## Review

`code-reviewer` subagent → **APPROVE** with required follow-up. Applied:
- Removed dead `_TRANSIENT_HTTP_STATUS` (required follow-up).
- S3: added direct-arg path SS-key test (coverage closure).
- W2: dropped redundant `!= "doi_unresolved"` assertion (already covered by `== "doi_check_unavailable"`).

## Out of scope (honest non-goals)

- Auto-detecting an SS API key rate-limit cool-off / multi-backend corroboration retry (the `uncorroborated` L2 axis is a separate concern; this PR only stops false-positive fail-closing on access-blocked DOIs and prevents a non-ASCII key from crashing the SS backend).
- Investigating the 418-in-`auto` anomaly observed pre-fix (gate was correct in isolation; the new principled "only 404/410 fails closed" structurally covers whatever non-transient status the publisher CDN had returned under load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)