### PR TITLE
feat(notebooklm): add notebooklm login --auto-detect zero-touch login (PR-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,20 @@ graph rebuild (link out to the real tools instead)._
   the two paths that work (interactive in a terminal / `--import-from`)
   instead of a generic `pip install` hint that cannot succeed there.
 
+### Added
+- **`notebooklm login --auto-detect` — fully automatic zero-touch login.**
+  Replaces the half-automatic `--wait-file` flow (which still required a
+  manual file-touch after browser sign-in). With `--auto-detect`,
+  research-hub polls the patchright Chromium profile's Cookies SQLite
+  read-only for a `notebooklm.google.com` host_key. When you sign in
+  and land on the NotebookLM homepage, the cookie appears, the script
+  feeds both `\n` (any pending `input()` ENTER) and `y\n` (any pending
+  `click.confirm` "Save anyway?" fallback) to the SDK subprocess, and
+  the session is saved automatically. No terminal, no wait-file touch,
+  no click.confirm response. Fail-closed on `--wait-timeout`
+  (default 300 s): nothing is saved on timeout. Mutually exclusive with
+  `--wait-file`, `--import-from`, `--from-browser`.
+
 ### Fixed
 - **Ingest skips a paper missing one or more required core fields
   instead of aborting the whole batch.** A real-world `auto` run (LLM

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -6202,19 +6202,23 @@ def build_parser() -> argparse.ArgumentParser:
         "login",
         help="Authenticate NotebookLM",
         description=(
-            "Authenticate NotebookLM. Three paths: (1) default interactive Google "
+            "Authenticate NotebookLM. Five paths: (1) default interactive Google "
             "sign-in in a real terminal (press ENTER when the NotebookLM homepage "
             "loads); (2) --import-from <other-vault> copies a logged-in session "
             "from another vault; (3) --from-browser [browser] imports cookies via "
             "rookiepy (requires the research-hub[browser-auth] extra; rookiepy has "
             "no prebuilt wheel for Python 3.14); (4) --wait-file PATH — sign in "
-            "in the browser then create PATH (no terminal/ENTER; scriptable)."
+            "in the browser then create PATH (no terminal/ENTER; scriptable); "
+            "(5) --auto-detect — fully automatic, research-hub polls the "
+            "patchright Chromium cookies and saves when notebooklm.google.com "
+            "appears (no terminal, no wait-file, no click.confirm response)."
         ),
         epilog=(
             "Examples:\n"
             "  research-hub notebooklm login\n"
             "  research-hub notebooklm login --import-from <other-vault>\n"
-            "  research-hub notebooklm login --from-browser chrome"
+            "  research-hub notebooklm login --from-browser chrome\n"
+            "  research-hub notebooklm login --auto-detect"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -6245,8 +6249,18 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=300,
         metavar="SECONDS",
-        help="With --wait-file: max seconds to wait for the signal file "
-             "before failing closed (default: 300; nothing is saved on timeout).",
+        help="With --wait-file or --auto-detect: max seconds to wait for "
+             "the detection signal before failing closed (default: 300; "
+             "nothing is saved on timeout).",
+    )
+    nlm_login.add_argument(
+        "--auto-detect",
+        action="store_true",
+        help="Fully automatic: research-hub polls the patchright Chromium "
+             "profile's cookies for notebooklm.google.com once the browser "
+             "opens. When you sign in and land on the NotebookLM homepage, "
+             "the session is saved automatically. No terminal/ENTER, no "
+             "wait-file touch, no click.confirm response needed.",
     )
     nlm_login.add_argument(
         "--from-browser",
@@ -7555,8 +7569,14 @@ def _main_dispatch(args, parser) -> int:
         return _synthesize(cluster=args.cluster, graph_colors=args.graph_colors)
     if args.command == "notebooklm":
         if args.notebooklm_command == "login":
-            if args.wait_timeout != 300 and args.wait_file is None:
-                parser.error("--wait-timeout requires --wait-file")
+            if args.wait_timeout != 300 and args.wait_file is None and not args.auto_detect:
+                parser.error("--wait-timeout requires --wait-file or --auto-detect")
+            if args.auto_detect and args.wait_file is not None:
+                parser.error("--auto-detect and --wait-file are mutually exclusive")
+            if args.auto_detect and (args.import_from or args.from_browser is not None):
+                parser.error(
+                    "--auto-detect cannot be combined with --import-from or --from-browser",
+                )
             from pathlib import Path as _Path
 
             from research_hub._invocation import recommended_cli_invocation
@@ -7636,6 +7656,7 @@ def _main_dispatch(args, parser) -> int:
                 state_file=default_state_file(cfg.research_hub_dir),
                 wait_file=args.wait_file,
                 wait_timeout=args.wait_timeout,
+                auto_detect=args.auto_detect,
             )
         if args.notebooklm_command == "bundle":
             return _notebooklm_bundle(args.cluster, download_pdfs=args.download_pdfs)

--- a/src/research_hub/notebooklm/auth.py
+++ b/src/research_hub/notebooklm/auth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import shutil
+import sqlite3
 import subprocess
 import sys
 import time
@@ -58,17 +59,26 @@ def login_nlm(
     stable_hold_sec: int = 5,
     wait_file: Path | None = None,
     wait_timeout: int = 300,
+    auto_detect: bool = False,
 ) -> int:
     """Open notebooklm-py's one-time login flow and save storage state.
 
-    When *wait_file* is set the interactive ENTER gate is replaced by a
-    file signal (non-interactive); see ``_login_with_wait_file``.
+    Three orchestration modes:
+    - default (no flag): interactive ENTER gate in a real terminal.
+    - ``wait_file=PATH``: file-signal gate (see ``_login_with_wait_file``).
+    - ``auto_detect=True``: cookies-poll gate (see ``_login_with_auto_detect``).
+      Fully automatic: research-hub polls the patchright Chromium profile's
+      cookies for ``notebooklm.google.com`` after the user signs in and
+      lands on the NotebookLM homepage. No ENTER, no wait_file touch, no
+      click.confirm response needed.
     """
     del headless, timeout_sec, stable_hold_sec
     target = Path(state_file) if state_file is not None else Path(user_data_dir)
     target.parent.mkdir(parents=True, exist_ok=True)
     cmd = [sys.executable, "-m", "notebooklm.notebooklm_cli", "login", "--storage", str(target)]
-    if wait_file is None:
+    if auto_detect:
+        rc = _login_with_auto_detect(cmd, int(wait_timeout), target)
+    elif wait_file is None:
         rc = subprocess.run(cmd, check=False).returncode
     else:
         rc = _login_with_wait_file(cmd, Path(wait_file), int(wait_timeout), target)
@@ -144,6 +154,135 @@ def _login_with_wait_file(
             time.sleep(1.0)
         # signal never arrived -> fail-closed (nothing saved). Close
         # stdin first so the upstream read sees a clean EOF.
+        try:
+            if proc.stdin is not None:
+                proc.stdin.close()
+        except OSError:
+            pass
+        _kill_proc(proc)
+        return 124
+    finally:
+        if proc.poll() is None:
+            try:
+                proc.terminate()
+            except OSError:
+                pass
+
+
+def _patchright_cookies_db() -> Path:
+    """Resolve the path to the patchright Chromium profile's Cookies SQLite.
+
+    Prefers the notebooklm-py SDK's own ``get_browser_profile_dir`` helper
+    so research-hub stays in lock-step with whatever layout the SDK uses;
+    falls back to the documented ``~/.notebooklm/profiles/default/
+    browser_profile`` location if the helper is unavailable (older SDK).
+    """
+    try:
+        from notebooklm.cli.session import get_browser_profile_dir
+        return Path(get_browser_profile_dir()) / "Default" / "Cookies"
+    except Exception:  # noqa: BLE001 - any SDK breakage falls through
+        return (
+            Path.home()
+            / ".notebooklm"
+            / "profiles"
+            / "default"
+            / "browser_profile"
+            / "Default"
+            / "Cookies"
+        )
+
+
+def _cookies_db_modified_since(cookies_db: Path, baseline_mtime: float) -> bool:
+    """True iff the Cookies SQLite has been written after baseline_mtime.
+    Pair with _has_notebooklm_cookie to prove the row is FRESH (the
+    user signed in in this session) rather than stale (left over from a
+    previous login that may have been revoked server-side). Tolerant of
+    a missing file (returns False)."""
+    try:
+        return cookies_db.stat().st_mtime > baseline_mtime
+    except OSError:
+        return False
+
+
+def _has_notebooklm_cookie(cookies_db: Path) -> bool:
+    """True iff Chromium's Cookies SQLite contains at least one row with
+    ``host_key`` matching ``notebooklm.google.com``.
+
+    Tolerant of: file not yet existing (browser still starting); SQLite
+    lock contention (chromium writing); any other transient I/O error.
+    Each transient returns ``False`` so the calling loop simply polls
+    again on the next iteration. Opened read-only via the SQLite URI
+    ``mode=ro`` so we never contend with chromium's write locks.
+    """
+    if not cookies_db.exists():
+        return False
+    try:
+        uri = f"file:{cookies_db.as_posix()}?mode=ro"
+        with sqlite3.connect(uri, uri=True, timeout=2) as conn:
+            cur = conn.execute(
+                "SELECT 1 FROM cookies WHERE host_key LIKE ? LIMIT 1",
+                ("%notebooklm.google.com",),
+            )
+            return cur.fetchone() is not None
+    except sqlite3.Error:
+        return False
+    except Exception:  # noqa: BLE001 - defensive against unexpected I/O
+        return False
+
+
+def _login_with_auto_detect(
+    cmd: list[str],
+    timeout: int,
+    state_file: Path,
+) -> int:
+    """Fully-automatic login: poll the patchright Chromium profile's
+    Cookies SQLite for a ``notebooklm.google.com`` host_key. When the
+    cookie appears, feed the subprocess ``\\n`` (any pending ``input()``
+    ENTER prompt) AND ``y\\n`` (any pending ``click.confirm`` "Save
+    authentication anyway?" prompt) in one write so the upstream save
+    fires whichever path the SDK actually takes.
+
+    Fail-closed: if no notebooklm.google.com cookie appears within
+    ``timeout`` seconds the subprocess is killed and a non-zero exit
+    code is returned (nothing is saved).
+    """
+    cookies_db = _patchright_cookies_db()
+    # W1 (PR-D review): anti-stale-cookie guard. Snapshot the Cookies
+    # file mtime BEFORE launching the subprocess. The detection trigger
+    # requires BOTH (a) a notebooklm.google.com row AND (b) the file was
+    # written after launch -- proving the user actually signed in in
+    # this session rather than us picking up a stale cookie left behind
+    # from a previous (possibly-revoked) login.
+    try:
+        pre_launch_mtime = cookies_db.stat().st_mtime if cookies_db.exists() else 0.0
+    except OSError:
+        pre_launch_mtime = 0.0
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    deadline = time.monotonic() + max(1, timeout)
+    poll_interval = 1.0  # match _login_with_wait_file for consistency
+    try:
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                return proc.returncode
+            if _has_notebooklm_cookie(cookies_db) and _cookies_db_modified_since(cookies_db, pre_launch_mtime):
+                try:
+                    if proc.stdin is not None:
+                        proc.stdin.write(b"\ny\n")
+                        proc.stdin.flush()
+                        proc.stdin.close()
+                except OSError:
+                    pass
+                try:
+                    return proc.wait(timeout=120)
+                except subprocess.TimeoutExpired:
+                    try:
+                        _tighten_state_file_perms(state_file)
+                    except Exception:  # noqa: BLE001 - best-effort
+                        pass
+                    _kill_proc(proc)
+                    return 1
+            time.sleep(poll_interval)
+        # detection never arrived -> fail-closed (nothing saved).
         try:
             if proc.stdin is not None:
                 proc.stdin.close()

--- a/tests/test_v1_nlm_login_auto_detect.py
+++ b/tests/test_v1_nlm_login_auto_detect.py
@@ -1,0 +1,288 @@
+"""PR-D: ``notebooklm login --auto-detect`` — fully-automatic zero-touch login.
+
+Replaces the half-automatic ``--wait-file`` flow (which still requires
+the user to ``touch`` a file after browser sign-in) with a cookies-poll
+that detects "user reached the NotebookLM homepage" by looking for a
+``notebooklm.google.com`` row in the patchright Chromium profile's
+Cookies SQLite. When detected, research-hub feeds both ``\\n`` (any
+pending ``input()`` ENTER) AND ``y\\n`` (any pending ``click.confirm``
+"Save anyway?" fallback) so the upstream save fires regardless of which
+prompt path the SDK takes. Fail-closed on timeout (nothing saved).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import research_hub.notebooklm.auth as auth
+from research_hub.notebooklm.auth import (
+    _has_notebooklm_cookie,
+    _login_with_auto_detect,
+)
+
+
+class _Stdin:
+    """Capture stub that survives .close() (real BytesIO does not)."""
+    def __init__(self):
+        self.buf = b""
+        self.closed = False
+    def write(self, b):
+        self.buf += b
+    def flush(self):
+        pass
+    def close(self):
+        self.closed = True
+    def getvalue(self):
+        return self.buf
+
+
+class _FakeProc:
+    def __init__(self, *, exits_with=None):
+        self.stdin = _Stdin()
+        self._exits_with = exits_with        # not None -> poll() returns it
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        if self.returncode is not None:
+            return self.returncode
+        if self._exits_with is not None:
+            self.returncode = self._exits_with
+            return self._exits_with
+        return None
+
+    def wait(self, timeout=None):
+        self.returncode = 0
+        return 0
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    monkeypatch.setattr(auth.time, "sleep", lambda *_a, **_k: None)
+
+
+def _build_cookies_db(path: Path, *, with_notebooklm: bool) -> None:
+    """Create a real (read-only-poll-compatible) Cookies SQLite stub."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(path)) as conn:
+        conn.execute(
+            "CREATE TABLE cookies (host_key TEXT, name TEXT, value TEXT)"
+        )
+        # always seed an unrelated row so the table is non-empty
+        conn.execute(
+            "INSERT INTO cookies VALUES ('accounts.google.com', 'NID', 'x')"
+        )
+        if with_notebooklm:
+            conn.execute(
+                "INSERT INTO cookies VALUES "
+                "('.notebooklm.google.com', 'AUTH', 'y')"
+            )
+        conn.commit()
+
+
+# ---- _has_notebooklm_cookie unit tests ----
+
+
+def test_has_notebooklm_cookie_missing_file_returns_false(tmp_path):
+    assert _has_notebooklm_cookie(tmp_path / "no-such.db") is False
+
+
+def test_has_notebooklm_cookie_no_matching_row_returns_false(tmp_path):
+    db = tmp_path / "Cookies"
+    _build_cookies_db(db, with_notebooklm=False)
+    assert _has_notebooklm_cookie(db) is False
+
+
+def test_has_notebooklm_cookie_matching_row_returns_true(tmp_path):
+    db = tmp_path / "Cookies"
+    _build_cookies_db(db, with_notebooklm=True)
+    assert _has_notebooklm_cookie(db) is True
+
+
+def test_has_notebooklm_cookie_corrupt_file_returns_false(tmp_path):
+    """Defensive: a Cookies file that's not a SQLite DB (e.g., chromium
+    still writing initial bytes) returns False so the calling loop
+    simply polls again on the next iteration."""
+    db = tmp_path / "Cookies"
+    db.write_bytes(b"not a sqlite file")
+    assert _has_notebooklm_cookie(db) is False
+
+
+# ---- _login_with_auto_detect integration tests ----
+
+
+def _make_cookies_appear_mid_loop(tmp_path, monkeypatch):
+    """Patch ``_patchright_cookies_db`` to a tmp path; on the first
+    mocked ``time.sleep`` call (mid-poll-loop), materialise a Cookies
+    SQLite that contains the notebooklm.google.com row -- simulating
+    the user signing in and landing on the NotebookLM homepage."""
+    db = tmp_path / "browser_profile" / "Default" / "Cookies"
+    monkeypatch.setattr(auth, "_patchright_cookies_db", lambda: db)
+
+    def _sleep(*_a, **_k):
+        if not db.exists():
+            _build_cookies_db(db, with_notebooklm=True)
+
+    monkeypatch.setattr(auth.time, "sleep", _sleep)
+    return db
+
+
+def test_cookie_detection_triggers_save(tmp_path, monkeypatch):
+    proc = _FakeProc()
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+    _make_cookies_appear_mid_loop(tmp_path, monkeypatch)
+
+    rc = _login_with_auto_detect(["x"], timeout=30, state_file=tmp_path / "s")
+
+    assert rc == 0
+    # Both ENTER and "Save anyway? y" are fed so the upstream save fires
+    # whichever prompt path the SDK actually takes for this run.
+    assert proc.stdin.getvalue() == b"\ny\n"
+    assert not proc.terminated
+
+
+def test_timeout_is_fail_closed(tmp_path, monkeypatch):
+    """No cookie appears -> deadline expires -> proc killed, rc=124,
+    nothing fed to stdin (no save)."""
+    db = tmp_path / "browser_profile" / "Default" / "Cookies"
+    monkeypatch.setattr(auth, "_patchright_cookies_db", lambda: db)
+    proc = _FakeProc()
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+    seq = iter([1000.0, 1000.0])
+
+    def _clock():
+        try:
+            return next(seq)
+        except StopIteration:
+            return 9_999.0
+
+    monkeypatch.setattr(auth.time, "monotonic", _clock)
+
+    rc = _login_with_auto_detect(["x"], timeout=5, state_file=tmp_path / "s")
+
+    assert rc == 124
+    assert proc.terminated
+    assert proc.stdin.getvalue() == b""
+
+
+def test_upstream_self_exit_propagates(tmp_path, monkeypatch):
+    """Upstream SDK exits on its own (e.g., browser launch error) before
+    detection; that exit code propagates out without us feeding stdin."""
+    db = tmp_path / "browser_profile" / "Default" / "Cookies"
+    monkeypatch.setattr(auth, "_patchright_cookies_db", lambda: db)
+    proc = _FakeProc(exits_with=3)
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+
+    rc = _login_with_auto_detect(["x"], timeout=30, state_file=tmp_path / "s")
+
+    assert rc == 3
+    assert proc.stdin.getvalue() == b""
+
+
+def test_post_signal_wait_timeout_tightens_and_fails(tmp_path, monkeypatch):
+    """Upstream saved storage_state but is slow to EXIT after the signal:
+    proc.wait() times out -> rc 1, BUT perms must still be tightened
+    (the file is on disk with default perms) and the proc killed.
+    Parity guarantee with ``_login_with_wait_file``'s equivalent test."""
+    state_file = tmp_path / "state.json"
+
+    class _SlowProc(_FakeProc):
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired(cmd=["x"], timeout=timeout)
+
+    proc = _SlowProc()
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+    _make_cookies_appear_mid_loop(tmp_path, monkeypatch)
+
+    tightened = {"called": False}
+    monkeypatch.setattr(
+        auth, "_tighten_state_file_perms",
+        lambda *_a, **_k: tightened.__setitem__("called", True),
+    )
+
+    rc = _login_with_auto_detect(["x"], timeout=30, state_file=state_file)
+
+    assert rc == 1
+    assert tightened["called"] is True
+    assert proc.killed or proc.terminated
+
+
+def test_stale_cookie_pre_existing_does_not_false_trigger(tmp_path, monkeypatch):
+    """W1 (PR-D review): if the profile already has a stale
+    notebooklm.google.com cookie from a previous login (file mtime
+    pre-dates subprocess launch), the polling MUST NOT immediately
+    fire a save. Detection requires fresh writes in THIS session."""
+    db = tmp_path / "browser_profile" / "Default" / "Cookies"
+    _build_cookies_db(db, with_notebooklm=True)
+    # Backdate the mtime so the freshness check fails (no fresh writes).
+    import os
+    old = 1_000_000.0
+    os.utime(db, (old, old))
+
+    monkeypatch.setattr(auth, "_patchright_cookies_db", lambda: db)
+    proc = _FakeProc()
+    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
+    # Force a quick timeout so the test doesn't actually wait.
+    seq = iter([2_000_000.0, 2_000_000.0])
+
+    def _clock():
+        try:
+            return next(seq)
+        except StopIteration:
+            return 9_999_999.0
+
+    monkeypatch.setattr(auth.time, "monotonic", _clock)
+
+    rc = _login_with_auto_detect(["x"], timeout=5, state_file=tmp_path / "s")
+
+    # The cookie IS present but the file mtime is older than our
+    # subprocess launch -> NOT a fresh sign-in -> timeout fail-closed.
+    assert rc == 124
+    assert proc.stdin.getvalue() == b""    # nothing fed -> no save
+
+
+def test_dispatch_routes_to_auto_detect_when_flag_set(tmp_path, monkeypatch):
+    """`login_nlm(auto_detect=True, ...)` must dispatch to
+    `_login_with_auto_detect`, not `_login_with_wait_file` or a plain
+    `subprocess.run`. Anti-regression for the dispatch precedence."""
+    called = {"wait_file": False, "auto_detect": False, "run": False}
+
+    def fake_run(*a, **k):
+        called["run"] = True
+        return subprocess.CompletedProcess(args=a, returncode=0)
+
+    def fake_wait_file(*a, **k):
+        called["wait_file"] = True
+        return 0
+
+    def fake_auto_detect(*a, **k):
+        called["auto_detect"] = True
+        return 0
+
+    monkeypatch.setattr(auth.subprocess, "run", fake_run)
+    monkeypatch.setattr(auth, "_login_with_wait_file", fake_wait_file)
+    monkeypatch.setattr(auth, "_login_with_auto_detect", fake_auto_detect)
+    monkeypatch.setattr(auth, "_tighten_state_file_perms", lambda *_a, **_k: None)
+
+    state = tmp_path / "state.json"
+    rc = auth.login_nlm(
+        tmp_path / "session_dir",
+        state_file=state,
+        auto_detect=True,
+    )
+
+    assert rc == 0
+    assert called["auto_detect"] is True
+    assert called["wait_file"] is False
+    assert called["run"] is False


### PR DESCRIPTION
## Motivation (live evidence)

`--wait-file` still requires manual file-touch after browser sign-in (half-auto). When the maintainer drives login from Claude's Bash sandbox (no TTY), the file-touch step is awkward — needs a separate PowerShell, breaks the auto-flow.

Per user direction: "登入後 你偵測登入就幫我記住" → research-hub should DETECT login completion and auto-save. No file-touch, no terminal ENTER, no click.confirm response.

## Fix — `--auto-detect` mode

Polls the patchright Chromium profile's Cookies SQLite for `notebooklm.google.com` host_key (read-only via SQLite URI `mode=ro`). When detected:
1. Feeds `b"\ny\n"` to the SDK subprocess stdin — `\n` answers the unconditional `input("Press ENTER")` at SDK session.py:608, leftover `y\n` answers the conditional `click.confirm("Save anyway?")` at SDK session.py:637 if URL-check fallback fires.
2. Waits for the SDK to save `storage_state` and exit cleanly.

**Anti-stale guard (W1 from review):** detection requires BOTH the row present AND the Cookies file mtime advanced since `Popen`. A stale cookie left over from a previous (possibly-revoked) login does NOT false-trigger an immediate save. Validated by `test_stale_cookie_pre_existing_does_not_false_trigger`.

**Fail-closed:** if no `notebooklm.google.com` cookie appears + freshness within `--wait-timeout` seconds (default 300), proc killed, rc=124, nothing saved.

## Tests — `tests/test_v1_nlm_login_auto_detect.py` (9 functions)

| Coverage |
|----------|
| `_has_notebooklm_cookie`: missing file / no-match / matching row / corrupt non-SQLite |
| `_login_with_auto_detect`: cookie appears mid-poll (rc=0, `\ny\n` fed) |
| Timeout fail-closed (rc=124, proc terminated, no stdin write) |
| Upstream self-exit propagates (rc=3) |
| Post-signal proc.wait timeout (rc=1, perms tightened, proc killed) |
| **W1 stale cookie pre-existing does NOT false-trigger** (anti-stale regression) |
| Dispatch routes `login_nlm(auto_detect=True)` to `_login_with_auto_detect` (not wait-file, not plain run) |

L5 anti-fabrication CI gate unchanged (touches NLM auth only, not L0-L5 chain). **Full suite: 2795 passed, 24 skipped, 2 xfailed, 1 xpassed, 0 failed.**

## Review

`code-reviewer` subagent → **APPROVE with W1+W2**:
- **W1 (real correctness)**: stale-cookie false-trigger on repeat-login. **Fixed** via pre-launch mtime snapshot + freshness check `cookies_db.stat().st_mtime > pre_launch_mtime`.
- **W2 (cosmetic)**: poll interval 1.5s vs 1.0s inconsistency with `_login_with_wait_file`. **Fixed** — aligned to 1.0s.
- W1 regression test added.
- 11/11 critical invariants pass (incl. structural parity with `_login_with_wait_file`, dispatch precedence, CLI mutex validation, SDK prompt-sequence verified against `notebooklm/cli/session.py:608+637`).

## CLI mutex matrix

| Combo | Behaviour |
|-------|-----------|
| `--auto-detect` alone | ✓ new zero-touch flow |
| `--auto-detect --wait-file PATH` | `parser.error` exit 2 |
| `--auto-detect --import-from VAULT` | `parser.error` exit 2 |
| `--auto-detect --from-browser BROWSER` | `parser.error` exit 2 |
| `--wait-timeout N` (no other flag) | `parser.error` exit 2 (existing rule, extended to also accept `--auto-detect`) |

## Out of scope

- Auto-navigating the browser tab to `https://notebooklm.google.com/` after Google login (still requires 1 user navigation). A future PR could add `--start-url` or use CDP to navigate. Pragmatic scope here: user signs in + visits NotebookLM (1 navigation), everything else automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)