### PR TITLE
ci: skill-version-guard — block skill changes without a plugin version bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,3 +142,55 @@ jobs:
         # so that the stress suite is actually selected here.
         run: pytest tests/stress/ -v -o "addopts=" -m stress
         timeout-minutes: 10
+
+  skill-version-guard:
+    # Phase 8.1 / dogfood V1b lesson: a skill-content change that ships to
+    # master without a plugin version bump never reaches user installs —
+    # the marketplace plugin cache directory is keyed on the version string
+    # in .claude-plugin/plugin.json. This job blocks that class of bug at
+    # PR time: if a PR touches skills/ or src/research_hub/skills_data/, it
+    # MUST also bump the plugin version.
+    name: skill-version-guard
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Skill-content change requires a plugin version bump
+        run: |
+          base='${{ github.event.pull_request.base.sha }}'
+          head='${{ github.event.pull_request.head.sha }}'
+          git fetch --no-tags origin "$base" >/dev/null 2>&1 || true
+          # Use the true common ancestor, not the base-branch tip — the tip
+          # can move after PR creation and produce false positives.
+          merge_base=$(git merge-base "$base" "$head")
+          changed=$(git diff --name-only "$merge_base" "$head")
+          echo "Merge base: $merge_base"
+          echo "Changed files in this PR:"
+          echo "$changed"
+          if echo "$changed" | grep -qE '^(skills|src/research_hub/skills_data)/'; then
+            echo "Skill content changed — a plugin version bump is required."
+            # Compare the version VALUE before/after — robust to reformatting
+            # (a diff-line grep would false-PASS when the line moves unchanged).
+            read_ver() {
+              git show "$1:.claude-plugin/plugin.json" 2>/dev/null \
+                | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',''))" 2>/dev/null \
+                || echo ''
+            }
+            base_ver=$(read_ver "$merge_base")
+            head_ver=$(read_ver "$head")
+            echo "plugin.json version: base='$base_ver' head='$head_ver'"
+            if [ -z "$head_ver" ]; then
+              echo "::error::Could not read \"version\" from .claude-plugin/plugin.json on the PR head."
+              exit 1
+            fi
+            if [ "$base_ver" = "$head_ver" ]; then
+              echo "::error::This PR changes skill content (skills/ or src/research_hub/skills_data/) but .claude-plugin/plugin.json version is unchanged ('$head_ver'). The marketplace plugin cache is keyed on the version string — an un-bumped change never reaches user installs. Bump the version (see Phase 8.1 / dogfood V1b). Even a non-functional edit needs a bump so the cache invalidates cleanly."
+              exit 1
+            fi
+            echo "OK — skill-content change is paired with a plugin version bump ('$base_ver' -> '$head_ver')."
+          else
+            echo "No skill-content change in this PR — guard not applicable."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ graph rebuild (link out to the real tools instead)._
   (`paper summarize --pending --cluster <slug>`).
 
 ### Added
+- **CI `skill-version-guard` job** (`.github/workflows/ci.yml`). Blocks
+  a PR that changes skill content (`skills/` or
+  `src/research_hub/skills_data/`) without also bumping
+  `.claude-plugin/plugin.json` `version`. The marketplace plugin cache
+  directory is keyed on the version string, so an un-bumped
+  skill-content change ships to `master` but never reaches user
+  installs. A 2026-05-21 dogfood verification (finding V1b) caught
+  exactly this — a SKILL.md change merged without a version bump and
+  silently failed to propagate. This guard makes that class of bug a
+  hard CI failure at PR time.
 - **`--peer-reviewed` flag on `search` and `auto`.** Drops preprint
   backends (arXiv/bioRxiv/chemRxiv/medRxiv), excludes gray doc types
   (preprint/posted-content/report/book-chapter/paratext/dataset), and


### PR DESCRIPTION
## Summary

Adds a `skill-version-guard` CI job to `.github/workflows/ci.yml` that prevents a recurring bug class found by a 2026-05-21 dogfood verification (finding **V1b**).

**The bug:** a SKILL.md change merged to `master` without bumping `.claude-plugin/plugin.json` `version`, and silently failed to reach user installs — the marketplace plugin cache directory is keyed on the version string. CI was green throughout; only a behavioral verification pass caught it. This happened twice (research-hub Wave 1 got it right; academic-writing-skills Wave 2 forgot, → Phase 8.1 fix).

**The guard:** if a PR touches `skills/` or `src/research_hub/skills_data/`, `.claude-plugin/plugin.json` `version` MUST change — else the PR fails CI.

## Guard logic (code-reviewer-hardened)

- Diffs against `git merge-base base head` (true common ancestor) — **not** the base-branch tip, which can move after PR creation and cause false positives.
- Compares the `version` *value* read from `plugin.json` at merge-base vs head (`git show` + JSON parse) — robust to reformatting. A diff-line grep would false-PASS when the version line moves unchanged.
- Empty head version → hard error. Missing `plugin.json` at base (new-file case) → tolerated.
- Runs only on `pull_request`; self-skips when no skill content changed.

## Files

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | new `skill-version-guard` job (+52) |
| `CHANGELOG.md` | `### Added` entry under `[Unreleased]` |

## Test plan

- [x] `ci.yml` valid YAML
- [x] Self-application traced: this PR touches `.github/` + `CHANGELOG.md`, not `skills/` → guard correctly self-skips
- [ ] CI green (the new job will run on this PR and print "guard not applicable")

## Review discipline

Trigger #5 (CI governance change — gates all future PRs). `code-reviewer` subagent — initial REQUEST CHANGES on W1 (merge-base vs base.sha) + W2 (JSON-value compare vs diff-grep); both fixed; re-review APPROVE.

## Provenance

Closes the systemic-prevention recommendation from the Phase 9 verification report (`~/.claude/audits/dogfood_runs/2026-05-20-llm-cognitive-biases/report.md`). Will be folded into the research-hub v1.1.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)