### PR TITLE
fix(authenticity): DOI resolve cache auto-migrates pre-PR-#51 poisoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,17 @@ graph rebuild (link out to the real tools instead)._
   non-latin-1 `SEMANTIC_SCHOLAR_API_KEY` now emits a clear warning and
   is ignored so the backend queries anonymously instead of crashing while
   requests encodes the `x-api-key` header.
+- **DOI resolve cache auto-migrates pre-PR-#51 poisoning.** The F7
+  completion (anti-bot HEAD defers, PR #51) was silently neutralised on
+  any DOI cached under the old non-transient classification -- the
+  cache-hit short-circuit returned the stale `doi_unresolved` outcome
+  before the new logic ran. `DoiResolveCache.load` now performs a
+  one-shot schema 1.0 -> 1.1 migration that prunes
+  `reason="doi_unresolved"` entries whose `status_code` is not in
+  `{404, 410}` (genuine non-existence) and rewrites the cache at the
+  new schema version. Entries with status 404/410, success entries, and
+  any other reason are preserved. Idempotent; logged at WARNING when
+  any entry is pruned.
 
 ### Removed
 - **Dead `notebooklm login` flags:** `--cdp`, `--chrome-binary`,

--- a/src/research_hub/authenticity.py
+++ b/src/research_hub/authenticity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 import time
 import unicodedata
@@ -18,6 +19,8 @@ from research_hub.locks import file_lock
 from research_hub.security import atomic_write_text
 from research_hub.utils.doi import extract_arxiv_id
 
+logger = logging.getLogger(__name__)
+
 try:
     from rapidfuzz import fuzz
 except ImportError:  # pragma: no cover - rapidfuzz is a declared dependency
@@ -31,7 +34,7 @@ except ImportError:  # pragma: no cover - rapidfuzz is a declared dependency
     fuzz = _FuzzFallback()
 
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.1"
 DOI_RESOLVE_CACHE = "doi_resolve_cache.json"
 QUARANTINE_DIR = "quarantine"
 # PR-C (deep F7): a TRANSIENT identifier-resolution failure (doi.org /
@@ -81,6 +84,26 @@ class ResolveOutcome:
         )
 
 
+def _is_pre_f7_poisoned(outcome: ResolveOutcome) -> bool:
+    """Return True for stale fail-closed cache entries from before PR #51.
+
+    These are old ``doi_unresolved`` outcomes for statuses that the F7
+    resolver now treats as transient/unavailable rather than definitive
+    non-registration. Genuine 404/410 misses and status-less legacy entries
+    are preserved. status_code=0 is provably never written to disk by
+    the current resolver: _resolve_head_with_retry's if status_code
+    and status_code < 400 guard is falsy for 0, so the loop falls
+    through to the transient return, and the transient branch in
+    _resolve_identifier returns BEFORE calling cache.put.
+    """
+    if outcome.reason != "doi_unresolved":
+        return False
+    status_code = outcome.status_code
+    if status_code is None:
+        return False
+    return status_code not in _DEFINITIVE_NOTFOUND_HTTP_STATUS
+
+
 class DoiResolveCache:
     """Small JSON cache for identifier resolution outcomes."""
 
@@ -95,12 +118,37 @@ class DoiResolveCache:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             return cls()
-        results = {
-            key: ResolveOutcome.from_dict(value)
-            for key, value in data.get("results", {}).items()
-            if isinstance(value, dict)
-        }
-        return cls(results)
+        if not isinstance(data, dict):
+            return cls()
+        loaded_version = str(data.get("schema_version", "1.0") or "1.0")
+        raw_results = data.get("results", {})
+        if not isinstance(raw_results, dict):
+            raw_results = {}
+        results: dict[str, ResolveOutcome] = {}
+        pruned = 0
+        needs_migration = loaded_version != SCHEMA_VERSION
+        for key, value in raw_results.items():
+            if not isinstance(value, dict):
+                continue
+            outcome = ResolveOutcome.from_dict(value)
+            if needs_migration and _is_pre_f7_poisoned(outcome):
+                pruned += 1
+                continue
+            results[key] = outcome
+        instance = cls(results)
+        if needs_migration:
+            instance.save(path)
+            if pruned:
+                logger.warning(
+                    "DoiResolveCache migrated schema %s -> %s: pruned %d "
+                    "stale `doi_unresolved` entr%s from before PR #51 "
+                    "(anti-bot HEAD statuses now defer, see CHANGELOG).",
+                    loaded_version,
+                    SCHEMA_VERSION,
+                    pruned,
+                    "y" if pruned == 1 else "ies",
+                )
+        return instance
 
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_authenticity.py
+++ b/tests/test_authenticity.py
@@ -88,7 +88,7 @@ def test_l1_doi_404_quarantines_and_uses_cache(tmp_path, monkeypatch):
 
     cache_path = cfg.research_hub_dir / "doi_resolve_cache.json"
     payload = json.loads(cache_path.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == "1.0"
+    assert payload["schema_version"] == "1.1"
     assert "doi:10.1000/missing" in payload["results"]
 
     def fail_if_called(*_args, **_kwargs):

--- a/tests/test_v1_f7_cache_migration.py
+++ b/tests/test_v1_f7_cache_migration.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research_hub.authenticity import DoiResolveCache, SCHEMA_VERSION
+
+
+def _entry(
+    key: str,
+    *,
+    ok: bool = False,
+    status_code: int | None = None,
+    reason: str = "doi_unresolved",
+) -> dict:
+    return {
+        "ok": ok,
+        "key": key,
+        "resolved_via": "doi.org",
+        "checked_at": "2026-05-18T00:00:00Z",
+        "status_code": status_code,
+        "reason": reason,
+        "url": f"https://doi.org/{key.removeprefix('doi:')}",
+    }
+
+
+def _write_cache(path: Path, schema_version: str, results: dict[str, dict]) -> None:
+    path.write_text(
+        json.dumps({"schema_version": schema_version, "results": results}),
+        encoding="utf-8",
+    )
+
+
+def _read_cache(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_pre_11_cache_with_poisoned_entries_is_pruned_and_bumped(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    path = tmp_path / "doi_resolve_cache.json"
+    _write_cache(
+        path,
+        "1.0",
+        {
+            "doi:10.1002/cav.2290": _entry("doi:10.1002/cav.2290", status_code=403),
+            "doi:wang2026": _entry("doi:wang2026", status_code=418),
+            "doi:fake.404": _entry("doi:fake.404", status_code=404),
+            "doi:ok.paper": _entry("doi:ok.paper", ok=True, status_code=200, reason=""),
+        },
+    )
+
+    with caplog.at_level("WARNING", logger="research_hub.authenticity"):
+        cache = DoiResolveCache.load(path)
+
+    assert set(cache.results) == {"doi:fake.404", "doi:ok.paper"}
+    assert "pruned 2 stale" in caplog.text
+    payload = _read_cache(path)
+    assert payload["schema_version"] == SCHEMA_VERSION == "1.1"
+    assert set(payload["results"]) == {"doi:fake.404", "doi:ok.paper"}
+
+
+def test_pre_11_cache_without_poisoned_entries_is_bumped_unchanged(
+    tmp_path: Path,
+    caplog,
+) -> None:
+    path = tmp_path / "doi_resolve_cache.json"
+    results = {
+        "doi:fake.404": _entry("doi:fake.404", status_code=404),
+        "doi:ok.paper": _entry("doi:ok.paper", ok=True, status_code=200, reason=""),
+    }
+    _write_cache(path, "1.0", results)
+
+    with caplog.at_level("WARNING", logger="research_hub.authenticity"):
+        cache = DoiResolveCache.load(path)
+
+    assert set(cache.results) == set(results)
+    assert "pruned" not in caplog.text
+    payload = _read_cache(path)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["results"] == results
+
+
+def test_already_11_cache_is_not_migrated_or_rewritten(tmp_path: Path) -> None:
+    path = tmp_path / "doi_resolve_cache.json"
+    results = {
+        "doi:blocked.403": _entry("doi:blocked.403", status_code=403),
+        "doi:fake.404": _entry("doi:fake.404", status_code=404),
+    }
+    _write_cache(path, SCHEMA_VERSION, results)
+    before_mtime_ns = path.stat().st_mtime_ns
+
+    cache = DoiResolveCache.load(path)
+
+    assert set(cache.results) == set(results)
+    assert "doi:blocked.403" in cache.results
+    assert path.stat().st_mtime_ns == before_mtime_ns
+    assert _read_cache(path)["results"] == results
+
+
+def test_cache_migration_is_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "doi_resolve_cache.json"
+    _write_cache(
+        path,
+        "1.0",
+        {
+            "doi:blocked.403": _entry("doi:blocked.403", status_code=403),
+            "doi:fake.404": _entry("doi:fake.404", status_code=404),
+            "doi:ok.paper": _entry("doi:ok.paper", ok=True, status_code=200, reason=""),
+        },
+    )
+
+    first = DoiResolveCache.load(path)
+    first_payload = _read_cache(path)
+    second = DoiResolveCache.load(path)
+    second_payload = _read_cache(path)
+
+    assert set(first.results) == {"doi:fake.404", "doi:ok.paper"}
+    assert set(second.results) == set(first.results)
+    assert second_payload == first_payload
+
+
+def test_arxiv_unresolved_entry_is_not_pruned(tmp_path: Path) -> None:
+    """S2 regression guard: F7 anti-bot completion targeted ONLY the
+    doi.org HEAD path. The `arxiv_unresolved` / `identifier_unresolved`
+    reasons come from separate resolvers and were not affected; their
+    cache entries must NOT be touched even with anti-bot-class status
+    codes attached."""
+    path = tmp_path / "doi_resolve_cache.json"
+    _write_cache(
+        path,
+        "1.0",
+        {
+            "arxiv:2401.00001": _entry(
+                "arxiv:2401.00001",
+                status_code=403,
+                reason="arxiv_unresolved",
+            ),
+            "other:custom-id": _entry(
+                "other:custom-id",
+                status_code=403,
+                reason="identifier_unresolved",
+            ),
+        },
+    )
+
+    cache = DoiResolveCache.load(path)
+
+    assert set(cache.results) == {"arxiv:2401.00001", "other:custom-id"}
+    payload = _read_cache(path)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert set(payload["results"]) == {"arxiv:2401.00001", "other:custom-id"}
+
+
+def test_statusless_doi_unresolved_entry_is_preserved(tmp_path: Path) -> None:
+    path = tmp_path / "doi_resolve_cache.json"
+    _write_cache(
+        path,
+        "1.0",
+        {"doi:statusless": _entry("doi:statusless", status_code=None)},
+    )
+
+    cache = DoiResolveCache.load(path)
+
+    assert set(cache.results) == {"doi:statusless"}
+    payload = _read_cache(path)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["results"]["doi:statusless"]["status_code"] is None
+
+
+def test_missing_empty_and_corrupt_cache_load_as_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    assert DoiResolveCache.load(missing).results == {}
+
+    empty = tmp_path / "empty.json"
+    empty.write_text("", encoding="utf-8")
+    assert DoiResolveCache.load(empty).results == {}
+
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    assert DoiResolveCache.load(corrupt).results == {}
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("[]", encoding="utf-8")
+    assert DoiResolveCache.load(malformed).results == {}


### PR DESCRIPTION
## Problem (directly observed; quantified)

PR #51 completed F7 (anti-bot HEAD 401/403/406/418/451/etc. → `L1-deferred / doi_check_unavailable`). Verified live: clearing the local cache moved `auto --peer-reviewed` from `0 written, 5 quarantined, 0 deferred` to `0 written, 1 quarantined, 2 deferred` — the 403/418 anti-bot DOIs landed in the deferred bucket as designed.

**But with the cache intact, the same fix appeared broken.** Root cause: `DoiResolveCache` stores pre-fix outcomes verbatim and `_resolve_identifier` short-circuits on cache hits BEFORE the resolver runs → stale `doi_unresolved` outcomes silently pin the old fail-closed behaviour. On the maintainer vault, **70 of 174 cache entries (40%)** were this poisoning class. Anyone who ran `research-hub auto` pre-PR-#51 and upgrades has F7 completion neutralised on the DOIs they touched.

## Fix — suppression-of-stale-cache only

**No version bump.** Strictly drops stale fail-closed entries; never creates an accepted (ok=True) entry. Failing the prune is strictly safer than over-pruning.

- Bump `SCHEMA_VERSION` `"1.0"` → `"1.1"` in `authenticity.py`.
- `DoiResolveCache.load` performs a one-shot schema 1.0→1.1 migration: prune entries where `reason == "doi_unresolved"` AND `status_code not in {404, 410}` (genuine non-existence stays). Persist via the existing `file_lock` + `atomic_write_text` path; log a WARNING with the pruned count. Subsequent loads find schema=1.1 and no-op (idempotent).
- Private predicate `_is_pre_f7_poisoned` is exact 3-part: reason-check first, then status_code-is-not-None, then status_code not in `{404, 410}`. Preserved: 404/410, ok=True success, status-less legacy `doi_unresolved` (defensive against RequestException path), `arxiv_unresolved` / `identifier_unresolved` (separate resolvers, not affected by F7 anti-bot work).
- Codex defensive additions (sound hardening): `if not isinstance(data, dict)` guards malformed-list cache, `if not isinstance(raw_results, dict)` guards malformed-results.

## Tests

7 cases in `tests/test_v1_f7_cache_migration.py`:
- Pre-1.1 with poisoned (403/418/404/200): only 404+200 survive, WARNING `"pruned 2 stale"`, file rewritten at 1.1.
- Pre-1.1 without poisoned: schema bumped silently, no WARNING.
- Already-1.1 cache with `status=403` blocked-but-cached entry: no migration, mtime_ns unchanged, entry preserved.
- Idempotency: load twice, second is clean no-op.
- `arxiv_unresolved` + `identifier_unresolved` with status 403: **NOT pruned** (S2 regression guard against future predicate widening).
- Status-less `doi_unresolved`: preserved (defensive).
- Missing / empty / corrupt / malformed-list cache: empty cache, no crash.

Plus the method-brain "grep old value after bump" hygiene: `tests/test_authenticity.py:91` schema-version assertion `"1.0"` → `"1.1"`.

L5 anti-fabrication invariant unchanged (`tests/test_authenticity_l5_invariant.py` green). **Full suite: 2753 passed, 24 skipped, 2 xfailed, 1 xpassed, 0 failed** (+6 migration tests vs cb7046f baseline; +1 from the S2 follow-up).

## Review

`code-reviewer` subagent → **APPROVE** (10/10 invariants pass: predicate exactness, L5 untouched, idempotency, save-on-post-prune-instance, scope confined to DOI cache, locking unchanged, defensive additions sound). Applied S1 (docstring note that `status_code=0` is provably never written — proved by tracing the `if status_code and status_code < 400` falsy path through `_resolve_head_with_retry` to the transient return that bypasses `cache.put`) and S2 (regression test for `arxiv_unresolved` not pruned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)