### PR TITLE
fix(notebooklm): --auto-detect cookies path hotfix (Default/Network/Cookies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ graph rebuild (link out to the real tools instead)._
   the two paths that work (interactive in a terminal / `--import-from`)
   instead of a generic `pip install` hint that cannot succeed there.
 
+### Fixed
+- **`--auto-detect` cookies path hotfix.** PR-D's `_patchright_cookies_db`
+  hardcoded the LEGACY `Default/Cookies` path; modern Chromium (80+,
+  including patchright's bundled chromium-1208) stores cookies under
+  `Default/Network/Cookies`. Result: auto-detect polled the wrong file,
+  never fired, user logged in successfully in the browser but the save
+  never triggered. The path resolver now prefers
+  `Default/Network/Cookies`, falls back to legacy `Default/Cookies`
+  only if modern is missing AND legacy exists; if neither has been
+  written yet (browser starting), returns the modern path so the next
+  poll finds it the moment chromium writes it.
+
 ### Added
 - **`notebooklm login --auto-detect` — fully automatic zero-touch login.**
   Replaces the half-automatic `--wait-file` flow (which still required a

--- a/src/research_hub/notebooklm/auth.py
+++ b/src/research_hub/notebooklm/auth.py
@@ -172,24 +172,37 @@ def _login_with_wait_file(
 def _patchright_cookies_db() -> Path:
     """Resolve the path to the patchright Chromium profile's Cookies SQLite.
 
-    Prefers the notebooklm-py SDK's own ``get_browser_profile_dir`` helper
-    so research-hub stays in lock-step with whatever layout the SDK uses;
-    falls back to the documented ``~/.notebooklm/profiles/default/
-    browser_profile`` location if the helper is unavailable (older SDK).
+    Modern Chromium (80+) stores cookies under ``Default/Network/Cookies``;
+    older versions used the legacy ``Default/Cookies`` path. Prefer modern;
+    fall back to legacy only if modern is missing AND legacy exists. If
+    neither exists yet (chromium still starting), return the modern path so
+    the next poll iteration finds it the moment chromium creates it.
+
+    Uses the notebooklm-py SDK's own ``get_browser_profile_dir`` helper to
+    locate the profile root so research-hub stays in lock-step with whatever
+    layout the SDK uses; falls back to the documented
+    ``~/.notebooklm/profiles/default/browser_profile`` location if the
+    helper is unavailable (older SDK).
     """
     try:
         from notebooklm.cli.session import get_browser_profile_dir
-        return Path(get_browser_profile_dir()) / "Default" / "Cookies"
+        profile = Path(get_browser_profile_dir())
     except Exception:  # noqa: BLE001 - any SDK breakage falls through
-        return (
+        profile = (
             Path.home()
             / ".notebooklm"
             / "profiles"
             / "default"
             / "browser_profile"
-            / "Default"
-            / "Cookies"
         )
+    modern = profile / "Default" / "Network" / "Cookies"
+    legacy = profile / "Default" / "Cookies"
+    if modern.exists():
+        return modern
+    if legacy.exists():
+        return legacy
+    # Neither exists yet -- chromium will create the modern one.
+    return modern
 
 
 def _cookies_db_modified_since(cookies_db: Path, baseline_mtime: float) -> bool:

--- a/tests/test_v1_nlm_login_auto_detect.py
+++ b/tests/test_v1_nlm_login_auto_detect.py
@@ -218,6 +218,53 @@ def test_post_signal_wait_timeout_tightens_and_fails(tmp_path, monkeypatch):
     assert proc.killed or proc.terminated
 
 
+def test_cookies_path_prefers_modern_network_subdir(tmp_path, monkeypatch):
+    """Hotfix regression: modern Chromium (80+) stores Cookies under
+    ``Default/Network/Cookies``. The pre-hotfix PR-D code hardcoded the
+    legacy ``Default/Cookies`` path -- auto-detect polling looked at the
+    wrong file, the user logged in but the save never fired."""
+    from notebooklm.cli import session as nlm_session
+    profile = tmp_path / "browser_profile"
+    (profile / "Default" / "Network").mkdir(parents=True)
+    (profile / "Default" / "Network" / "Cookies").write_bytes(b"modern")
+    monkeypatch.setattr(nlm_session, "get_browser_profile_dir", lambda: profile)
+
+    result = auth._patchright_cookies_db()
+
+    assert result == profile / "Default" / "Network" / "Cookies"
+    assert result.exists()
+
+
+def test_cookies_path_falls_back_to_legacy_when_only_legacy_exists(tmp_path, monkeypatch):
+    """A user on an old Chromium version with no Network/ subdir gets the
+    legacy ``Default/Cookies`` path. Defensive fallback."""
+    from notebooklm.cli import session as nlm_session
+    profile = tmp_path / "browser_profile"
+    (profile / "Default").mkdir(parents=True)
+    (profile / "Default" / "Cookies").write_bytes(b"legacy")
+    monkeypatch.setattr(nlm_session, "get_browser_profile_dir", lambda: profile)
+
+    result = auth._patchright_cookies_db()
+
+    assert result == profile / "Default" / "Cookies"
+
+
+def test_cookies_path_returns_modern_path_when_neither_exists_yet(
+    tmp_path, monkeypatch,
+) -> None:
+    """At browser startup neither path exists yet. Return the modern
+    path so the next poll iteration finds it the moment chromium writes
+    it (which it will, in the modern location)."""
+    from notebooklm.cli import session as nlm_session
+    profile = tmp_path / "browser_profile"
+    monkeypatch.setattr(nlm_session, "get_browser_profile_dir", lambda: profile)
+
+    result = auth._patchright_cookies_db()
+
+    assert result == profile / "Default" / "Network" / "Cookies"
+    assert not result.exists()    # neither path materialised yet
+
+
 def test_stale_cookie_pre_existing_does_not_false_trigger(tmp_path, monkeypatch):
     """W1 (PR-D review): if the profile already has a stale
     notebooklm.google.com cookie from a previous login (file mtime


### PR DESCRIPTION
Hotfix for PR #56 (PR-D --auto-detect).

**Live bug**: PR-D's `_patchright_cookies_db` hardcoded the legacy `Default/Cookies` path. Modern Chromium (80+, including patchright chromium-1208) stores cookies under `Default/Network/Cookies`. Auto-detect polled the wrong file → never fired → user real-life login DID succeed in the browser, but research-hub never detected it.

**Fix**: prefer modern path, fall back to legacy only if modern missing AND legacy exists.

3 new path-resolution tests verify modern / legacy / both-missing branches. 13 auto-detect tests green. L5 invariant untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)