### PR TITLE
fix(authenticity): L2 augments single-source DOIs via direct CrossRef metadata verify (PR-A of 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@ graph rebuild (link out to the real tools instead)._
   instead of a generic `pip install` hint that cannot succeed there.
 
 ### Fixed
+- **L2 corroboration augments single-source DOIs with direct CrossRef
+  metadata verify.** A paper found by only one search backend (e.g.
+  `source: 'openalex'`) was quarantined `L2 / uncorroborated` even when
+  its DOI was independently confirmable via CrossRef. The gate now
+  does a direct `https://api.crossref.org/works/{doi}` metadata fetch
+  for such papers; if CrossRef returns a record whose title/year/
+  authors match per the existing `_records_agree` predicate
+  (`fuzz.token_set_ratio >= 85`, `|year_delta| <= 1`, surname
+  intersection >= 1), CrossRef is recorded as a verified backend and
+  the paper passes L2. Strictly augmentative: CrossRef is an
+  authoritative metadata source, this only adds an existing-paper
+  evidence check; the L2 corroboration bar itself is unchanged. Result
+  cached in `crossref_verify_cache.json` (schema 1.0); failures are
+  fail-quiet and not cached.
 - `zotero gc` / `zotero mark-kept --all-orphans`: a real cluster
   collection whose Zotero key drifted from its `cluster.zotero_collection_key`
   binding (e.g. a Zotero-truncated date-prefixed name like

--- a/src/research_hub/authenticity.py
+++ b/src/research_hub/authenticity.py
@@ -16,6 +16,7 @@ import requests
 
 from research_hub.dedup import normalize_doi, normalize_title
 from research_hub.locks import file_lock
+from research_hub.search.crossref import CrossrefBackend
 from research_hub.security import atomic_write_text
 from research_hub.utils.doi import extract_arxiv_id
 
@@ -36,6 +37,8 @@ except ImportError:  # pragma: no cover - rapidfuzz is a declared dependency
 
 SCHEMA_VERSION = "1.1"
 DOI_RESOLVE_CACHE = "doi_resolve_cache.json"
+CROSSREF_VERIFY_SCHEMA_VERSION = "1.0"
+CROSSREF_VERIFY_CACHE = "crossref_verify_cache.json"
 QUARANTINE_DIR = "quarantine"
 # PR-C (deep F7): a TRANSIENT identifier-resolution failure (doi.org /
 # Crossref rate-limit or network blip, after PR-B's bounded retry) is
@@ -176,6 +179,64 @@ class DoiResolveCache:
         return self.results.pop(key, None) is not None
 
 
+class CrossrefVerifyCache:
+    """Small JSON cache for direct CrossRef metadata verification outcomes."""
+
+    def __init__(self, results: dict[str, dict[str, Any]] | None = None) -> None:
+        self.results = results or {}
+
+    @classmethod
+    def load(cls, path: Path) -> "CrossrefVerifyCache":
+        if not path.exists():
+            return cls()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return cls()
+        if not isinstance(data, dict):
+            return cls()
+        raw_results = data.get("results", {})
+        if not isinstance(raw_results, dict):
+            return cls()
+        results: dict[str, dict[str, Any]] = {}
+        for key, value in raw_results.items():
+            if not isinstance(value, dict):
+                continue
+            verified = value.get("verified")
+            if not isinstance(verified, bool):
+                continue
+            results[str(key)] = {
+                "verified": verified,
+                "checked_at": str(value.get("checked_at", "") or ""),
+            }
+        return cls(results)
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": CROSSREF_VERIFY_SCHEMA_VERSION,
+            "results": {
+                key: value
+                for key, value in sorted(self.results.items())
+            },
+        }
+        with file_lock(path):
+            atomic_write_text(
+                path,
+                json.dumps(payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+
+    def get(self, key: str) -> dict[str, Any] | None:
+        return self.results.get(key)
+
+    def put(self, key: str, verified: bool) -> None:
+        self.results[key] = {
+            "verified": bool(verified),
+            "checked_at": _utc_now_iso(),
+        }
+
+
 def verify_authenticity(
     papers: list[dict],
     cfg,
@@ -192,6 +253,8 @@ def verify_authenticity(
     """
     cache_path = Path(cfg.research_hub_dir) / DOI_RESOLVE_CACHE
     cache = DoiResolveCache.load(cache_path)
+    crossref_cache_path = Path(cfg.research_hub_dir) / CROSSREF_VERIFY_CACHE
+    crossref_cache = CrossrefVerifyCache.load(crossref_cache_path)
     accepted: list[dict] = []
     quarantined: list[dict] = []
     fit_scores = _load_fit_scores(cfg, cluster_slug) if do_fit_check else {}
@@ -295,6 +358,12 @@ def verify_authenticity(
                     )
                 )
                 continue
+
+            # L2 augment (PR-A, 2026-05): direct CrossRef-by-DOI metadata verify
+            # for single-source papers with a DOI. Strictly augmentative: adds a
+            # verified backend; never bypasses the L2 gate that follows.
+            if _corroboration_label(paper) == "single-source":
+                _crossref_verify_corroboration(paper, crossref_cache, crossref_cache_path)
 
             # L2b: uncorroborated single-source gate — enforces already-computed signal
             corro = _corroboration_label(paper)
@@ -655,6 +724,149 @@ def _metadata_integrity_reason(paper: dict) -> str:
     if has_straggler and has_real:
         return "straggler venue conflicts with real venue"
     return ""
+
+
+def _crossref_verify_corroboration(
+    paper: dict,
+    cache: "CrossrefVerifyCache",
+    cache_path: Path,
+) -> bool:
+    """Augment ``paper`` in-place with a verified CrossRef record.
+
+    Runs only when the existing corroboration is single-source and the paper
+    has a DOI not already CrossRef-corroborated. Returns True iff CrossRef
+    confirmed and the paper was augmented; False otherwise.
+
+    Strictly augmentative: only appends to ``paper['source_records']`` and
+    ``paper['backends']``; never removes or downgrades anything. CrossRef
+    errors fail quiet so the existing L2 gate continues unchanged.
+    """
+    doi = normalize_doi(str(paper.get("doi", "") or ""))
+    if not doi:
+        return False
+    if _corroboration_label(paper) != "single-source":
+        return False
+    backend_names = _backend_names(paper)
+    if any(name.casefold() == "crossref" for name in backend_names):
+        return False
+
+    key = f"doi:{doi}"
+    existing_backend = next(
+        (name for name in backend_names if name.casefold() != "crossref"),
+        "candidate",
+    )
+    paper_record = {
+        "source": existing_backend,
+        "title": str(paper.get("title", "") or ""),
+        "year": paper.get("year"),
+        "authors": _authors_as_list(paper.get("authors")),
+    }
+
+    cached = cache.get(key)
+    if cached is not None:
+        if not bool(cached.get("verified")):
+            return False
+        _append_crossref_corroboration(paper, _crossref_record_from_paper(paper))
+        return True
+
+    try:
+        result, crossref_status, response_missing = _crossref_get_paper_with_status(doi)
+    except Exception as exc:
+        logger.debug("CrossRef DOI metadata verification failed for %s: %s", doi, exc)
+        return False
+
+    if result is None:
+        # 200-with-empty-body is a transient CrossRef API anomaly (the
+        # response was OK but `message` was empty/missing) -- treat as
+        # transient, do NOT cache. Per the F7-style spec: only definitive
+        # outcomes (200+match, 200+mismatch, 404) are cached; every other
+        # status/state retries on next run.
+        if response_missing or crossref_status == 200 or (
+            crossref_status is not None
+            and crossref_status >= 400
+            and crossref_status != 404
+        ):
+            return False
+        cache.put(key, verified=False)
+        cache.save(cache_path)
+        return False
+
+    crossref_record = {
+        "source": "crossref",
+        "title": str(result.title or ""),
+        "year": result.year,
+        "authors": _authors_as_list(result.authors),
+    }
+    if not _records_agree([paper_record, crossref_record]):
+        cache.put(key, verified=False)
+        cache.save(cache_path)
+        return False
+
+    _append_crossref_corroboration(paper, crossref_record)
+    cache.put(key, verified=True)
+    cache.save(cache_path)
+    return True
+
+
+def _crossref_get_paper_with_status(doi: str) -> tuple[Any, int | None, bool]:
+    backend = CrossrefBackend()
+    status_code: int | None = None
+    response_missing = False
+    original_request = getattr(backend, "_request", None)
+
+    if callable(original_request):
+
+        def tracked_request(*args: Any, **kwargs: Any) -> Any:
+            nonlocal response_missing, status_code
+            response = original_request(*args, **kwargs)
+            if response is None:
+                response_missing = True
+                return None
+            try:
+                status_code = int(getattr(response, "status_code", 0) or 0)
+            except (TypeError, ValueError):
+                status_code = None
+            return response
+
+        backend._request = tracked_request  # type: ignore[method-assign]
+
+    return backend.get_paper(doi), status_code, response_missing
+
+
+def _crossref_record_from_paper(paper: dict) -> dict[str, Any]:
+    return {
+        "source": "crossref",
+        "title": str(paper.get("title", "") or ""),
+        "year": paper.get("year"),
+        "authors": _authors_as_list(paper.get("authors")),
+    }
+
+
+def _append_crossref_corroboration(paper: dict, crossref_record: dict[str, Any]) -> None:
+    backends = paper.get("backends")
+    if isinstance(backends, str):
+        backend_values = [backends]
+    elif isinstance(backends, list):
+        backend_values = backends
+    else:
+        backend_values = []
+    if not any(str(name).casefold() == "crossref" for name in backend_values):
+        backend_values.append("crossref")
+    paper["backends"] = backend_values
+
+    source_records = paper.get("source_records")
+    if not isinstance(source_records, list):
+        source_records = []
+        paper["source_records"] = source_records
+    source_records.append(crossref_record)
+
+
+def _authors_as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return list(value)
+    return [value]
 
 
 def _corroboration_label(paper: dict) -> str:

--- a/tests/test_v1_l2_crossref_doi_verify.py
+++ b/tests/test_v1_l2_crossref_doi_verify.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+import research_hub.authenticity as auth
+from research_hub.authenticity import (
+    CROSSREF_VERIFY_CACHE,
+    CrossrefVerifyCache,
+    verify_authenticity,
+)
+
+
+class _Resp:
+    def __init__(self, status_code: int = 200, payload: dict | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> dict:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(str(self.status_code))
+
+
+def _cfg(tmp_path: Path) -> SimpleNamespace:
+    root = tmp_path / "vault"
+    cfg = SimpleNamespace(
+        root=root,
+        raw=root / "raw",
+        hub=root / "hub",
+        logs=root / "logs",
+        research_hub_dir=root / ".research_hub",
+        clusters_file=root / ".research_hub" / "clusters.yaml",
+        zotero_library_id="",
+        zotero_default_collection=None,
+        zotero_collections={},
+    )
+    for path in (cfg.raw, cfg.hub, cfg.logs, cfg.research_hub_dir):
+        path.mkdir(parents=True, exist_ok=True)
+    return cfg
+
+
+def _paper(
+    title: str = "Review and Intercomparison of Machine Learning Applications for Short-term Flood Forecasting",
+    doi: str = "10.1007/s11269-025-04093-x",
+    **extra,
+) -> dict:
+    paper = {
+        "title": title,
+        "doi": doi,
+        "authors": [{"creatorType": "author", "firstName": "Jane", "lastName": "Doe"}],
+        "authors_str": "Doe, Jane",
+        "year": 2025,
+        "journal": "Journal of Testing",
+        "venue": "Journal of Testing",
+        "abstract": "A real abstract.",
+        "summary": "Summary",
+        "key_findings": ["One"],
+        "methodology": "Survey",
+        "relevance": "Relevant",
+        "slug": title.lower().replace(" ", "-")[:80],
+        "sub_category": "agents",
+        "tags": [],
+        "source": "openalex",
+        "citation_count": 0,
+    }
+    paper.update(extra)
+    return paper
+
+
+def _work(
+    *,
+    doi: str = "10.1007/s11269-025-04093-x",
+    title: str = "Review and Intercomparison of Machine Learning Applications for Short-term Flood Forecasting",
+    year: int = 2025,
+    family: str = "Doe",
+    given: str = "Jane",
+) -> dict:
+    return {
+        "DOI": doi,
+        "title": [title],
+        "author": [{"family": family, "given": given}],
+        "issued": {"date-parts": [[year, 1, 1]]},
+        "container-title": ["Journal of Testing"],
+        "type": "journal-article",
+    }
+
+
+def _ok_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth.requests, "head", lambda *a, **k: _Resp(200))
+
+
+def _crossref_get(monkeypatch: pytest.MonkeyPatch, response: _Resp) -> None:
+    monkeypatch.setattr("research_hub.search.crossref.requests.get", lambda *a, **k: response)
+
+
+def _cache_payload(cfg: SimpleNamespace) -> dict:
+    return json.loads((cfg.research_hub_dir / CROSSREF_VERIFY_CACHE).read_text(encoding="utf-8"))
+
+
+def _write_verify_cache(cfg: SimpleNamespace, doi: str, verified: bool) -> None:
+    path = cfg.research_hub_dir / CROSSREF_VERIFY_CACHE
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "results": {
+                    f"doi:{auth.normalize_doi(doi)}": {
+                        "verified": verified,
+                        "checked_at": "2026-05-20T00:00:00Z",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_openalex_only_single_source_crossref_match_passes_l2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+    _crossref_get(monkeypatch, _Resp(payload={"message": _work()}))
+
+    paper = _paper()
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert quarantined == []
+    assert len(accepted) == 1
+    accepted_paper = accepted[0]
+    assert "crossref" in accepted_paper["backends"]
+    assert any(record.get("source") == "crossref" for record in accepted_paper["source_records"])
+    assert accepted_paper["provenance"]["corroboration"] == "corroborated"
+    entry = _cache_payload(cfg)["results"]["doi:10.1007/s11269-025-04093-x"]
+    assert entry["verified"] is True
+
+
+def test_crossref_404_keeps_single_source_quarantined_and_caches_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+    _crossref_get(monkeypatch, _Resp(status_code=404))
+
+    accepted, quarantined = verify_authenticity([_paper()], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["layer"] == "L2"
+    assert quarantined[0]["reason"] == "uncorroborated"
+    entry = _cache_payload(cfg)["results"]["doi:10.1007/s11269-025-04093-x"]
+    assert entry["verified"] is False
+
+
+def test_crossref_different_paper_does_not_satisfy_l2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+    _crossref_get(
+        monkeypatch,
+        _Resp(
+            payload={
+                "message": _work(
+                    title="A Different Article About Bridge Inspection",
+                    year=2020,
+                    family="Smith",
+                    given="Alex",
+                )
+            }
+        ),
+    )
+
+    paper = _paper()
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["layer"] == "L2"
+    assert quarantined[0]["reason"] == "uncorroborated"
+    assert "crossref" not in [str(name).casefold() for name in paper.get("backends", [])]
+    assert not any(record.get("source") == "crossref" for record in paper.get("source_records", []))
+    entry = _cache_payload(cfg)["results"]["doi:10.1007/s11269-025-04093-x"]
+    assert entry["verified"] is False
+
+
+def test_already_two_backend_paper_does_not_fetch_crossref(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("CrossRef should not be fetched for already corroborated papers")
+
+    monkeypatch.setattr(auth.CrossrefBackend, "get_paper", fail_if_called)
+    paper = _paper(backends=["crossref", "openalex"])
+
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert quarantined == []
+    assert len(accepted) == 1
+    assert not (cfg.research_hub_dir / CROSSREF_VERIFY_CACHE).exists()
+
+
+def test_no_doi_paper_does_not_fetch_or_augment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("CrossRef should not be fetched without a DOI")
+
+    monkeypatch.setattr(auth.CrossrefBackend, "get_paper", fail_if_called)
+    paper = _paper(doi="", openalex_id="W12345")
+
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["layer"] == "L2"
+    assert quarantined[0]["reason"] == "uncorroborated"
+    assert "backends" not in paper
+    assert "source_records" not in paper
+
+
+def test_crossref_exception_fails_quiet_and_does_not_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+
+    def raise_request_error(*_args, **_kwargs):
+        raise requests.RequestException("timeout")
+
+    monkeypatch.setattr("research_hub.search.crossref.requests.get", raise_request_error)
+    paper = _paper()
+
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["reason"] == "uncorroborated"
+    assert not (cfg.research_hub_dir / CROSSREF_VERIFY_CACHE).exists()
+    assert "backends" not in paper
+    assert "source_records" not in paper
+
+
+def test_crossref_5xx_fails_quiet_and_does_not_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+    _crossref_get(monkeypatch, _Resp(status_code=500))
+    paper = _paper()
+
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["reason"] == "uncorroborated"
+    assert not (cfg.research_hub_dir / CROSSREF_VERIFY_CACHE).exists()
+    assert "backends" not in paper
+    assert "source_records" not in paper
+
+
+def test_crossref_200_empty_body_fails_quiet_and_does_not_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """W2: a 200 OK with missing/empty `message` is a transient CrossRef
+    API anomaly, not a definitive negative -- must fail quiet (no cache
+    write) so the next run retries instead of permanently blocking the
+    paper. Anti-fabrication still safe: paper stays uncorroborated."""
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+    _crossref_get(monkeypatch, _Resp(status_code=200, payload={}))
+    paper = _paper()
+
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["reason"] == "uncorroborated"
+    assert not (cfg.research_hub_dir / CROSSREF_VERIFY_CACHE).exists()
+    assert "backends" not in paper
+    assert "source_records" not in paper
+
+
+def test_verified_true_cache_hit_augments_without_fetch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+    doi = "10.1007/s11269-025-04093-x"
+    _write_verify_cache(cfg, doi, verified=True)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("verified cache hit should not fetch CrossRef")
+
+    monkeypatch.setattr(auth.CrossrefBackend, "get_paper", fail_if_called)
+    paper = _paper(doi=doi)
+
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert quarantined == []
+    assert len(accepted) == 1
+    assert "crossref" in paper["backends"]
+    assert any(record.get("source") == "crossref" for record in paper["source_records"])
+
+
+def test_verified_false_cache_hit_does_not_augment_or_fetch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = _cfg(tmp_path)
+    _ok_head(monkeypatch)
+    doi = "10.1007/s11269-025-04093-x"
+    _write_verify_cache(cfg, doi, verified=False)
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("negative cache hit should not fetch CrossRef")
+
+    monkeypatch.setattr(auth.CrossrefBackend, "get_paper", fail_if_called)
+    paper = _paper(doi=doi)
+
+    accepted, quarantined = verify_authenticity([paper], cfg, cluster_slug="agents")
+
+    assert accepted == []
+    assert len(quarantined) == 1
+    assert quarantined[0]["reason"] == "uncorroborated"
+    assert "backends" not in paper
+    assert "source_records" not in paper
+
+
+def test_crossref_verify_cache_loads_missing_and_corrupt_as_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    assert CrossrefVerifyCache.load(missing).results == {}
+
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    assert CrossrefVerifyCache.load(corrupt).results == {}
+
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("[]", encoding="utf-8")
+    assert CrossrefVerifyCache.load(malformed).results == {}
+
+
+def test_crossref_verify_cache_save_writes_schema_and_results(tmp_path: Path) -> None:
+    path = tmp_path / CROSSREF_VERIFY_CACHE
+    cache = CrossrefVerifyCache()
+    cache.put("doi:10.1000/example", verified=True)
+    cache.save(path)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "1.0"
+    assert set(payload["results"]["doi:10.1000/example"]) == {"verified", "checked_at"}
+    assert payload["results"]["doi:10.1000/example"]["verified"] is True
+    assert payload["results"]["doi:10.1000/example"]["checked_at"].endswith("Z")


### PR DESCRIPTION
## Problem (live evidence, master 48889f9)

Fresh-vault `auto --peer-reviewed` quarantined `asif2025` (real Springer paper, DOI `10.1007/s11269-025-04093-x`) as **L2 / uncorroborated**. The paper came from a single search backend (`source: "openalex"`) — CrossRef wasn't recorded in its `backends` list, so `_corroboration_label` returned `"single-source"` even though the DOI is a real CrossRef-registered Springer journal article. Existing exemptions don't apply (no arxiv_id, no PMID, not bioRxiv prefix, citation_count=0).

## Fix — PR-A of 2, strictly augmentative

For any single-source paper with a DOI not already CrossRef-corroborated, do a direct `https://api.crossref.org/works/{doi}` metadata lookup via the existing `CrossrefBackend.get_paper`. If CrossRef returns a record whose **title/year/authors match the paper per the EXISTING `_records_agree` predicate** (`fuzz.token_set_ratio >= 85`, `|year_delta| <= 1`, surname intersection >= 1), append `"crossref"` to `paper["backends"]` and a synthesised record to `paper["source_records"]`. The L2b gate that follows re-evaluates `_corroboration_label` and now finds `"crossref" in backends` → "corroborated" → paper passes L2.

**CrossRef's authoritative metadata IS a fabrication check** — this adds an evidence source, never lowers the L2 bar. PR-B will follow with the L1-deferred-but-L2-corroborated → admit-with-recheck change on top of this.

## Cache discipline (`crossref_verify_cache.json`, schema 1.0)

| Outcome | Cached? |
|---------|---------|
| 200 + `_records_agree` True | `verified=True` |
| 200 + `_records_agree` False | `verified=False` (**fabrication guard**: DOI present but mismatched paper) |
| 404 | `verified=False` (definitive) |
| 5xx / RequestException / network / **200-with-empty-body** | **NO cache** (transient, next run retries) |

200-with-empty-body classification (W1 from review) is a real spec compliance: CrossRef API hiccup returning OK + missing/empty `message` field is transient, must not permanently block re-checking.

## Tests — `tests/test_v1_l2_crossref_doi_verify.py` (12 cases, 375 LOC)

1. openalex-only + CrossRef match → accepted, `backends` has `"crossref"`.
2. 404 → still quarantined, cache `verified=False`.
3. title/year/authors mismatch → NOT augmented (**L5 fabrication guard**).
4. **200-with-empty-body → fail-quiet, NO cache** (W2 regression for W1).
5. 5xx → fail-quiet, no cache.
6. `RequestException` → fail-quiet, no cache.
7. Already 2-backend paper → no CrossRef fetch.
8. No-DOI paper → no fetch, no augment.
9. `verified=True` cache hit → no fetch, augmented from cache.
10. `verified=False` cache hit → no fetch, no augment.
11. `CrossrefVerifyCache` missing/corrupt → empty.
12. `CrossrefVerifyCache` save writes schema+results.

L5 invariant CI gate (`tests/test_authenticity_l5_invariant.py`) green. **Full suite: 2765 passed, 24 skipped, 2 xfailed, 1 xpassed, 0 failed.**

## Review

`code-reviewer` subagent → **APPROVE** with 11/11 invariants pass:
- Strictly augmentative (no removal/replacement/downgrade).
- No L2 bypass (gate re-evaluates after augment).
- `_records_agree` reuse intact (no relaxed matching).
- Cache discipline correct (incl. instance-scoped monkey-patch of `_request`).
- Idempotent (early-exit when `"crossref"` already in backends).
- `crossref.py` untouched.
- L1-defer-continue flow untouched (PR-B scope).

Applied W1 (200-with-empty-body must NOT cache — spec required) + W2 (regression test).

## Out of scope (PR-B will follow)

L1-deferred-but-L2-corroborated → admit with `doi_recheck_pending` marker. PR-A is a prerequisite (L2 needs a way to corroborate a paper with the doi.org HEAD currently anti-bot-blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)