### PR TITLE
feat(summarize): 4 quality improvements — link cap, remove cascade, relevance prompt, crystal first_finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,22 @@ graph rebuild (link out to the real tools instead)._
   (`paper summarize --pending --cluster <slug>`).
 
 ### Added
+- **Summary quality improvements** (4 changes):
+  - `link_updater.find_related_in_cluster` capped at **10 results** (was
+    unbounded) — prevents mega-hub nodes in the Obsidian graph for large
+    clusters.
+  - `remove_paper_links(slug, raw_dir, cluster)` — new function scrubs a
+    deleted paper's slug from every sibling note's Related Papers section;
+    removes the entire section header when the deleted slug was the last
+    entry.
+  - `remove_paper()` now cascades the cleanup automatically and returns
+    `links_cleaned` in its result dict.  `dry_run=True` is respected.
+  - `paper_summarize` RELEVANCE prompt updated to require a **specific
+    dimension** (method / empirical context / finding) rather than
+    accepting a generic "this paper is relevant to [cluster]" sentence.
+  - `crystal emit` prompt now exposes a `first_finding` field per paper
+    (first Key Findings bullet, callout-format aware) to give the LLM
+    more signal per paper.
 - **`docs/literature-review-deliverable.md` — format specification.**
   Defines the consolidated document the skill pipeline (`search` →
   `literature-triage-matrix` → `research-design-helper`) produces end

--- a/src/research_hub/crystal.py
+++ b/src/research_hub/crystal.py
@@ -206,6 +206,7 @@ def emit_crystal_prompt(cfg, cluster_slug: str, *, question_slugs: list[str] | N
             f"- year: {paper['year'] or '????'}",
             f"- doi: {paper['doi'] or '(none)'}",
             f"- one_liner: {paper['one_liner'] or '(no one-line summary)'}",
+            f"- first_finding: {paper['first_finding'] or '(none)'}",
             "",
         ])
     lines.extend([f"## Canonical questions to answer ({len(questions)} total)", ""])
@@ -342,6 +343,7 @@ def _read_cluster_papers(cfg, cluster_slug: str) -> list[dict[str, str]]:
             "year": str(fm.get("year", "") or ""),
             "doi": str(fm.get("doi", "") or ""),
             "one_liner": _extract_one_liner(text),
+            "first_finding": _extract_first_finding(text),
         })
     papers.sort(key=lambda item: item["slug"])
     return papers
@@ -366,6 +368,34 @@ def _extract_one_liner(text: str) -> str:
             normalized = re.sub(r"\s+", " ", match.group(1).strip())
             if normalized:
                 return re.split(r"(?<=[.!?])\s+", normalized, maxsplit=1)[0][:200]
+    return ""
+
+
+def _extract_first_finding(text: str) -> str:
+    """Return the first Key Findings bullet (≤200 chars), or '' if absent.
+
+    Handles both plain-markdown bullets and Obsidian callout format
+    (``> [!success]\\n> - bullet``), which is what vault notes produced
+    by ``apply_parsed_summary_to_note`` actually contain.
+    """
+    from research_hub.markdown_conventions import unwrap_callout
+
+    body = _strip_frontmatter(text)
+    match = re.search(
+        r"^##\s+Key\s+Findings\s*\n(.*?)(?=^##\s|\Z)",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not match:
+        return ""
+    # Strip Obsidian callout wrapper (``> [!kind]`` header + ``> `` prefixes)
+    # before iterating bullets so real vault notes work correctly.
+    section_body = unwrap_callout(match.group(1))
+    for line in section_body.splitlines():
+        line = re.sub(r"^\d+\.\s*", "", line.strip().lstrip("-*•").strip())
+        # Skip bare callout header lines that survive unwrap (e.g. "[!success]")
+        if line and not line.startswith("[!"):
+            return line[:200]
     return ""
 
 

--- a/src/research_hub/operations.py
+++ b/src/research_hub/operations.py
@@ -94,8 +94,11 @@ def _read_title(md_path: Path) -> str:
 
 def remove_paper(identifier: str, include_zotero: bool = False, dry_run: bool = False) -> dict:
     """Remove one or more notes resolved by DOI or slug."""
+    from research_hub.vault.link_updater import remove_paper_links
+
     removed_files: list[str] = []
     zotero_deleted = False
+    links_cleaned: int = 0
     for md_path in _find_note_paths(identifier):
         if include_zotero:
             zotero_key = _frontmatter_value(md_path, "zotero-key")
@@ -107,14 +110,21 @@ def remove_paper(identifier: str, include_zotero: bool = False, dry_run: bool = 
                     zotero_deleted = True
                 except Exception:
                     pass
+        slug = md_path.stem
+        cluster_slug = _frontmatter_value(md_path, "topic_cluster")
         removed_files.append(str(md_path))
         if not dry_run and md_path.exists():
             md_path.unlink()
+            # Cascade: scrub backward wikilinks in sibling notes.
+            # Vault layout: raw/<cluster>/<note>.md → parent.parent = cfg.raw
+            if cluster_slug:
+                links_cleaned += remove_paper_links(slug, md_path.parent.parent, cluster_slug)
     if removed_files and not dry_run:
         _save_index_without_paths([Path(path) for path in removed_files])
     return {
         "removed_files": removed_files,
         "zotero_deleted": zotero_deleted,
+        "links_cleaned": links_cleaned,
         "dry_run": dry_run,
     }
 

--- a/src/research_hub/paper_summarize.py
+++ b/src/research_hub/paper_summarize.py
@@ -44,7 +44,10 @@ Output exactly four sections in markdown:
 1. SUMMARY: 1-2 sentences using the paper's own terminology.
 2. KEY_FINDINGS: 3-5 bullets, each starting with a concrete claim.
 3. METHODOLOGY: 1 paragraph (study type, dataset, sample, primary metric).
-4. RELEVANCE: 1 sentence connecting to "{topic_cluster}".
+4. RELEVANCE: 1 sentence naming the SPECIFIC dimension this paper contributes
+   to "{topic_cluster}" — e.g. a new method, an empirical context, a finding
+   that confirms or challenges prior work.  Do NOT write a generic
+   "This paper is relevant to [cluster]" sentence.
 
 If abstract is <100 chars or says "(no abstract)", output
 `[no-abstract-fallback]` for all four sections. Do NOT hallucinate

--- a/src/research_hub/vault/link_updater.py
+++ b/src/research_hub/vault/link_updater.py
@@ -64,13 +64,16 @@ def find_related_in_cluster(
     all_notes: list[NoteMeta],
     min_tag_overlap: int = 1,
 ) -> list[NoteMeta]:
-    """Find same-cluster notes ordered by descending tag overlap.
+    """Find same-cluster notes ordered by descending tag overlap (at most 10).
 
     When ``new_note`` has a ``topic_cluster`` set, cluster membership
     alone is sufficient — notes in the same cluster are included even
     when tag overlap is zero. Tag overlap only affects ranking so the
     most topically-similar papers appear first. When ``new_note`` has
     no cluster, fall back to the tag-overlap threshold.
+
+    The result is capped at 10 entries to prevent mega-hub nodes in the
+    Obsidian graph view when a cluster grows large.
     """
     related: list[tuple[int, NoteMeta]] = []
     new_tag_set = set(new_note.tags)
@@ -88,7 +91,7 @@ def find_related_in_cluster(
             if overlap >= min_tag_overlap:
                 related.append((overlap, other))
     related.sort(key=lambda item: (-item[0], item[1].slug))
-    return [item[1] for item in related]
+    return [item[1] for item in related][:10]
 
 
 def add_wikilinks_to_note(
@@ -168,3 +171,42 @@ def update_cluster_links(
                 backward += 1
 
     return {"forward": forward, "backward": backward, "scanned": len(all_notes)}
+
+
+def remove_paper_links(
+    removed_slug: str,
+    vault_raw_dir: Path,
+    cluster_slug: str,
+) -> int:
+    """Scrub *removed_slug* from every Related Papers section in *cluster_slug*.
+
+    Called after a note is deleted so sibling notes don't accumulate phantom
+    wikilinks.  Returns the number of notes that were actually modified.
+    """
+    modified = 0
+    # Build existing_stems once so add_wikilinks_to_note's v0.84.0 safety net
+    # can filter out any slugs that no longer exist on disk.
+    existing_stems = {p.stem for p in vault_raw_dir.rglob("*.md")}
+    for md_path in vault_raw_dir.rglob("*.md"):
+        meta = parse_frontmatter(md_path)
+        if meta is None or meta.topic_cluster != cluster_slug:
+            continue
+        text = md_path.read_text(encoding="utf-8", errors="ignore")
+        match = SECTION_PATTERN.search(text)
+        if not match:
+            continue
+        existing_slugs = re.findall(r"\[\[([^\]]+)\]\]", match.group(2))
+        if removed_slug not in existing_slugs:
+            continue
+        new_slugs = [slug for slug in existing_slugs if slug != removed_slug]
+        if not new_slugs:
+            # Last entry removed — delete the entire Related section so we
+            # don't leave an empty "## Related Papers in This Cluster" header.
+            text = md_path.read_text(encoding="utf-8", errors="ignore")
+            new_text = SECTION_PATTERN.sub(lambda m: m.group(3), text, count=1)
+            if new_text != text:
+                md_path.write_text(new_text, encoding="utf-8")
+                modified += 1
+        elif add_wikilinks_to_note(md_path, new_slugs, existing_stems):
+            modified += 1
+    return modified

--- a/tests/test_crystal.py
+++ b/tests/test_crystal.py
@@ -333,3 +333,67 @@ def test_mcp_emit_and_check_crystals(tmp_path, monkeypatch):
     _get_mcp_tool(mcp, "apply_crystals").fn("test", _make_fake_crystals_json(["what-is-this-field"]))
     checked = _get_mcp_tool(mcp, "check_crystal_staleness").fn("test")
     assert "what-is-this-field" in emitted["prompt"] and checked["crystals"]["what-is-this-field"]["stale"] is False
+
+
+# ---------------------------------------------------------------------------
+# _extract_first_finding + crystal prompt first_finding field (v1.1.0)
+# ---------------------------------------------------------------------------
+
+from research_hub.crystal import _extract_first_finding  # noqa: E402
+
+
+def test_extract_first_finding_returns_first_bullet():
+    """Plain-markdown bullet format (no callout wrapper)."""
+    text = (
+        "---\ntitle: \"P\"\n---\n"
+        "## Key Findings\n"
+        "- Finding A is the key result.\n"
+        "- Finding B is secondary.\n"
+    )
+    assert _extract_first_finding(text) == "Finding A is the key result."
+
+
+def test_extract_first_finding_handles_callout_format():
+    """Obsidian callout format — the actual output of apply_parsed_summary_to_note."""
+    text = (
+        "---\ntitle: \"P\"\n---\n"
+        "## Key Findings\n"
+        "> [!success]\n"
+        "> - Finding A is the key result.\n"
+        "> - Finding B is secondary.\n"
+        "^findings\n"
+    )
+    assert _extract_first_finding(text) == "Finding A is the key result."
+
+
+def test_extract_first_finding_returns_empty_when_no_section():
+    text = "---\ntitle: \"P\"\n---\n## Summary\nSome text.\n"
+    assert _extract_first_finding(text) == ""
+
+
+def test_extract_first_finding_truncates_at_200_chars():
+    long_line = "X" * 250
+    text = f"---\ntitle: \"P\"\n---\n## Key Findings\n- {long_line}\n"
+    result = _extract_first_finding(text)
+    assert len(result) <= 200
+
+
+def test_crystal_prompt_includes_first_finding_field(tmp_path):
+    """emit_crystal_prompt must expose first_finding for each paper (callout format)."""
+    cfg = _make_cluster_with_papers(
+        tmp_path,
+        "test",
+        [("paper-a", "Paper A", "one line")],
+    )
+    # Use the callout format that vault ingest actually writes.
+    note = cfg.raw / "test" / "paper-a.md"
+    note.write_text(
+        note.read_text(encoding="utf-8")
+        + "\n## Key Findings\n> [!success]\n> - First finding here.\n^findings\n",
+        encoding="utf-8",
+    )
+    from research_hub.crystal import emit_crystal_prompt
+
+    prompt = emit_crystal_prompt(cfg, "test")
+    assert "first_finding" in prompt
+    assert "First finding here." in prompt

--- a/tests/test_link_updater.py
+++ b/tests/test_link_updater.py
@@ -7,6 +7,7 @@ from research_hub.vault.link_updater import (
     add_wikilinks_to_note,
     find_related_in_cluster,
     parse_frontmatter,
+    remove_paper_links,
 )
 
 
@@ -117,3 +118,107 @@ def test_add_wikilinks_without_existing_stems_writes_all(tmp_path):
     content = note.read_text(encoding="utf-8")
     assert "[[slug-a]]" in content
     assert "[[slug-b]]" in content
+
+
+# ---------------------------------------------------------------------------
+# top-10 cap (v1.1.0 quality improvement)
+# ---------------------------------------------------------------------------
+
+def test_find_related_caps_at_ten_results():
+    """find_related_in_cluster returns at most 10 notes even for large clusters."""
+    new_note = NoteMeta(Path("new.md"), "New", ["llm"], "cluster-a")
+    # Build 15 sibling notes all in the same cluster.
+    siblings = [
+        NoteMeta(Path(f"p{i}.md"), f"Paper {i}", ["llm"], "cluster-a")
+        for i in range(15)
+    ]
+
+    related = find_related_in_cluster(new_note, siblings)
+
+    assert len(related) <= 10
+
+
+# ---------------------------------------------------------------------------
+# remove_paper_links (v1.1.0)
+# ---------------------------------------------------------------------------
+
+def _make_cluster_note(path: Path, cluster: str, related_slugs: list[str]) -> None:
+    """Write a minimal vault note with a Related Papers section."""
+    links = "\n".join(f"- [[{slug}]]" for slug in related_slugs)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f'---\ntitle: "{path.stem}"\ntopic_cluster: "{cluster}"\n---\n\n'
+        f"## Related Papers in This Cluster\n{links}\n",
+        encoding="utf-8",
+    )
+
+
+def test_remove_paper_links_scrubs_slug_from_siblings(tmp_path):
+    """remove_paper_links must remove the target slug from sibling Related sections."""
+    raw = tmp_path / "raw"
+    (raw / "cluster-a").mkdir(parents=True)
+    _make_cluster_note(raw / "cluster-a" / "paper-a.md", "cluster-a", ["paper-b", "paper-c"])
+    _make_cluster_note(raw / "cluster-a" / "paper-c.md", "cluster-a", ["paper-b"])
+
+    modified = remove_paper_links("paper-b", raw, "cluster-a")
+
+    assert modified == 2
+    for note_path in [raw / "cluster-a" / "paper-a.md", raw / "cluster-a" / "paper-c.md"]:
+        text = note_path.read_text(encoding="utf-8")
+        assert "[[paper-b]]" not in text
+
+
+def test_remove_paper_links_leaves_other_slugs_intact(tmp_path):
+    """Only the removed slug is scrubbed; other wikilinks must survive.
+
+    paper-c.md must exist on disk so the v0.84.0 existing_stems safety
+    net does not filter it out as a broken wikilink.
+    """
+    raw = tmp_path / "raw"
+    (raw / "cluster-a").mkdir(parents=True)
+    _make_cluster_note(raw / "cluster-a" / "paper-a.md", "cluster-a", ["paper-b", "paper-c"])
+    # Create the sibling note so its slug survives the existing_stems filter.
+    _make_cluster_note(raw / "cluster-a" / "paper-c.md", "cluster-a", [])
+
+    remove_paper_links("paper-b", raw, "cluster-a")
+
+    text = (raw / "cluster-a" / "paper-a.md").read_text(encoding="utf-8")
+    assert "[[paper-c]]" in text
+
+
+def test_remove_paper_links_ignores_other_clusters(tmp_path):
+    """Notes in a different cluster must not be modified."""
+    raw = tmp_path / "raw"
+    (raw / "cluster-a").mkdir(parents=True)
+    (raw / "cluster-b").mkdir(parents=True)
+    _make_cluster_note(raw / "cluster-a" / "paper-a.md", "cluster-a", ["paper-b"])
+    _make_cluster_note(raw / "cluster-b" / "paper-x.md", "cluster-b", ["paper-b"])
+
+    modified = remove_paper_links("paper-b", raw, "cluster-a")
+
+    assert modified == 1
+    # cluster-b note untouched
+    assert "[[paper-b]]" in (raw / "cluster-b" / "paper-x.md").read_text(encoding="utf-8")
+
+
+def test_remove_paper_links_returns_zero_when_slug_absent(tmp_path):
+    """Returns 0 when no notes reference the given slug."""
+    raw = tmp_path / "raw"
+    (raw / "cluster-a").mkdir(parents=True)
+    _make_cluster_note(raw / "cluster-a" / "paper-a.md", "cluster-a", ["paper-c"])
+
+    modified = remove_paper_links("nonexistent-slug", raw, "cluster-a")
+
+    assert modified == 0
+
+
+def test_remove_paper_links_removes_entire_section_when_last_slug(tmp_path):
+    """When the removed slug was the only entry, the whole Related section is deleted."""
+    raw = tmp_path / "raw"
+    (raw / "cluster-a").mkdir(parents=True)
+    _make_cluster_note(raw / "cluster-a" / "paper-a.md", "cluster-a", ["paper-b"])
+
+    remove_paper_links("paper-b", raw, "cluster-a")
+
+    text = (raw / "cluster-a" / "paper-a.md").read_text(encoding="utf-8")
+    assert "## Related Papers in This Cluster" not in text

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -299,3 +299,85 @@ def test_cluster_split_keeps_non_matching_notes(tmp_path, monkeypatch):
 
     assert result["moved"] == 0
     assert result["remaining"] == 1
+
+
+# ---------------------------------------------------------------------------
+# remove_paper backward link cascade (v1.1.0)
+# ---------------------------------------------------------------------------
+
+def _write_note_with_links(path: Path, *, cluster: str, related: list[str]) -> None:
+    """Write a note that already has a Related Papers section."""
+    links = "\n".join(f"- [[{slug}]]" for slug in related)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\n"
+        f'title: "{path.stem}"\n'
+        f'topic_cluster: "{cluster}"\n'
+        "---\n\n"
+        f"## Related Papers in This Cluster\n{links}\n",
+        encoding="utf-8",
+    )
+
+
+def test_remove_paper_cleans_backward_wikilinks(tmp_path, monkeypatch):
+    """After remove_paper, the removed slug disappears from sibling Related sections."""
+    cfg = _make_config(tmp_path, monkeypatch)
+    # Paper being removed
+    _write_note(cfg.raw / "cluster-a" / "paper-x.md", title="Paper X", cluster="cluster-a")
+    # Sibling notes that reference it
+    _write_note_with_links(
+        cfg.raw / "cluster-a" / "paper-y.md",
+        cluster="cluster-a",
+        related=["paper-x", "paper-z"],
+    )
+    _write_note_with_links(
+        cfg.raw / "cluster-a" / "paper-z.md",
+        cluster="cluster-a",
+        related=["paper-x"],
+    )
+
+    result = remove_paper("paper-x")
+
+    assert result["links_cleaned"] == 2
+    assert "[[paper-x]]" not in (cfg.raw / "cluster-a" / "paper-y.md").read_text(encoding="utf-8")
+    assert "[[paper-x]]" not in (cfg.raw / "cluster-a" / "paper-z.md").read_text(encoding="utf-8")
+
+
+def test_remove_paper_preserves_other_links_in_siblings(tmp_path, monkeypatch):
+    """Only the removed slug is scrubbed; unrelated wikilinks must survive.
+
+    paper-z.md must exist so the v0.84.0 existing_stems safety net
+    keeps it in the Related section after paper-x is removed.
+    """
+    cfg = _make_config(tmp_path, monkeypatch)
+    _write_note(cfg.raw / "cluster-a" / "paper-x.md", title="Paper X", cluster="cluster-a")
+    _write_note_with_links(
+        cfg.raw / "cluster-a" / "paper-y.md",
+        cluster="cluster-a",
+        related=["paper-x", "paper-z"],
+    )
+    # Create paper-z so its slug survives the existing_stems filter.
+    _write_note(cfg.raw / "cluster-a" / "paper-z.md", title="Paper Z", cluster="cluster-a")
+
+    remove_paper("paper-x")
+
+    text = (cfg.raw / "cluster-a" / "paper-y.md").read_text(encoding="utf-8")
+    assert "[[paper-z]]" in text
+
+
+def test_remove_paper_dry_run_does_not_clean_links(tmp_path, monkeypatch):
+    """With dry_run=True nothing is written."""
+    cfg = _make_config(tmp_path, monkeypatch)
+    _write_note(cfg.raw / "cluster-a" / "paper-x.md", title="Paper X", cluster="cluster-a")
+    _write_note_with_links(
+        cfg.raw / "cluster-a" / "paper-y.md",
+        cluster="cluster-a",
+        related=["paper-x"],
+    )
+
+    result = remove_paper("paper-x", dry_run=True)
+
+    # dry_run: file not deleted, links not cleaned
+    assert (cfg.raw / "cluster-a" / "paper-x.md").exists()
+    assert result["links_cleaned"] == 0
+    assert "[[paper-x]]" in (cfg.raw / "cluster-a" / "paper-y.md").read_text(encoding="utf-8")

--- a/tests/test_v0872_summarize_worker.py
+++ b/tests/test_v0872_summarize_worker.py
@@ -250,3 +250,15 @@ def test_apply_parsed_summary_adds_summary_before_abstract(tmp_path: Path) -> No
     )
 
     assert updated.index("## Summary") < updated.index("## Abstract")
+
+
+# ---------------------------------------------------------------------------
+# RELEVANCE prompt anti-generic guard (v1.1.0)
+# ---------------------------------------------------------------------------
+
+def test_prompt_template_relevance_anti_generic():
+    """RELEVANCE instruction must forbid the generic 'This paper is relevant to...' form."""
+    from research_hub.paper_summarize import PROMPT_TEMPLATE
+
+    assert "Do NOT write" in PROMPT_TEMPLATE
+    assert "SPECIFIC dimension" in PROMPT_TEMPLATE


### PR DESCRIPTION
## Summary

- **Link cap**: `find_related_in_cluster` capped at 10 results — prevents mega-hub nodes in the Obsidian graph for large clusters (was unbounded)
- **Remove cascade**: `remove_paper_links()` scrubs a deleted paper's slug from all sibling Related Papers sections; removes the section header entirely when the last slug is gone. Hooked into `remove_paper()` automatically; `dry_run` respected; returns `links_cleaned` count
- **RELEVANCE prompt**: requires a specific dimension (method / empirical context / finding that confirms or challenges prior work); bans the generic "This paper is relevant to [cluster]" fallback
- **Crystal `first_finding`**: new `_extract_first_finding()` extracts the first Key Findings bullet (callout-format aware, ≤200 chars); surfaced as `first_finding` field per paper in `emit_crystal_prompt`

## Implementation notes

- `remove_paper_links` passes `existing_stems` to preserve the v0.84.0 phantom-wikilink safety net — critical fix caught in code review (plain call without it would re-introduce broken wikilinks)
- `_extract_first_finding` handles Obsidian callout format which is the actual output of `apply_parsed_summary_to_note` — plain-markdown-only would have returned `"> [!success]"` for every real vault note (also caught in code review)

## Test plan

- [ ] 6 new `test_link_updater` cases: top-10 cap, scrub, preserve others, cross-cluster isolation, absent slug, last-slug section deletion
- [ ] 3 new `test_operations` cases: cascade cleanup, preserve other links, dry-run no-op
- [ ] 5 new `test_crystal` cases: plain-markdown bullet, callout format, no section, truncation, prompt field
- [ ] 1 new `test_v0872_summarize_worker` case: RELEVANCE anti-generic guard
- Full suite: **2935 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)