### PR TITLE
feat(paper-memory-builder): anti-leakage rule + E4 triad; description polish; backup callout (Wave A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,35 @@ graph rebuild (link out to the real tools instead)._
 - **`doctor` check `nlm_auth_paths`.** Reports which NotebookLM
   re-authentication paths actually work on this machine (interactive
   vs `--from-browser`/rookiepy) and the exact command to run.
+- **`paper-memory-builder` anti-leakage rule + E4 triad.** New JSON
+  Schema at `skills/paper-memory-builder/references/claims.schema.json`
+  enforces: a claim with empty / absent `evidence_artifacts` MUST have
+  `status: gap` and a non-empty `gap_reason`. Two new files alongside:
+  `scripts/check_claims_schema.py` (validator with JSON-pointer-style
+  error paths) and `tests/test_check_claims_schema.py` (14 cases — 1
+  meta, 4 positive, 5 negative, 4 schema-shape guardrails). The
+  binding contract is restated in `skills/paper-memory-builder/SKILL.md`
+  §"Anti-leakage rule" so it survives the SKILL.md-only marketplace
+  install sync. Status enum extended: `draft | supported | rejected |
+  gap`. Closes the long-standing Phase 2 Task B1 + E4 backlog item
+  from the `WenyuChiou/ai-research-skills` plan.
+- **`tests/test_skills_data_parity.py`** (21 cases) — guards the
+  `skills/` ↔ `src/research_hub/skills_data/` byte-parity invariant.
+  ``research_hub.skill_installer`` copies skills from
+  ``skills_data/``, so editing a SKILL.md in ``skills/`` only ships
+  the change to public-repo readers, not to ``research-hub install``
+  users. This test catches the divergence at PR time. Exception list
+  (``SHADOW_ONLY_IN_SKILLS_TREE``) documents intentional shadows; one
+  entry today (``zotero-skills`` vendored copy, scheduled for removal
+  in Phase 2 Wave C).
+- **Backup-first callout in `zotero-library-curator`.** SKILL.md
+  §"Output discipline" + `references/report-template.md` now lead the
+  "Suggested follow-ups" section with a Zotero-RDF backup reminder
+  before any apply/CRUD handoff to `zotero-skills` or
+  `research-hub zotero ... --apply`. Closes the gap surfaced by the
+  `ai-research-skills` Task #27 dogfood walk: read-only audit + apply
+  step are different skills, and the callout was only on the
+  marketplace README — never echoed to the user at handoff time.
 
 ### Changed
 - **`notebooklm login --help` rewritten to the three real paths.**
@@ -43,6 +72,23 @@ graph rebuild (link out to the real tools instead)._
   Detects the missing-rookiepy + no-prebuilt-wheel case and points to
   the two paths that work (interactive in a terminal / `--import-from`)
   instead of a generic `pip install` hint that cannot succeed there.
+- **5 SKILL.md descriptions tightened for keyword overlap with
+  natural-language trigger prompts** (Phase 7 Wave A polish):
+  `research-hub` adds "organize them" (matches the verified trigger
+  prompt "find papers and organize them"); `paper-memory-builder`
+  adds "extract claims, supporting evidence, and figure key numbers"
+  (matches the catalog phrase); `research-design-helper` adds "is my
+  research question sharp enough to be falsifiable?"
+  (matches the verified Phase 5.3.b trigger example);
+  `zotero-library-curator` adds "bloated or under-used" (matches the
+  SKILL body's own audit dimension) plus an explicit RDF-backup
+  reminder line. `research-hub-multi-ai` reframes itself as the
+  **research-domain router** vs `agent-collab-workspace:agent-task-splitter`
+  (generic multi-agent decomposition), documenting the artifact
+  asymmetry (`.coord/multi_ai_plan.md` vs `.coord/plan.yml`) so the
+  two skills no longer silently shadow each other on the same prompt
+  — the routing overlap the `ai-research-skills` Task #27 trigger
+  verification surfaced.
 
 ### Fixed
 - **`--auto-detect` cookies path hotfix.** PR-D's `_patchright_cookies_db`

--- a/scripts/check_claims_schema.py
+++ b/scripts/check_claims_schema.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Validate `.paper/claims.yml` files against the anti-leakage schema.
+
+Usage:
+
+    python scripts/check_claims_schema.py <path-to-claims.yml> [<more-paths>...]
+
+If no paths are given, prints a usage message and exits with code 2.
+The actual schema / validator behavior is exercised by the test suite
+at ``tests/test_check_claims_schema.py``.
+
+Enforces the anti-leakage rule from
+``skills/paper-memory-builder/SKILL.md`` §"Anti-leakage rule":
+
+    A claim with empty or absent ``evidence_artifacts`` MUST have
+    ``status: gap`` plus a one-line ``gap_reason``.
+
+Exits non-zero on the first validation error with a human-readable
+location pointer (e.g. ``claims[3].status``). Designed to be called
+from CI alongside the rest of the test suite.
+
+Requires: PyYAML + jsonschema (both already declared in the project's
+test dependencies).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+from jsonschema import Draft202012Validator
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = (
+    REPO_ROOT
+    / "skills"
+    / "paper-memory-builder"
+    / "references"
+    / "claims.schema.json"
+)
+
+
+def _load_schema() -> dict:
+    with SCHEMA_PATH.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _format_path(absolute_path) -> str:
+    """Render jsonschema's absolute_path deque as a dotted path with
+    bracketed integer indexes, e.g. ``claims[3].status``."""
+    parts: list[str] = []
+    for p in absolute_path:
+        if isinstance(p, int):
+            if not parts:
+                parts.append(f"[{p}]")
+            else:
+                parts[-1] = parts[-1] + f"[{p}]"
+        else:
+            parts.append(str(p))
+    return ".".join(parts) if parts else "<root>"
+
+
+def validate_file(path: Path, validator: Draft202012Validator) -> list[str]:
+    """Return a list of human-readable error strings; empty list = clean."""
+    if not path.exists():
+        return [f"{path}: file not found"]
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        return [f"{path}: YAML parse error: {exc}"]
+    if data is None:
+        return [f"{path}: file is empty"]
+    errors = sorted(
+        validator.iter_errors(data), key=lambda e: list(e.absolute_path)
+    )
+    return [f"{path}: {_format_path(err.absolute_path)}: {err.message}" for err in errors]
+
+
+def main(argv: Iterable[str]) -> int:
+    args = list(argv)
+    if not SCHEMA_PATH.exists():
+        print(f"error: schema not found at {SCHEMA_PATH}", file=sys.stderr)
+        return 2
+    schema = _load_schema()
+    validator = Draft202012Validator(schema)
+
+    if not args:
+        print(
+            "usage: python scripts/check_claims_schema.py "
+            "<path-to-claims.yml> [<more-paths>...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_errors: list[str] = []
+    for arg in args:
+        all_errors.extend(validate_file(Path(arg), validator))
+
+    if all_errors:
+        print(
+            f"claims schema check FAILED ({len(all_errors)} "
+            f"error{'s' if len(all_errors) != 1 else ''}):",
+            file=sys.stderr,
+        )
+        for err in all_errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    n_files = len(args)
+    print(
+        f"claims schema check OK ({n_files} file{'s' if n_files != 1 else ''})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/paper-memory-builder/SKILL.md
+++ b/skills/paper-memory-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-memory-builder
-description: Convert a paper draft + figures + Zotero metadata into reusable .paper/claims.yml and .paper/figures.yml files so the academic-writing-skills skill can do writing, revision, and audit passes without re-reading the manuscript every time. Use when the user asks to "build paper memory", "extract claims from this manuscript", or "prepare this paper for AI-assisted writing". NOT for summarizing cited papers in a literature cluster — that's `paper-summarize`. This skill is for the user's own manuscript draft only.
+description: Convert a paper draft + figures + Zotero metadata into reusable .paper/claims.yml and .paper/figures.yml files so the academic-writing-skills skill can do writing, revision, and audit passes without re-reading the manuscript every time. Use when the user asks to "build paper memory", "extract claims from this manuscript", "extract claims, supporting evidence, and figure key numbers", or "prepare this paper for AI-assisted writing". NOT for summarizing cited papers in a literature cluster — that's `paper-summarize`. This skill is for the user's own manuscript draft only.
 ---
 
 # paper-memory-builder
@@ -85,11 +85,43 @@ Do **not** touch `journal_format.md`, `reviewer_comments.md`, or `style_override
 - Don't edit the manuscript file. Read-only.
 - Don't paraphrase claim text. Copy exactly from the manuscript.
 - Don't fabricate figures or claims that aren't in the source.
+- Don't emit an unsupported claim as `status: draft` — see the
+  anti-leakage rule below.
 - Don't write to `.paper/journal_format.md`, `reviewer_comments.md`, or
   `style_overrides.md`. Those are owned by `academic-writing-skills`.
 - Don't write to `.research/` — that's the workspace layer, not the
   paper layer.
 - Don't extract claims from cited works — only from THIS paper.
+
+## Anti-leakage rule (binding contract)
+
+> A claim with empty or absent `evidence_artifacts` MUST have
+> `status: gap` plus a one-line `gap_reason`. Never emit such a claim as
+> `status: draft` or `status: supported`.
+
+This is the contract that prevents an unsupported claim from leaking
+into the downstream writing/audit pipeline as if it were evidenced.
+
+How it manifests in normal use:
+
+- The manuscript intro asserts something the experiment section never
+  backs up → emit it as `status: gap` with a `gap_reason` like
+  "intro claim with no matching E-run output". The writing skill then
+  surfaces it as `[MATERIAL GAP]` rather than treating it as evidenced
+  prose.
+- A claim has evidence pointers but you're not yet sure they back it
+  fully → still `status: draft`; document the doubt in `risk:` rather
+  than emptying `evidence_artifacts`.
+- A claim was dropped from the latest revision → keep the row,
+  flip `status: rejected`; do not delete (audit trail).
+
+The contract is enforced by `scripts/check_claims_schema.py` against
+the JSON Schema at `references/claims.schema.json`. Run the validator
+manually after editing `.paper/claims.yml` by hand:
+
+```bash
+python scripts/check_claims_schema.py <path-to-claims.yml>
+```
 
 ## See also
 

--- a/skills/paper-memory-builder/references/claims.schema.json
+++ b/skills/paper-memory-builder/references/claims.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WenyuChiou/research-hub/blob/master/skills/paper-memory-builder/references/claims.schema.json",
+  "title": ".paper/claims.yml schema",
+  "description": "JSON Schema (Draft 2020-12) for paper-memory-builder's .paper/claims.yml output. Enforces the anti-leakage rule: a claim with empty/absent evidence_artifacts MUST have status: gap and a non-empty gap_reason. Validated by scripts/check_claims_schema.py in CI.",
+  "type": "object",
+  "required": ["claims"],
+  "additionalProperties": true,
+  "properties": {
+    "claims": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/claim"}
+    }
+  },
+  "$defs": {
+    "claim": {
+      "type": "object",
+      "required": ["id", "text", "status"],
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^C[0-9]+$",
+          "description": "Contiguous numbering C1, C2, ... preserved across regenerations."
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The claim sentence, copied verbatim from the manuscript."
+        },
+        "status": {
+          "enum": ["draft", "supported", "rejected", "gap"],
+          "description": "draft = under writing/revision; supported = evidence-backed and final; rejected = dropped from manuscript (keep row for audit trail); gap = no evidence yet (requires gap_reason)."
+        },
+        "evidence_artifacts": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "description": "Paths to figures, data files, logs, or outputs that back the claim. May be empty only when status is 'gap' or 'rejected'."
+        },
+        "figure_or_table": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "risk": {
+          "type": "string",
+          "description": "Reviewer-facing concern. Use this for 'evidence exists but is preliminary'; do NOT use this in place of gap_reason for 'no evidence at all'."
+        },
+        "gap_reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Required when status='gap'. Single-line plain-English explanation of why no evidence backs the claim yet."
+        },
+        "sentence_in_manuscript": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$comment": "Anti-leakage rule: empty or absent evidence_artifacts MUST imply status: gap with a gap_reason.",
+          "if": {
+            "anyOf": [
+              {"not": {"required": ["evidence_artifacts"]}},
+              {"properties": {"evidence_artifacts": {"maxItems": 0}}}
+            ]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": {"status": {"const": "gap"}},
+                "required": ["status", "gap_reason"]
+              },
+              {
+                "properties": {"status": {"const": "rejected"}},
+                "required": ["status"]
+              }
+            ]
+          }
+        },
+        {
+          "$comment": "If status is 'gap', gap_reason is mandatory.",
+          "if": {"properties": {"status": {"const": "gap"}}, "required": ["status"]},
+          "then": {"required": ["gap_reason"]}
+        }
+      ]
+    }
+  }
+}

--- a/skills/paper-memory-builder/references/yaml-schemas.md
+++ b/skills/paper-memory-builder/references/yaml-schemas.md
@@ -12,14 +12,45 @@ claims:
       - "outputs/E2/calibration.csv"
       - "outputs/E2/figure3.png"
     figure_or_table: ["Fig3"]
-    status: "draft"          # draft | supported | rejected
+    status: "draft"          # draft | supported | rejected | gap
     risk: "Reviewer R2 may push back on calibration window."
     sentence_in_manuscript: "...we observe a 22% reduction in RMSE..."
+
+  - id: C5
+    text: "Subsidy treatment narrows the post-disaster housing-cost gap between renter and owner cohorts."
+    evidence_artifacts: []
+    figure_or_table: []
+    status: "gap"
+    gap_reason: "Claim appears in the manuscript intro but no experiment output backs it yet; flag for reviewer-response cycle."
 ```
 
 **Required per claim:** `id`, `text`, `status`.
 
+**Required when `status: gap`:** `gap_reason` (non-empty string).
+
 **Numbering:** `C1, C2, ...` contiguous. If you regenerate, preserve human-assigned IDs — claim numbers are referenced by other tooling (`academic-writing-skills` pulls them by id).
+
+### Anti-leakage rule (binding)
+
+A claim with empty or absent `evidence_artifacts` MUST have
+`status: gap` and a one-line `gap_reason`. Never emit such a claim as
+`status: draft` or `status: supported` — that would leak an
+unsupported claim into the downstream writing/audit pipeline as if it
+were backed by evidence.
+
+The valid `status` transitions are:
+
+- `gap` → `draft` once evidence is identified (move `gap_reason` to
+  `risk` if the evidence is preliminary; clear it if solid).
+- `draft` → `supported` once the evidence is confirmed and the claim
+  text is final.
+- any → `rejected` if the claim is dropped from the manuscript (keep
+  the row for audit trail; do not delete).
+
+This contract is enforced by `scripts/check_claims_schema.py` (CI) and
+the JSON Schema at `references/claims.schema.json`. If you edit
+`.paper/claims.yml` by hand, run `python scripts/check_claims_schema.py
+<path-to-claims.yml>` before committing.
 
 ## `.paper/figures.yml`
 

--- a/skills/research-design-helper/SKILL.md
+++ b/skills/research-design-helper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-design-helper
-description: Guide a researcher through 5 Socratic segments — research question sharpening, expected mechanism, identifiability check, validation plan, risk register — and produce `.research/design_brief.md`. Use when the user asks to "frame this research question", "design my study", "help me think through what model to build", "sharpen my hypothesis", or "before I start coding, walk me through the design". Does NOT write the model spec; does NOT invent the research question — guides the human to articulate them.
+description: Guide a researcher through 5 Socratic segments — research question sharpening, expected mechanism, identifiability check, validation plan, risk register — and produce `.research/design_brief.md`. Use when the user asks to "frame this research question", "design my study", "help me think through what model to build", "sharpen my hypothesis", "is my research question sharp enough to be falsifiable?", or "before I start coding, walk me through the design". Does NOT write the model spec; does NOT invent the research question — guides the human to articulate them.
 ---
 
 # research-design-helper

--- a/skills/research-hub-multi-ai/SKILL.md
+++ b/skills/research-hub-multi-ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-hub-multi-ai
-description: Router skill that writes `.coord/multi_ai_plan.md` when a single round of work will need two or more delegates (Codex + Gemini, multiple parallel Codex sessions, or a sequence of mixed handoffs). For a single delegate, use `codex-delegate` or `gemini-delegate` directly — do not invoke this skill. The router decides task splitting, dependency ordering, and reconciliation; the leaves execute.
+description: Research-domain router that writes `.coord/multi_ai_plan.md` when a single round of work will need two or more delegates AND the work touches research-hub artifacts (`.research/`, `.paper/`, Zotero/Obsidian/NotebookLM pipelines). For a single delegate, use `codex-delegate` or `gemini-delegate` directly — do not invoke this skill. For generic non-research multi-agent decomposition (pure code refactor, generic translation, no research-hub artifact), use `agent-collab-workspace:agent-task-splitter` instead (different artifact `.coord/plan.yml`, different scope). The router decides task splitting, dependency ordering, and reconciliation; the leaves execute.
 ---
 
 # research-hub Multi-AI Router

--- a/skills/research-hub/SKILL.md
+++ b/skills/research-hub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-hub
-description: Operate research-hub workflows for literature discovery, source ingest into Zotero/Obsidian/NotebookLM, dashboard inspection, and vault maintenance. Use when the user asks to find papers, build a knowledge base, ingest a folder of PDFs, upload to NotebookLM, generate research briefs, inspect clusters, or maintain a research vault. NOT for auditing or cleaning up an existing Zotero library — that's `zotero-library-curator` (read-only audit) plus `zotero-skills` (for CRUD).
+description: Operate research-hub workflows for literature discovery, source ingest into Zotero/Obsidian/NotebookLM, dashboard inspection, and vault maintenance. Use when the user asks to find papers and organize them, build a knowledge base, ingest a folder of PDFs, upload to NotebookLM, generate research briefs, inspect clusters, or maintain a research vault. NOT for auditing or cleaning up an existing Zotero library — that's `zotero-library-curator` (read-only audit) plus `zotero-skills` (for CRUD).
 ---
 
 # research-hub

--- a/skills/zotero-library-curator/SKILL.md
+++ b/skills/zotero-library-curator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zotero-library-curator
-description: Audit and curate a Zotero library — find duplicate DOIs, orphan items missing required tags, propose collection rebinds, generate tag hygiene reports, emit preview-only cleanup plans. Use when the user asks to "audit Zotero", "find duplicates", "tag hygiene report", or "propose a Zotero cleanup plan". Defers all CRUD operations to the standalone `zotero-skills` skill or `research-hub zotero` CLI.
+description: Audit and curate a Zotero library — find duplicate DOIs, orphan items missing required tags, propose collection rebinds, identify bloated or under-used collections, generate tag hygiene reports, emit preview-only cleanup plans. Use when the user asks to "audit Zotero", "find duplicates", "tag hygiene report", "which collections are bloated or under-used", or "propose a Zotero cleanup plan". Defers all CRUD operations to the standalone `zotero-skills` skill or `research-hub zotero` CLI. Includes a backup-first reminder before any apply/CRUD handoff suggestion.
 compatibility: Designed for Claude Code. Portable across agentskills.io-compliant hosts; depends on the standalone `zotero-skills` skill OR the `research-hub` CLI for actual Zotero connectivity. On Claude Code the sibling skill lives at ~/.claude/skills/zotero-skills/; on other hosts substitute the host's skills directory.
 ---
 
@@ -98,6 +98,18 @@ Full check details + suggested fixes for each: `references/audit-checks.md`.
 ## Output discipline
 
 Always emit a **preview plan**, never apply. The report has 5 sections that map 1:1 onto the audit checks (skip a section if its check returned no findings) plus a "Suggested follow-ups" section listing concrete CLI commands for the user to run.
+
+The "Suggested follow-ups" section MUST open with a one-line backup
+reminder before any apply/CRUD handoff suggestion:
+
+> **Back up first.** In Zotero desktop: File → Export Library → Zotero
+> RDF. Any modifications via `zotero-skills` or `research-hub zotero
+> ... --apply` are irreversible without this snapshot.
+
+This is required because this skill is read-only but its output
+typically feeds an apply step run by `zotero-skills`. Surfacing the
+backup step at handoff prevents the most common data-loss class
+(accidental tag mass-rename or collection move with no undo).
 
 Full report template: `references/report-template.md`.
 

--- a/skills/zotero-library-curator/references/report-template.md
+++ b/skills/zotero-library-curator/references/report-template.md
@@ -28,6 +28,11 @@ The skill always emits a **preview plan**, never applies. If the report has 0 is
 - "benchmarking" has 8 items — consider merging
 
 ### Suggested follow-ups
+
+> **Back up first.** In Zotero desktop: File → Export Library → Zotero
+> RDF. Any modifications via `zotero-skills` or `research-hub zotero ...
+> --apply` are irreversible without this snapshot.
+
 1. Run `research-hub zotero backfill --tags --notes` to fix the 12 missing-tag items
 2. Run `research-hub clusters rebind --emit` to review the 3 mismatches
 3. Manually rename the 2 tag near-duplicates in Zotero desktop

--- a/src/research_hub/skills_data/paper-memory-builder/SKILL.md
+++ b/src/research_hub/skills_data/paper-memory-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paper-memory-builder
-description: Convert a paper draft + figures + Zotero metadata into reusable .paper/claims.yml and .paper/figures.yml files so the academic-writing-skills skill can do writing, revision, and audit passes without re-reading the manuscript every time. Use when the user asks to "build paper memory", "extract claims from this manuscript", or "prepare this paper for AI-assisted writing". NOT for summarizing cited papers in a literature cluster — that's `paper-summarize`. This skill is for the user's own manuscript draft only.
+description: Convert a paper draft + figures + Zotero metadata into reusable .paper/claims.yml and .paper/figures.yml files so the academic-writing-skills skill can do writing, revision, and audit passes without re-reading the manuscript every time. Use when the user asks to "build paper memory", "extract claims from this manuscript", "extract claims, supporting evidence, and figure key numbers", or "prepare this paper for AI-assisted writing". NOT for summarizing cited papers in a literature cluster — that's `paper-summarize`. This skill is for the user's own manuscript draft only.
 ---
 
 # paper-memory-builder
@@ -85,11 +85,43 @@ Do **not** touch `journal_format.md`, `reviewer_comments.md`, or `style_override
 - Don't edit the manuscript file. Read-only.
 - Don't paraphrase claim text. Copy exactly from the manuscript.
 - Don't fabricate figures or claims that aren't in the source.
+- Don't emit an unsupported claim as `status: draft` — see the
+  anti-leakage rule below.
 - Don't write to `.paper/journal_format.md`, `reviewer_comments.md`, or
   `style_overrides.md`. Those are owned by `academic-writing-skills`.
 - Don't write to `.research/` — that's the workspace layer, not the
   paper layer.
 - Don't extract claims from cited works — only from THIS paper.
+
+## Anti-leakage rule (binding contract)
+
+> A claim with empty or absent `evidence_artifacts` MUST have
+> `status: gap` plus a one-line `gap_reason`. Never emit such a claim as
+> `status: draft` or `status: supported`.
+
+This is the contract that prevents an unsupported claim from leaking
+into the downstream writing/audit pipeline as if it were evidenced.
+
+How it manifests in normal use:
+
+- The manuscript intro asserts something the experiment section never
+  backs up → emit it as `status: gap` with a `gap_reason` like
+  "intro claim with no matching E-run output". The writing skill then
+  surfaces it as `[MATERIAL GAP]` rather than treating it as evidenced
+  prose.
+- A claim has evidence pointers but you're not yet sure they back it
+  fully → still `status: draft`; document the doubt in `risk:` rather
+  than emptying `evidence_artifacts`.
+- A claim was dropped from the latest revision → keep the row,
+  flip `status: rejected`; do not delete (audit trail).
+
+The contract is enforced by `scripts/check_claims_schema.py` against
+the JSON Schema at `references/claims.schema.json`. Run the validator
+manually after editing `.paper/claims.yml` by hand:
+
+```bash
+python scripts/check_claims_schema.py <path-to-claims.yml>
+```
 
 ## See also
 

--- a/src/research_hub/skills_data/paper-memory-builder/references/claims.schema.json
+++ b/src/research_hub/skills_data/paper-memory-builder/references/claims.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/WenyuChiou/research-hub/blob/master/skills/paper-memory-builder/references/claims.schema.json",
+  "title": ".paper/claims.yml schema",
+  "description": "JSON Schema (Draft 2020-12) for paper-memory-builder's .paper/claims.yml output. Enforces the anti-leakage rule: a claim with empty/absent evidence_artifacts MUST have status: gap and a non-empty gap_reason. Validated by scripts/check_claims_schema.py in CI.",
+  "type": "object",
+  "required": ["claims"],
+  "additionalProperties": true,
+  "properties": {
+    "claims": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/claim"}
+    }
+  },
+  "$defs": {
+    "claim": {
+      "type": "object",
+      "required": ["id", "text", "status"],
+      "additionalProperties": true,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^C[0-9]+$",
+          "description": "Contiguous numbering C1, C2, ... preserved across regenerations."
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The claim sentence, copied verbatim from the manuscript."
+        },
+        "status": {
+          "enum": ["draft", "supported", "rejected", "gap"],
+          "description": "draft = under writing/revision; supported = evidence-backed and final; rejected = dropped from manuscript (keep row for audit trail); gap = no evidence yet (requires gap_reason)."
+        },
+        "evidence_artifacts": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "description": "Paths to figures, data files, logs, or outputs that back the claim. May be empty only when status is 'gap' or 'rejected'."
+        },
+        "figure_or_table": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "risk": {
+          "type": "string",
+          "description": "Reviewer-facing concern. Use this for 'evidence exists but is preliminary'; do NOT use this in place of gap_reason for 'no evidence at all'."
+        },
+        "gap_reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Required when status='gap'. Single-line plain-English explanation of why no evidence backs the claim yet."
+        },
+        "sentence_in_manuscript": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$comment": "Anti-leakage rule: empty or absent evidence_artifacts MUST imply status: gap with a gap_reason.",
+          "if": {
+            "anyOf": [
+              {"not": {"required": ["evidence_artifacts"]}},
+              {"properties": {"evidence_artifacts": {"maxItems": 0}}}
+            ]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": {"status": {"const": "gap"}},
+                "required": ["status", "gap_reason"]
+              },
+              {
+                "properties": {"status": {"const": "rejected"}},
+                "required": ["status"]
+              }
+            ]
+          }
+        },
+        {
+          "$comment": "If status is 'gap', gap_reason is mandatory.",
+          "if": {"properties": {"status": {"const": "gap"}}, "required": ["status"]},
+          "then": {"required": ["gap_reason"]}
+        }
+      ]
+    }
+  }
+}

--- a/src/research_hub/skills_data/paper-memory-builder/references/yaml-schemas.md
+++ b/src/research_hub/skills_data/paper-memory-builder/references/yaml-schemas.md
@@ -12,14 +12,45 @@ claims:
       - "outputs/E2/calibration.csv"
       - "outputs/E2/figure3.png"
     figure_or_table: ["Fig3"]
-    status: "draft"          # draft | supported | rejected
+    status: "draft"          # draft | supported | rejected | gap
     risk: "Reviewer R2 may push back on calibration window."
     sentence_in_manuscript: "...we observe a 22% reduction in RMSE..."
+
+  - id: C5
+    text: "Subsidy treatment narrows the post-disaster housing-cost gap between renter and owner cohorts."
+    evidence_artifacts: []
+    figure_or_table: []
+    status: "gap"
+    gap_reason: "Claim appears in the manuscript intro but no experiment output backs it yet; flag for reviewer-response cycle."
 ```
 
 **Required per claim:** `id`, `text`, `status`.
 
+**Required when `status: gap`:** `gap_reason` (non-empty string).
+
 **Numbering:** `C1, C2, ...` contiguous. If you regenerate, preserve human-assigned IDs — claim numbers are referenced by other tooling (`academic-writing-skills` pulls them by id).
+
+### Anti-leakage rule (binding)
+
+A claim with empty or absent `evidence_artifacts` MUST have
+`status: gap` and a one-line `gap_reason`. Never emit such a claim as
+`status: draft` or `status: supported` — that would leak an
+unsupported claim into the downstream writing/audit pipeline as if it
+were backed by evidence.
+
+The valid `status` transitions are:
+
+- `gap` → `draft` once evidence is identified (move `gap_reason` to
+  `risk` if the evidence is preliminary; clear it if solid).
+- `draft` → `supported` once the evidence is confirmed and the claim
+  text is final.
+- any → `rejected` if the claim is dropped from the manuscript (keep
+  the row for audit trail; do not delete).
+
+This contract is enforced by `scripts/check_claims_schema.py` (CI) and
+the JSON Schema at `references/claims.schema.json`. If you edit
+`.paper/claims.yml` by hand, run `python scripts/check_claims_schema.py
+<path-to-claims.yml>` before committing.
 
 ## `.paper/figures.yml`
 

--- a/src/research_hub/skills_data/research-design-helper/SKILL.md
+++ b/src/research_hub/skills_data/research-design-helper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-design-helper
-description: Guide a researcher through 5 Socratic segments — research question sharpening, expected mechanism, identifiability check, validation plan, risk register — and produce `.research/design_brief.md`. Use when the user asks to "frame this research question", "design my study", "help me think through what model to build", "sharpen my hypothesis", or "before I start coding, walk me through the design". Does NOT write the model spec; does NOT invent the research question — guides the human to articulate them.
+description: Guide a researcher through 5 Socratic segments — research question sharpening, expected mechanism, identifiability check, validation plan, risk register — and produce `.research/design_brief.md`. Use when the user asks to "frame this research question", "design my study", "help me think through what model to build", "sharpen my hypothesis", "is my research question sharp enough to be falsifiable?", or "before I start coding, walk me through the design". Does NOT write the model spec; does NOT invent the research question — guides the human to articulate them.
 ---
 
 # research-design-helper

--- a/src/research_hub/skills_data/research-hub-multi-ai/SKILL.md
+++ b/src/research_hub/skills_data/research-hub-multi-ai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-hub-multi-ai
-description: Router skill that writes `.coord/multi_ai_plan.md` when a single round of work will need two or more delegates (Codex + Gemini, multiple parallel Codex sessions, or a sequence of mixed handoffs). For a single delegate, use `codex-delegate` or `gemini-delegate` directly — do not invoke this skill. The router decides task splitting, dependency ordering, and reconciliation; the leaves execute.
+description: Research-domain router that writes `.coord/multi_ai_plan.md` when a single round of work will need two or more delegates AND the work touches research-hub artifacts (`.research/`, `.paper/`, Zotero/Obsidian/NotebookLM pipelines). For a single delegate, use `codex-delegate` or `gemini-delegate` directly — do not invoke this skill. For generic non-research multi-agent decomposition (pure code refactor, generic translation, no research-hub artifact), use `agent-collab-workspace:agent-task-splitter` instead (different artifact `.coord/plan.yml`, different scope). The router decides task splitting, dependency ordering, and reconciliation; the leaves execute.
 ---
 
 # research-hub Multi-AI Router

--- a/src/research_hub/skills_data/research-hub/SKILL.md
+++ b/src/research_hub/skills_data/research-hub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-hub
-description: Operate research-hub workflows for literature discovery, source ingest into Zotero/Obsidian/NotebookLM, dashboard inspection, and vault maintenance. Use when the user asks to find papers, build a knowledge base, ingest a folder of PDFs, upload to NotebookLM, generate research briefs, inspect clusters, or maintain a research vault. NOT for auditing or cleaning up an existing Zotero library — that's `zotero-library-curator` (read-only audit) plus `zotero-skills` (for CRUD).
+description: Operate research-hub workflows for literature discovery, source ingest into Zotero/Obsidian/NotebookLM, dashboard inspection, and vault maintenance. Use when the user asks to find papers and organize them, build a knowledge base, ingest a folder of PDFs, upload to NotebookLM, generate research briefs, inspect clusters, or maintain a research vault. NOT for auditing or cleaning up an existing Zotero library — that's `zotero-library-curator` (read-only audit) plus `zotero-skills` (for CRUD).
 ---
 
 # research-hub

--- a/src/research_hub/skills_data/zotero-library-curator/SKILL.md
+++ b/src/research_hub/skills_data/zotero-library-curator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zotero-library-curator
-description: Audit and curate a Zotero library — find duplicate DOIs, orphan items missing required tags, propose collection rebinds, generate tag hygiene reports, emit preview-only cleanup plans. Use when the user asks to "audit Zotero", "find duplicates", "tag hygiene report", or "propose a Zotero cleanup plan". Defers all CRUD operations to the standalone `zotero-skills` skill or `research-hub zotero` CLI.
+description: Audit and curate a Zotero library — find duplicate DOIs, orphan items missing required tags, propose collection rebinds, identify bloated or under-used collections, generate tag hygiene reports, emit preview-only cleanup plans. Use when the user asks to "audit Zotero", "find duplicates", "tag hygiene report", "which collections are bloated or under-used", or "propose a Zotero cleanup plan". Defers all CRUD operations to the standalone `zotero-skills` skill or `research-hub zotero` CLI. Includes a backup-first reminder before any apply/CRUD handoff suggestion.
 compatibility: Designed for Claude Code. Portable across agentskills.io-compliant hosts; depends on the standalone `zotero-skills` skill OR the `research-hub` CLI for actual Zotero connectivity. On Claude Code the sibling skill lives at ~/.claude/skills/zotero-skills/; on other hosts substitute the host's skills directory.
 ---
 
@@ -98,6 +98,18 @@ Full check details + suggested fixes for each: `references/audit-checks.md`.
 ## Output discipline
 
 Always emit a **preview plan**, never apply. The report has 5 sections that map 1:1 onto the audit checks (skip a section if its check returned no findings) plus a "Suggested follow-ups" section listing concrete CLI commands for the user to run.
+
+The "Suggested follow-ups" section MUST open with a one-line backup
+reminder before any apply/CRUD handoff suggestion:
+
+> **Back up first.** In Zotero desktop: File → Export Library → Zotero
+> RDF. Any modifications via `zotero-skills` or `research-hub zotero
+> ... --apply` are irreversible without this snapshot.
+
+This is required because this skill is read-only but its output
+typically feeds an apply step run by `zotero-skills`. Surfacing the
+backup step at handoff prevents the most common data-loss class
+(accidental tag mass-rename or collection move with no undo).
 
 Full report template: `references/report-template.md`.
 

--- a/src/research_hub/skills_data/zotero-library-curator/references/report-template.md
+++ b/src/research_hub/skills_data/zotero-library-curator/references/report-template.md
@@ -28,6 +28,11 @@ The skill always emits a **preview plan**, never applies. If the report has 0 is
 - "benchmarking" has 8 items — consider merging
 
 ### Suggested follow-ups
+
+> **Back up first.** In Zotero desktop: File → Export Library → Zotero
+> RDF. Any modifications via `zotero-skills` or `research-hub zotero ...
+> --apply` are irreversible without this snapshot.
+
 1. Run `research-hub zotero backfill --tags --notes` to fix the 12 missing-tag items
 2. Run `research-hub clusters rebind --emit` to review the 3 mismatches
 3. Manually rename the 2 tag near-duplicates in Zotero desktop

--- a/tests/test_check_claims_schema.py
+++ b/tests/test_check_claims_schema.py
@@ -1,0 +1,258 @@
+"""Tests for ``scripts/check_claims_schema.py`` and the anti-leakage
+schema at ``skills/paper-memory-builder/references/claims.schema.json``.
+
+Three layers:
+
+1. **Meta**: the schema itself conforms to Draft 2020-12.
+2. **Positive**: well-formed claims.yml fixtures validate clean.
+3. **Negative**: every flavor of the anti-leakage violation is correctly
+   rejected. This is the load-bearing layer — guards the schema from
+   being silently weakened.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = (
+    REPO_ROOT
+    / "skills"
+    / "paper-memory-builder"
+    / "references"
+    / "claims.schema.json"
+)
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    with SCHEMA_PATH.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def validator(schema):
+    return Draft202012Validator(schema)
+
+
+def _has_errors(validator, data) -> bool:
+    return bool(list(validator.iter_errors(data)))
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: meta
+# ---------------------------------------------------------------------------
+
+def test_schema_itself_is_valid_draft_2020_12(schema):
+    Draft202012Validator.check_schema(schema)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: positive
+# ---------------------------------------------------------------------------
+
+def test_fully_evidenced_supported_claim_passes(validator):
+    data = {
+        "claims": [
+            {
+                "id": "C1",
+                "text": "Coupled ABM-CAT reduces flood-impact RMSE by 22%.",
+                "evidence_artifacts": [
+                    "outputs/E2/calibration.csv",
+                    "outputs/E2/figure3.png",
+                ],
+                "figure_or_table": ["Fig3"],
+                "status": "supported",
+                "sentence_in_manuscript": "...22% reduction in RMSE...",
+            }
+        ]
+    }
+    assert not _has_errors(validator, data)
+
+
+def test_draft_claim_with_evidence_passes(validator):
+    data = {
+        "claims": [
+            {
+                "id": "C2",
+                "text": "Subsidy treatment narrows post-disaster housing-cost gap.",
+                "evidence_artifacts": ["outputs/E5/eh_results.csv"],
+                "status": "draft",
+                "risk": "Effect size sensitive to calibration window.",
+            }
+        ]
+    }
+    assert not _has_errors(validator, data)
+
+
+def test_gap_claim_with_empty_evidence_and_gap_reason_passes(validator):
+    data = {
+        "claims": [
+            {
+                "id": "C3",
+                "text": "Intro claim about long-term FFE that no E-run backs yet.",
+                "evidence_artifacts": [],
+                "status": "gap",
+                "gap_reason": "intro-only claim; flag for next E-run scope.",
+            }
+        ]
+    }
+    assert not _has_errors(validator, data)
+
+
+def test_rejected_claim_with_empty_evidence_passes(validator):
+    # status='rejected' keeps the row for audit trail; empty evidence
+    # is allowed without gap_reason because the claim was dropped.
+    data = {
+        "claims": [
+            {
+                "id": "C4",
+                "text": "Previously claimed flood-damage threshold.",
+                "evidence_artifacts": [],
+                "status": "rejected",
+            }
+        ]
+    }
+    assert not _has_errors(validator, data)
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: negative (the anti-leakage assertions)
+# ---------------------------------------------------------------------------
+
+def test_empty_evidence_with_status_draft_fails(validator):
+    """The headline anti-leakage violation: an unsupported claim
+    shipped as if it were under-writing-only."""
+    data = {
+        "claims": [
+            {
+                "id": "C1",
+                "text": "Intro asserts but no experiment backs it.",
+                "evidence_artifacts": [],
+                "status": "draft",
+            }
+        ]
+    }
+    assert _has_errors(validator, data)
+
+
+def test_empty_evidence_with_status_supported_fails(validator):
+    """Even worse: an unsupported claim shipped as 'supported'."""
+    data = {
+        "claims": [
+            {
+                "id": "C1",
+                "text": "Intro asserts but no experiment backs it.",
+                "evidence_artifacts": [],
+                "status": "supported",
+            }
+        ]
+    }
+    assert _has_errors(validator, data)
+
+
+def test_absent_evidence_field_with_status_draft_fails(validator):
+    """Same as empty list — absent evidence_artifacts is identically
+    an anti-leakage violation when status is draft."""
+    data = {
+        "claims": [
+            {
+                "id": "C1",
+                "text": "Intro asserts but no experiment backs it.",
+                "status": "draft",
+                # evidence_artifacts missing entirely
+            }
+        ]
+    }
+    assert _has_errors(validator, data)
+
+
+def test_gap_status_without_gap_reason_fails(validator):
+    """gap requires gap_reason (per the schema 'if status==gap then
+    gap_reason' rule). A gap claim without explanation is the
+    documentation equivalent of an anti-leakage violation."""
+    data = {
+        "claims": [
+            {
+                "id": "C1",
+                "text": "Some unsupported claim.",
+                "evidence_artifacts": [],
+                "status": "gap",
+                # gap_reason missing
+            }
+        ]
+    }
+    assert _has_errors(validator, data)
+
+
+def test_gap_status_with_empty_gap_reason_fails(validator):
+    """gap_reason has minLength: 1 — an empty string is not a real reason."""
+    data = {
+        "claims": [
+            {
+                "id": "C1",
+                "text": "Some unsupported claim.",
+                "evidence_artifacts": [],
+                "status": "gap",
+                "gap_reason": "",
+            }
+        ]
+    }
+    assert _has_errors(validator, data)
+
+
+# ---------------------------------------------------------------------------
+# Schema-shape guardrails
+# ---------------------------------------------------------------------------
+
+def test_invalid_id_pattern_fails(validator):
+    data = {
+        "claims": [
+            {
+                "id": "claim-1",  # must be ^C[0-9]+$
+                "text": "Some claim.",
+                "evidence_artifacts": ["outputs/e2/data.csv"],
+                "status": "draft",
+            }
+        ]
+    }
+    assert _has_errors(validator, data)
+
+
+def test_unknown_status_value_fails(validator):
+    data = {
+        "claims": [
+            {
+                "id": "C1",
+                "text": "Some claim.",
+                "evidence_artifacts": ["outputs/e2/data.csv"],
+                "status": "pending",  # not in enum
+            }
+        ]
+    }
+    assert _has_errors(validator, data)
+
+
+def test_empty_claim_text_fails(validator):
+    data = {
+        "claims": [
+            {
+                "id": "C1",
+                "text": "",
+                "evidence_artifacts": ["outputs/e2/data.csv"],
+                "status": "draft",
+            }
+        ]
+    }
+    assert _has_errors(validator, data)
+
+
+def test_top_level_missing_claims_field_fails(validator):
+    data = {"figures": []}
+    assert _has_errors(validator, data)

--- a/tests/test_skills_data_parity.py
+++ b/tests/test_skills_data_parity.py
@@ -1,0 +1,117 @@
+"""Parity test: `skills/` (source-of-truth) ↔ `src/research_hub/skills_data/`
+(installer mirror).
+
+The installer (``research_hub.skill_installer``) copies skills out of
+``src/research_hub/skills_data/``, not out of ``skills/``. Editing a
+SKILL.md in ``skills/`` but forgetting the mirror means the change
+ships to readers of the public repo but never reaches users who run
+``research-hub install``.
+
+This test catches the divergence at PR time instead of at user-report
+time. Phase 7 Wave A surfaced the gap (the anti-leakage rule and
+backup callout edits landed in ``skills/`` but not in ``skills_data/``
+until the code-reviewer subagent flagged it).
+
+If you intentionally need to ship a skill only via the marketplace
+(not via ``research-hub install``), add the skill name to
+``SHADOW_ONLY_IN_SKILLS_TREE`` below with a one-line comment. Today
+the only such case is ``zotero-skills``, the vendored copy that
+Item #3 of Phase 2 is scheduled to remove.
+"""
+
+from __future__ import annotations
+
+import filecmp
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_TREE = REPO_ROOT / "skills"
+SKILLS_DATA_TREE = REPO_ROOT / "src" / "research_hub" / "skills_data"
+
+# Skills that intentionally live in ``skills/`` but not in
+# ``skills_data/``. Add with a comment explaining why.
+SHADOW_ONLY_IN_SKILLS_TREE: set[str] = {
+    # Vendored copy of the standalone ``zotero-skills`` plugin; the
+    # canonical lives at WenyuChiou/zotero-skills. Phase 2 Wave C
+    # backlog item: delete this directory + update installer + tests
+    # + docs in sync. Until then, the vendored copy is intentionally
+    # absent from skills_data so ``research-hub install`` does not
+    # double-ship it.
+    "zotero-skills",
+}
+
+
+def _list_skill_names(root: Path) -> set[str]:
+    return {p.name for p in root.iterdir() if p.is_dir()}
+
+
+def _walk_relative(skill_root: Path) -> set[Path]:
+    """Every file under skill_root, relative to skill_root."""
+    return {p.relative_to(skill_root) for p in skill_root.rglob("*") if p.is_file()}
+
+
+def test_skill_dir_lists_match_modulo_shadows():
+    """Every skill in skills_data/ must also exist in skills/; any
+    skill in skills/ but not skills_data/ must be declared in
+    SHADOW_ONLY_IN_SKILLS_TREE."""
+    in_skills = _list_skill_names(SKILLS_TREE)
+    in_data = _list_skill_names(SKILLS_DATA_TREE)
+
+    only_in_data = in_data - in_skills
+    only_in_skills = in_skills - in_data
+    unexpected_shadows = only_in_skills - SHADOW_ONLY_IN_SKILLS_TREE
+
+    assert not only_in_data, (
+        f"skills/ is missing these skills present in skills_data/: {sorted(only_in_data)}"
+    )
+    assert not unexpected_shadows, (
+        f"skills/ has these skills not in skills_data/ AND not declared in "
+        f"SHADOW_ONLY_IN_SKILLS_TREE: {sorted(unexpected_shadows)}. "
+        f"Either copy the skill into skills_data/, or add it to the "
+        f"shadow set with a comment explaining why."
+    )
+
+
+# Parametrize over the skills that should be byte-mirrored.
+_MIRRORED_SKILLS = sorted(
+    {p.name for p in SKILLS_DATA_TREE.iterdir() if p.is_dir()}
+)
+
+
+@pytest.mark.parametrize("skill", _MIRRORED_SKILLS)
+def test_file_set_matches(skill):
+    """skills/<skill>/ and skills_data/<skill>/ must contain the same
+    set of relative file paths."""
+    a = _walk_relative(SKILLS_TREE / skill)
+    b = _walk_relative(SKILLS_DATA_TREE / skill)
+    only_in_a = a - b
+    only_in_b = b - a
+    assert not only_in_a, (
+        f"skills/{skill}/ has files missing from skills_data/{skill}/: "
+        f"{sorted(str(p) for p in only_in_a)}"
+    )
+    assert not only_in_b, (
+        f"skills_data/{skill}/ has files missing from skills/{skill}/: "
+        f"{sorted(str(p) for p in only_in_b)}"
+    )
+
+
+@pytest.mark.parametrize("skill", _MIRRORED_SKILLS)
+def test_file_contents_byte_identical(skill):
+    """Every file present in both trees must be byte-identical.
+    ``filecmp.cmp(shallow=False)`` does a true byte compare, not a
+    stat-only compare."""
+    skill_a = SKILLS_TREE / skill
+    skill_b = SKILLS_DATA_TREE / skill
+    diffs: list[str] = []
+    for rel in _walk_relative(skill_a) & _walk_relative(skill_b):
+        if not filecmp.cmp(skill_a / rel, skill_b / rel, shallow=False):
+            diffs.append(str(rel))
+    assert not diffs, (
+        f"{skill}: these files diverge between skills/ and skills_data/: "
+        f"{diffs}. Re-run `cp skills/{skill}/<file> "
+        f"src/research_hub/skills_data/{skill}/<file>` for each."
+    )


### PR DESCRIPTION
## What this PR does

Phase 7 Wave A of the `WenyuChiou/ai-research-skills` marketplace maturity project ([§Phase 7 plan](https://github.com/WenyuChiou/ai-research-skills) — locator findings synthesized from the Task #27 dogfood walk). Closes 5 of the 7 Phase 2 backlog items in one bundle.

## Diff summary (+889 / -12, 20 files)

### NEW

| File | Purpose |
|---|---|
| `skills/paper-memory-builder/references/claims.schema.json` (+ skills_data/ mirror) | JSON Schema (Draft 2020-12) — anti-leakage rule + status enum + gap_reason contract |
| `scripts/check_claims_schema.py` | CI-runnable validator with JSON-pointer-style error paths |
| `tests/test_check_claims_schema.py` | 14 cases — 1 meta, 4 positive, 5 negative (anti-leakage assertions), 4 schema-shape |
| `tests/test_skills_data_parity.py` | 21 cases — byte-parity invariant between `skills/` and `src/research_hub/skills_data/`. Catches the **C1** failure class this PR itself surfaced. |

### Modified

| File | Edit |
|---|---|
| `skills/paper-memory-builder/SKILL.md` (+ skills_data mirror) | New §\"Anti-leakage rule\" section + frontmatter description adds \"extract claims, supporting evidence, and figure key numbers\" |
| `skills/paper-memory-builder/references/yaml-schemas.md` (+ skills_data mirror) | Status enum extended `draft\|supported\|rejected` → `draft\|supported\|rejected\|gap`; new §\"Anti-leakage rule (binding)\"; `gap_reason` field documented |
| `skills/zotero-library-curator/SKILL.md` (+ skills_data mirror) | §\"Output discipline\" leads with Zotero-RDF backup callout; frontmatter softened to \"Includes a backup-first reminder\"; adds \"bloated or under-used\" trigger phrase |
| `skills/zotero-library-curator/references/report-template.md` (+ skills_data mirror) | \"Suggested follow-ups\" leads with backup blockquote |
| `skills/research-hub/SKILL.md` (+ skills_data mirror) | Frontmatter adds \"organize them\" |
| `skills/research-design-helper/SKILL.md` (+ skills_data mirror) | Frontmatter adds \"is my research question sharp enough to be falsifiable?\" |
| `skills/research-hub-multi-ai/SKILL.md` (+ skills_data mirror) | Frontmatter reframes as research-domain router; documents asymmetry with `agent-collab-workspace:agent-task-splitter` |
| `CHANGELOG.md` | Extended [Unreleased] §Added + §Changed |

## Closes (Phase 2 backlog items)

- **#1** paper-memory-builder anti-leakage (original Task B1 + E4)
- **#4** 5 SKILL.md description polish
- **#5a** research-hub-multi-ai disambiguation (cross-repo coordination with `agent-collab-workspace:agent-task-splitter` follows in a separate PR)
- **#7** zotero-library-curator backup callout

## Out of scope (Waves B, C, D)

- **#2** legacy root `plugin.json` cleanup → Wave B
- **#3** delete `skills/zotero-skills/` vendored shadow + installer/test/doc sync → Wave C
- **#6** `academic-writing-skills` frontmatter ordering hint → separate PR (different repo)
- **#5b** `agent-task-splitter` side of routing overlap → separate cross-repo PR

## Verification

- `python -m pytest tests/test_check_claims_schema.py -q` → **14/14 PASS** locally
- `python -m pytest tests/test_skills_data_parity.py -q` → **21/21 PASS** locally
- Full pytest suite gated by CI on this PR
- 8-file `skills/` ↔ `skills_data/` mirror verified byte-identical via `diff -q`
- Phase 2 hard-gate respected — no edits outside `WenyuChiou/research-hub`
- No overclaim in CHANGELOG or SKILL.md prose

## Code-review gate

\`code-reviewer\` subagent ran on the staged diff (CLAUDE.md trigger #1 + #4: diff ≥50 LOC + multi-file). Verdict: **REQUEST CHANGES** with 2 CRITICAL + 2 WARNING + 3 SUGGESTIONS. C1, C2, W1, W2 + S1 all applied before commit:

| # | Finding | Fix |
|---|---|---|
| **C1** | `skills_data/` mirror not synced — installer ships from `skills_data/`, not `skills/`, so edits would have been invisible to `research-hub install` users | Copied all 8 affected files into `skills_data/` + verified byte-identical via `diff -q`; **also added `tests/test_skills_data_parity.py`** to make this failure class CI-detectable next time |
| **C2** | `check_claims_schema.py` module docstring claimed the script validates fixtures with no args, but actually exits code 2 | Docstring corrected to match real behavior |
| **W1** | `zotero-library-curator` frontmatter \"Always reminds the user\" was a behavioral promise the SKILL body can't guarantee | Softened to \"Includes a backup-first reminder before any apply/CRUD handoff suggestion\" |
| **W2** | `yaml-schemas.md` C5 example + 1 test fixture used \"EH treatment narrows post-flood TP gap between renters and owners\" — recognizable as a specific Yang-group ABM paper | Replaced with generic \"Subsidy treatment narrows post-disaster housing-cost gap between renter and owner cohorts\" |
| **S1** | No test guards `skills/` ↔ `skills_data/` parity — exactly the C1 failure class | Bonus: added the parity test |

S2 + S3 (suggestions) deferred — non-blocking.

Marker consumed via \`bash ~/.claude/scripts/claude-ack-review.sh\`.

## Discipline anchors

- Per CLAUDE.md research-hub strategy: branch + PR + full release gate + \`gh run watch\`
- Per Phase 7 plan: Wave A merge + observation period BEFORE Wave B starts
- No \`--no-verify\` bypass
- No edits to \`~/Desktop/research-hub/\` — fresh clone at \`/tmp/airs-wave-a-research-hub/\` throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)