### PR TITLE
fix(pipeline): ingest skips missing-required-core-field papers instead of aborting batch (PR-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,23 @@ graph rebuild (link out to the real tools instead)._
   instead of a generic `pip install` hint that cannot succeed there.
 
 ### Fixed
+- **Ingest skips a paper missing one or more required core fields
+  instead of aborting the whole batch.** A real-world `auto` run (LLM
+  reservoir management search) hit a CrossRef return with empty
+  `authors: []` and the pipeline fail-fast-aborted the entire ingest
+  with "INPUT VALIDATION FAILED" even though 2 other valid papers
+  were ready to write. The previous `missing_doi_only` skip branch
+  was inert (`doi` is not in any required-fields list, so
+  `_validate_paper_input` never emitted "missing required field
+  'doi'") and is replaced by a working
+  `_only_missing_required_field_errors` predicate covering every
+  field in `REQUIRED_FIELDS_CORE` (title / authors / year). When
+  every error for a paper is a "missing required field 'X'" error,
+  that paper is skipped from the batch with a logged "SKIPPED invalid
+  input" entry, and the remaining valid papers still write to Zotero /
+  Obsidian. Strict dry-run behaviour is preserved (every validation
+  issue surfaces) so the operator sees the full picture before a real
+  run.
 - **L1-deferred-but-L2-corroborated papers no longer fail-close at
   `L1-deferred`.** When the DOI resolver HEAD is transient-blocked
   (anti-bot 401/403/406/418/451/etc. -- classified as

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -237,6 +237,20 @@ def _validate_paper_input(pp: dict, idx: int) -> list[str]:
     return errors
 
 
+def _only_missing_required_field_errors(errors: list[str]) -> bool:
+    """True iff every error in *errors* is a "missing required field 'X'"
+    error from _validate_paper_input.
+
+    Used to classify a paper as "skip but don't abort the batch" when the
+    search backend returned an entry missing one of REQUIRED_FIELDS_CORE
+    (e.g., a CrossRef record with empty authors, or an OpenAlex entry
+    missing year). The remaining valid papers in the same batch still
+    write to Zotero/Obsidian; this skip is real-run only -- dry_run
+    keeps the strict surfacing of all validation issues.
+    """
+    return bool(errors) and all("missing required field" in err for err in errors)
+
+
 def _is_nonfatal_paper_error(err: str) -> bool:
     return ("missing field '" in err and "pipeline will KeyError" in err) or "WARN --" in err
 
@@ -778,12 +792,12 @@ def run_pipeline(
                 _unescape_html_in_paper(paper)
                 _normalize_paper_metadata(paper)
                 paper_errors = _validate_paper_input(paper, idx)
-                missing_doi_only = (
-                    not dry_run
-                    and paper_errors
-                    and all("missing required field 'doi'" in err for err in paper_errors)
-                )
-                if missing_doi_only:
+                # PR-C: a paper missing one or more required core fields
+                # (e.g. CrossRef returning an entry with empty `authors`) is
+                # skipped from THIS batch, not allowed to abort the whole
+                # ingest. Dry-run keeps the strict surfacing so all
+                # validation issues stay visible.
+                if not dry_run and _only_missing_required_field_errors(paper_errors):
                     skipped_invalid.append((idx, paper, paper_errors))
                     continue
                 valid_papers.append(paper)

--- a/tests/test_v1_ingest_skip_missing_required.py
+++ b/tests/test_v1_ingest_skip_missing_required.py
@@ -1,0 +1,313 @@
+"""PR-C: ingest skips a paper missing one or more REQUIRED_FIELDS_CORE
+(title/authors/year) instead of aborting the whole batch.
+
+Pre-PR-C the pipeline already skipped papers whose ONLY error was a
+missing DOI; this PR generalises that escape to every required core
+field. Real-world trigger: a CrossRef record returned with an empty
+``authors: []`` (editorial materials / metadata not yet author-registered)
+would otherwise fail-fast the entire `auto` run, even when the rest of
+the candidates are valid.
+
+The escape is strictly real-run -- dry-run still surfaces every
+validation issue so the operator sees the full picture.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from research_hub import pipeline
+from research_hub.clusters import ClusterRegistry
+from research_hub.pipeline import (
+    _only_missing_required_field_errors,
+    _validate_paper_input,
+    run_pipeline,
+)
+
+
+# --- unit: predicate ---
+
+
+def test_only_missing_required_field_errors_empty_returns_false():
+    """No errors means no classification (the caller's `paper_errors`
+    truthiness check fires first; this predicate only meaningful for a
+    populated list)."""
+    assert _only_missing_required_field_errors([]) is False
+
+
+def test_only_missing_required_field_errors_single_match_returns_true():
+    assert _only_missing_required_field_errors(
+        ["Paper 0: missing required field 'authors' - add 'authors: <value>' ..."]
+    ) is True
+
+
+def test_only_missing_required_field_errors_multiple_all_match_returns_true():
+    """A paper missing title AND authors AND year is still all-classifiable
+    as missing-required — skip it cleanly."""
+    assert _only_missing_required_field_errors(
+        [
+            "Paper 3: missing required field 'title' - ...",
+            "Paper 3: missing required field 'authors' - ...",
+            "Paper 3: missing required field 'year' - ...",
+        ]
+    ) is True
+
+
+def test_only_missing_required_field_errors_mixed_returns_false():
+    """If even one error is a non-missing-required (e.g., a dict-author
+    shape error), the paper should NOT be silently skipped — the
+    operator needs to see it as fatal."""
+    assert _only_missing_required_field_errors(
+        [
+            "Paper 0: missing required field 'authors' - ...",
+            "Paper 0, author 0: dict authors must have 'creatorType' ...",
+        ]
+    ) is False
+
+
+def test_only_missing_required_field_errors_non_required_only_returns_false():
+    assert _only_missing_required_field_errors(
+        ["Paper 0: 'authors' must be a list"]
+    ) is False
+
+
+# --- composition: real _validate_paper_input output flows into the predicate ---
+
+
+def test_validator_for_empty_paper_yields_mixed_errors_predicate_false():
+    """Anti-overreach guard: an empty paper dict produces missing-required
+    errors for the 3 core fields PLUS "missing field '...'" errors for
+    non-required-but-still-validated fields (methodology/summary/...).
+    The mixed error set must NOT classify as "skippable as a whole" —
+    the operator needs to see the fatal validation failure."""
+    errors = _validate_paper_input({}, 0)
+    assert any("missing required field 'title'" in e for e in errors)
+    assert any("missing required field 'authors'" in e for e in errors)
+    assert any("missing required field 'year'" in e for e in errors)
+    has_non_required = any(
+        "missing field '" in e and "missing required field" not in e
+        for e in errors
+    )
+    assert has_non_required, "empty dict should also trip non-required-field checks"
+    # Predicate returns False because non-required errors are mixed in.
+    assert _only_missing_required_field_errors(errors) is False
+
+
+def test_validator_for_empty_authors_list_yields_missing_required_authors():
+    """A real-world CrossRef return: every required field present except
+    authors=[]. The validator must report ONLY missing-authors so the
+    predicate skips it cleanly (no surprise extra errors that would
+    make it fatal)."""
+    paper = {
+        "title": "Paper",
+        "doi": "10.1/x",
+        "authors": [],          # empty list -> treated as missing
+        "year": 2025,
+        "abstract": "Abstract",
+        "journal": "Journal",
+        "summary": "Summary",
+        "key_findings": ["One"],
+        "methodology": "Method",
+        "relevance": "Relevant",
+    }
+    errors = _validate_paper_input(paper, 0)
+    # filter to just the required-core errors:
+    core_errors = [e for e in errors if "missing required field" in e]
+    assert any("'authors'" in e for e in core_errors)
+    # The whole error set must be all-missing-required for the skip
+    # path to fire (any other error class would mark it fatal).
+    assert _only_missing_required_field_errors(errors) is True
+
+
+# --- integration: mixed batch with 1 valid + 1 missing-authors paper ---
+
+
+def _cfg(tmp_path: Path, *, default_collection: str | None = "DEFAULT") -> SimpleNamespace:
+    root = tmp_path / "vault"
+    raw = root / "raw"
+    logs = root / "logs"
+    hub = root / ".research_hub"
+    raw.mkdir(parents=True)
+    logs.mkdir(parents=True)
+    hub.mkdir(parents=True)
+    return SimpleNamespace(
+        root=root,
+        raw=raw,
+        logs=logs,
+        research_hub_dir=hub,
+        clusters_file=hub / "clusters.yaml",
+        zotero_default_collection=default_collection,
+        zotero_collections={},
+        zotero_library_id="123",
+    )
+
+
+def _valid_paper(idx: int) -> dict:
+    return {
+        "title": f"Valid Paper {idx}",
+        "doi": f"10.1000/valid-{idx}",
+        "authors": [{"creatorType": "author", "lastName": "Doe", "firstName": "Jane"}],
+        "year": 2026,
+        "abstract": "Abstract",
+        "journal": "Journal",
+        "summary": "Summary",
+        "key_findings": ["Finding"],
+        "methodology": "Method",
+        "relevance": "Relevant",
+        "slug": f"doe2026-valid-paper-{idx}",
+        "sub_category": "agents",
+        "citation_count": 1,
+    }
+
+
+def _no_authors_paper() -> dict:
+    return {
+        "title": "Missing Authors Paper",
+        "doi": "10.31673/2412-9070.2026.028906",  # the real culprit from the LLM-reservoir run
+        "authors": [],
+        "year": 2026,
+        "abstract": "Abstract",
+        "journal": "Connectivity",
+        "summary": "Summary",
+        "key_findings": ["Finding"],
+        "methodology": "Method",
+        "relevance": "Relevant",
+        "slug": "unknown2026-missing-authors-paper",
+        "sub_category": "agents",
+        "citation_count": 1,
+    }
+
+
+class _FastZotero:
+    def __init__(self) -> None:
+        self.created: list[list[dict]] = []
+
+    def item_template(self, item_type: str) -> dict:
+        return {"itemType": item_type}
+
+    def create_items(self, items):  # type: ignore[no-untyped-def]
+        self.created.append(items)
+        return {
+            "successful": {
+                str(idx): {"key": f"K{idx}"} for idx, _item in enumerate(items)
+            }
+        }
+
+
+def _mock_zotero(monkeypatch: pytest.MonkeyPatch) -> _FastZotero:
+    z = _FastZotero()
+    monkeypatch.setattr(pipeline, "get_client", lambda: z)
+    monkeypatch.setattr(
+        pipeline, "check_duplicate",
+        lambda zot, title, doi="", **kwargs: False,
+    )
+    monkeypatch.setattr(pipeline, "add_note", lambda zot, key, content: True)
+    monkeypatch.setattr(
+        pipeline, "_load_or_build_dedup",
+        lambda *args, **kwargs: SimpleNamespace(
+            doi_to_hits={},
+            title_to_hits={},
+            check=lambda payload: (False, []),
+            add=lambda hit: None,
+            save=lambda path: None,
+        ),
+    )
+    monkeypatch.setattr("research_hub.pipeline.time.sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        "research_hub.pipeline.update_cluster_links",
+        lambda *args, **kwargs: None,
+    )
+    return z
+
+
+def test_mixed_batch_skips_no_authors_paper_and_ingests_valid_ones(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CrossRef-no-authors paper is skipped; the valid paper still
+    writes to Zotero. Without PR-C the run aborts with exit code 1
+    and 0 papers ingested."""
+    cfg = _cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(
+        query="agents", name="Agents", slug="agents",
+        zotero_collection_key="DEFAULT",
+    )
+    payload = {"papers": [_valid_paper(1), _no_authors_paper(), _valid_paper(2)]}
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps(payload), encoding="utf-8",
+    )
+    monkeypatch.setattr("research_hub.pipeline.get_config", lambda: cfg)
+    z = _mock_zotero(monkeypatch)
+
+    rc = run_pipeline(dry_run=False, cluster_slug="agents", verify=False)
+
+    # PR-C: batch must NOT abort with the no-authors paper; the 2 valid
+    # papers are passed to Zotero.
+    assert rc == 0
+    # Zotero received some items (the 2 valid papers).
+    assert z.created, "expected at least one create_items call for valid papers"
+    created_titles = {
+        item.get("title") for batch in z.created for item in batch
+        if isinstance(item, dict)
+    }
+    assert "Valid Paper 1" in created_titles
+    assert "Valid Paper 2" in created_titles
+    # The no-authors paper must NOT have been created.
+    assert "Missing Authors Paper" not in created_titles
+    # The SKIP message must appear in pipeline_log.txt.
+    log_text = (cfg.logs / "pipeline_log.txt").read_text(encoding="utf-8")
+    assert "SKIPPED invalid input" in log_text
+    assert "Missing Authors Paper" in log_text
+
+
+def test_pure_valid_batch_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: a fully-valid batch keeps the existing happy path
+    (no spurious skips logged)."""
+    cfg = _cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(
+        query="agents", name="Agents", slug="agents",
+        zotero_collection_key="DEFAULT",
+    )
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps({"papers": [_valid_paper(1)]}), encoding="utf-8",
+    )
+    monkeypatch.setattr("research_hub.pipeline.get_config", lambda: cfg)
+    _mock_zotero(monkeypatch)
+
+    rc = run_pipeline(dry_run=False, cluster_slug="agents", verify=False)
+
+    assert rc == 0
+    log_text = (cfg.logs / "pipeline_log.txt").read_text(encoding="utf-8")
+    assert "INPUT VALIDATION FAILED" not in log_text
+    assert "SKIPPED invalid input" not in log_text
+
+
+def test_dry_run_does_not_skip_missing_required(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The PR-C escape is real-run only. In dry-run, every validation
+    issue must surface so the operator sees the full picture."""
+    cfg = _cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(
+        query="agents", name="Agents", slug="agents",
+        zotero_collection_key="DEFAULT",
+    )
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps({"papers": [_valid_paper(1), _no_authors_paper()]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("research_hub.pipeline.get_config", lambda: cfg)
+    _mock_zotero(monkeypatch)
+
+    rc = run_pipeline(dry_run=True, cluster_slug="agents", verify=False)
+
+    # Dry-run still surfaces the validation failure as a non-zero exit
+    # (existing strict behaviour preserved).
+    assert rc == 1
+    log_text = (cfg.logs / "pipeline_log.txt").read_text(encoding="utf-8")
+    assert "INPUT VALIDATION FAILED" in log_text or "missing required field" in log_text


### PR DESCRIPTION
## Problem (live evidence)

During the LLM-reservoir-management research ingest on master `8d3f56e`, a CrossRef return with empty `authors: []` triggered:

```
=== INPUT VALIDATION FAILED ===
  !!Paper 1: missing required field 'authors' - ...

Fix papers_input.json and re-run. 1 errors total.
[FAIL] ingest pipeline returned exit code 1
```

3 papers loaded (2 valid + 1 no-authors); the entire batch aborted because of the 1 broken record. Required manual intervention to filter the no-authors paper then re-run ingest.

Investigation found the pre-existing `missing_doi_only` skip branch was **dead code** — `doi` is not in `REQUIRED_FIELDS_CORE`/`REQUIRED_FIELDS_ZOTERO`/`REQUIRED_FIELDS_NOTE`, so `_validate_paper_input` never emits `"missing required field 'doi'"`. The branch existed but never fired.

## Fix

Replace the dead branch with a working predicate covering every `REQUIRED_FIELDS_CORE` (title / authors / year):

```python
def _only_missing_required_field_errors(errors: list[str]) -> bool:
    return bool(errors) and all("missing required field" in err for err in errors)
```

Used at the input-validation loop site, gated by `not dry_run`:
- Real-run: paper with ONLY missing-required errors → `skipped_invalid.append(...)`, batch continues with remaining valid papers.
- Dry-run: strict behaviour preserved (every issue surfaces, `INPUT VALIDATION FAILED` still aborts).
- Mixed-error paper (missing-required + other validation error) → predicate False → fatal as before.

L5 anti-fabrication unchanged: the skip fires in input-parsing BEFORE `verify_authenticity` runs. Skipped papers never reach the gate.

## Tests (11 cases in new `tests/test_v1_ingest_skip_missing_required.py`)

| Layer | Coverage |
|-------|----------|
| Unit (predicate) | empty / single-match / multi-all-match / mixed / non-required-only |
| Composition | `_validate_paper_input({})` → mixed errors → predicate False; `{authors: []}` → only-missing-required → predicate True |
| Integration | mixed batch (1 valid + 1 no-authors + 1 valid) → rc=0, valid papers in Zotero, no-authors logged as SKIPPED |
| Integration | pure-valid batch unchanged (no spurious skips) |
| Integration | dry-run keeps strict behaviour (rc=1, INPUT VALIDATION FAILED reported) |

**Full suite: 2786 passed, 24 skipped, 2 xfailed, 1 xpassed, 0 failed.**

## Review

`code-reviewer` subagent → **APPROVE** with 10/10 invariants pass:
- Strict dry-run unchanged.
- Mixed-error papers still fatal.
- Empty paper still fatal (mixed errors).
- Predicate substring match safe (only validator's "missing required field 'X'" output triggers it).
- Reporting path (`SKIPPED invalid input`) unchanged.
- L5 anti-fabrication untouched (skip is upstream of the gate).

Applied **W1**: CHANGELOG wording corrected — the old `missing_doi_only` was dead code, so this is net-new working behaviour not "generalising" a working prior path.

## Out of scope

- Better backend-side handling of `authors: []` (e.g., reject earlier in search backend) — separate concern.
- Year-format / author-shape validation strengthening — separate.

Written directly by Claude per user override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)