### PR TITLE
feat(auto): NLM session pre-flight check — graceful skip + HINT on expired session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ graph rebuild (link out to the real tools instead)._
   (`paper summarize --pending --cluster <slug>`).
 
 ### Added
+- **NLM session pre-flight in `auto_pipeline`.**  Before attempting any
+  NotebookLM browser work, `auto_pipeline` now calls `check_session_health`
+  on the stored `state.json`.  When the session is missing or expired the
+  pipeline skips NLM gracefully, sets `nlm_deferred=True`, and prints a
+  `[HINT]` pointing at `research-hub notebooklm login` — instead of running
+  a full headless browser session that would crash with an opaque Playwright
+  error.  The `_print_next_steps` footer now distinguishes
+  *"session expired → login first"* from *"transient error → retry"*.
+  Health-check errors are caught so existing behaviour is preserved when
+  the auth module is unavailable.
 - **Summary quality improvements** (4 changes):
   - `link_updater.find_related_in_cluster` capped at **10 results** (was
     unbounded) — prevents mega-hub nodes in the Obsidian graph for large

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -413,8 +413,45 @@ def auto_pipeline(
             _print_next_steps(report, slug, cfg, do_crystals=do_crystals)
         return report
 
-    # 6, 7, 8, 9 ??NotebookLM
+    # 6, 7, 8, 9 — NotebookLM
     cluster = registry.get(slug)  # refresh
+
+    # Pre-flight: check NLM session health before attempting any browser work.
+    # A stale / missing state.json produces an opaque browser error deep inside
+    # upload_cluster; catching it here lets us print a clear HINT and skip
+    # gracefully instead.
+    try:
+        from research_hub.notebooklm.auth import check_session_health, default_state_file
+        _state_file = default_state_file(cfg.research_hub_dir)
+        _health = check_session_health(_state_file)
+        if not _health.get("ok"):
+            from research_hub._invocation import recommended_cli_invocation
+            _inv = recommended_cli_invocation()
+            _reason = _health.get("reason", "unknown")
+            report.nlm_deferred = True
+            report.ok = True
+            report.nlm_error = f"nlm.preflight: session not valid ({_reason})"
+            _step_log(report, "nlm.preflight", False, _elapsed(started, report),
+                      f"session not valid — run: {_inv} notebooklm login", print_progress)
+            if print_progress:
+                print(f"  [HINT] NLM session is not valid ({_reason}).")
+                print(f"         Run:  {_inv} notebooklm login")
+                print(f"         Then re-run auto to upload to NotebookLM.")
+            if do_crystals:
+                _run_crystal_step(cfg, slug, effective_cli, report, started, print_progress)
+            report.total_duration_sec = time.time() - started
+            if print_progress:
+                _print_next_steps(report, slug, cfg, do_crystals=do_crystals)
+            return report
+    except ImportError:
+        # Auth module not installed; fall through to normal NLM steps.
+        pass
+    except Exception as exc:
+        # Health check failed at runtime (e.g. file lock, event-loop conflict).
+        # Log and fall through so the normal NLM path handles it.
+        if print_progress:
+            print(f"  [NLM] preflight check failed ({type(exc).__name__}); proceeding.")
+
     nlm_step = "nlm"
     try:
         nlm_step = "nlm.bundle"
@@ -743,7 +780,12 @@ def _print_next_steps(report: AutoReport, slug: str, cfg, *, do_crystals: bool) 
     if report.nlm_deferred:
         from research_hub._invocation import recommended_cli_invocation
         inv = recommended_cli_invocation()
-        print(f"  [NLM] skipped (check: {inv} notebooklm login). Resume with:")
+        is_auth_error = (report.nlm_error or "").startswith("nlm.preflight:")
+        if is_auth_error:
+            print(f"  [NLM] skipped — session expired. Fix:")
+            print(f"    {inv} notebooklm login")
+        else:
+            print(f"  [NLM] skipped (check: {inv} notebooklm login). Resume with:")
         print(f"    {inv} notebooklm bundle   --cluster {slug}")
         print(f"    {inv} notebooklm upload   --cluster {slug}")
         print(f"    {inv} notebooklm generate --cluster {slug} --type brief")

--- a/tests/test_v046_auto.py
+++ b/tests/test_v046_auto.py
@@ -20,7 +20,8 @@ def mock_deps():
          patch("research_hub.vault.hub_overview.populate_all_overviews"), \
          patch("research_hub.auto._run_search") as mock_run_search, \
          patch("research_hub.auto._run_fit_check_step", side_effect=lambda cfg, papers, *a, **k: papers), \
-         patch("research_hub.auto.detect_llm_cli", return_value="claude"):
+         patch("research_hub.auto.detect_llm_cli", return_value="claude"), \
+         patch("research_hub.notebooklm.auth.check_session_health", return_value={"ok": True}):
         # NOTE: a judge IS present here on purpose. These tests verify
         # auto_pipeline orchestration (search/ingest/NLM wiring) with
         # _run_fit_check_step mocked to a pass-through — they are NOT
@@ -203,6 +204,7 @@ def test_auto_nlm_failure_does_not_abort_pipeline(mock_deps, capsys):
     assert report.nlm_error == "nlm.upload: login expired"
     mock_crystals.assert_called_once()
     assert "[NLM] skipped (check: research-hub notebooklm login). Resume with:" in out
+    assert "session expired. Fix:" not in out  # must not be misclassified as auth error
     assert "research-hub notebooklm bundle   --cluster nlm-deferred-topic" in out
     assert "research-hub notebooklm upload   --cluster nlm-deferred-topic" in out
     assert "research-hub notebooklm generate --cluster nlm-deferred-topic --type brief" in out

--- a/tests/test_v1_nlm_preflight.py
+++ b/tests/test_v1_nlm_preflight.py
@@ -1,0 +1,232 @@
+"""Tests for NLM session pre-flight check in auto_pipeline (v1.1.0).
+
+When check_session_health returns ok=False, auto_pipeline must:
+  - set nlm_deferred=True with a "preflight" error string
+  - return ok=True (pipeline itself succeeded; NLM is skipped gracefully)
+  - NOT attempt bundle/upload/generate/download
+  - print a [HINT] pointing at `notebooklm login`
+
+When check_session_health returns ok=True, the preflight passes and the
+normal NLM steps run (or raise, which is caught and deferred as before).
+
+When the health check itself raises (e.g. import error), auto_pipeline
+must fall through to the normal NLM steps (backward compatibility).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import json
+
+import pytest
+
+import research_hub.auto as auto_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _paper_input(title: str, slug: str, doi: str) -> dict:
+    return {
+        "title": title,
+        "authors": ["Author A"],
+        "year": 2025,
+        "doi": doi,
+        "abstract": "Abstract text.",
+        "source": "test",
+        "slug": slug,
+        "score": 0.9,
+    }
+
+
+def _setup_auto_pipeline(tmp_path: Path, monkeypatch, *, papers: int = 1):
+    """Wire a minimal auto_pipeline that skips real network + file writes."""
+    import research_hub.config as cfg_mod
+
+    root = tmp_path / "vault"
+    raw = root / "raw"
+    hub = root / "hub"
+    logs = root / "logs"
+    research_hub_dir = root / ".research_hub"
+    for p in (raw, hub, logs, research_hub_dir):
+        p.mkdir(parents=True, exist_ok=True)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({
+            "knowledge_base": {
+                "root": str(root),
+                "raw": str(raw),
+                "hub": str(hub),
+                "logs": str(logs),
+            },
+            "clusters_file": str(research_hub_dir / "clusters.yaml"),
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("RESEARCH_HUB_CONFIG", str(config_path))
+    monkeypatch.setenv("RESEARCH_HUB_ROOT", str(root))
+    cfg_mod._config = None
+    cfg_mod._config_path = None
+    cfg = cfg_mod.get_config()
+    (cfg.research_hub_dir / "dedup_index.json").write_text("{}", encoding="utf-8")
+
+    fake_papers = [_paper_input(f"Paper {i}", f"paper-{i}", f"10.0/{i}") for i in range(papers)]
+
+    monkeypatch.setattr(auto_mod, "_ensure_zotero_collection", lambda *a, **k: None)
+    monkeypatch.setattr(auto_mod, "_run_search", lambda *a, **k: fake_papers)
+    # run_pipeline must return integer exit code 0 for success.
+    monkeypatch.setattr(auto_mod, "run_pipeline", lambda *a, **k: 0)
+    # stub populate_all_overviews so vault state is irrelevant
+    monkeypatch.setattr(
+        "research_hub.vault.hub_overview.populate_all_overviews",
+        lambda *a, **k: None,
+        raising=False,
+    )
+
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Preflight: session not valid → graceful skip + HINT
+# ---------------------------------------------------------------------------
+
+def test_nlm_preflight_skip_when_session_invalid(tmp_path, monkeypatch, capsys):
+    """auto_pipeline defers NLM and prints a HINT when session health = not ok."""
+    cfg = _setup_auto_pipeline(tmp_path, monkeypatch)
+
+    # Patch check_session_health inside auto_module's import path.
+    import research_hub.notebooklm.auth as auth_mod
+    monkeypatch.setattr(
+        auth_mod,
+        "check_session_health",
+        lambda state_file: {"ok": False, "reason": "state.json missing"},
+    )
+
+    bundle_called = []
+    monkeypatch.setattr(
+        "research_hub.notebooklm.bundle.bundle_cluster",
+        lambda *a, **k: bundle_called.append(1) or type("R", (), {"pdf_count": 0})(),
+    )
+
+    report = auto_mod.auto_pipeline(
+        "test query",
+        do_nlm=True,
+        do_fit_check=False,
+        do_cluster_overview=False,
+        print_progress=True,
+    )
+
+    assert report.ok is True
+    assert report.nlm_deferred is True
+    assert "preflight" in report.nlm_error
+    assert not bundle_called, "bundle_cluster must NOT be called when session is invalid"
+
+    out = capsys.readouterr().out
+    assert "HINT" in out
+    assert "notebooklm login" in out
+    assert "session expired. Fix:" in out
+    assert "Resume with:" not in out
+
+
+def test_nlm_preflight_does_not_skip_when_session_valid(tmp_path, monkeypatch):
+    """When session is healthy, preflight passes and the normal NLM steps run."""
+    cfg = _setup_auto_pipeline(tmp_path, monkeypatch)
+
+    import research_hub.notebooklm.auth as auth_mod
+    monkeypatch.setattr(
+        auth_mod,
+        "check_session_health",
+        lambda state_file: {"ok": True, "reason": "ok"},
+    )
+
+    # Stub the actual NLM steps so we don't need a real browser.
+    bundle_called = []
+
+    def fake_bundle(cluster, cfg_, **kw):
+        bundle_called.append(1)
+        return type("R", (), {"pdf_count": 0})()
+
+    monkeypatch.setattr("research_hub.notebooklm.bundle.bundle_cluster", fake_bundle)
+    monkeypatch.setattr(
+        "research_hub.notebooklm.upload.upload_cluster",
+        lambda *a, **k: type("R", (), {"success_count": 0, "notebook_url": None, "notebook_was_reused": False})(),
+    )
+    monkeypatch.setattr(
+        "research_hub.notebooklm.upload.generate_artifact",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "research_hub.notebooklm.upload.download_briefing_for_cluster",
+        lambda *a, **k: type("R", (), {"artifact_path": None, "char_count": 0})(),
+    )
+
+    report = auto_mod.auto_pipeline(
+        "test query",
+        do_nlm=True,
+        do_fit_check=False,
+        do_cluster_overview=False,
+        print_progress=False,
+    )
+
+    assert bundle_called, "bundle_cluster MUST be called when session is valid"
+    assert report.nlm_deferred is False
+    assert not report.nlm_error
+
+
+def test_nlm_preflight_fallthrough_on_health_check_error(tmp_path, monkeypatch):
+    """If check_session_health itself raises, auto_pipeline falls through to normal NLM steps."""
+    cfg = _setup_auto_pipeline(tmp_path, monkeypatch)
+
+    import research_hub.notebooklm.auth as auth_mod
+    monkeypatch.setattr(
+        auth_mod,
+        "check_session_health",
+        lambda state_file: (_ for _ in ()).throw(RuntimeError("import failure")),
+    )
+
+    bundle_called = []
+
+    def fake_bundle(cluster, cfg_, **kw):
+        bundle_called.append(1)
+        raise RuntimeError("browser not available")  # normal NLM deferred path
+
+    monkeypatch.setattr("research_hub.notebooklm.bundle.bundle_cluster", fake_bundle)
+
+    report = auto_mod.auto_pipeline(
+        "test query",
+        do_nlm=True,
+        do_fit_check=False,
+        do_cluster_overview=False,
+        print_progress=False,
+    )
+
+    assert report.ok is True
+    # The normal NLM exception path defers without "preflight" in the error.
+    assert bundle_called
+    assert "preflight" not in (report.nlm_error or "")
+
+
+def test_nlm_preflight_not_run_when_do_nlm_false(tmp_path, monkeypatch):
+    """do_nlm=False must bypass the preflight entirely."""
+    cfg = _setup_auto_pipeline(tmp_path, monkeypatch)
+
+    import research_hub.notebooklm.auth as auth_mod
+    health_called = []
+    monkeypatch.setattr(
+        auth_mod,
+        "check_session_health",
+        lambda state_file: health_called.append(1) or {"ok": False, "reason": "expired"},
+    )
+
+    report = auto_mod.auto_pipeline(
+        "test query",
+        do_nlm=False,
+        do_fit_check=False,
+        do_cluster_overview=False,
+        print_progress=False,
+    )
+
+    assert report.ok is True
+    assert not health_called, "check_session_health must NOT be called when do_nlm=False"
+    assert report.nlm_deferred is False


### PR DESCRIPTION
## Summary

- Before any NotebookLM browser work, `auto_pipeline` now calls `check_session_health()` on the stored `state.json`
- When session is missing/expired: sets `nlm_deferred=True`, prints a `[HINT]` pointing at `notebooklm login`, returns early — instead of crashing deep inside Playwright with an opaque auth error
- `_print_next_steps` now distinguishes `nlm.preflight:` auth failures from transient errors with different UX copy
- Exception handling: `ImportError` falls through silently; other runtime exceptions log a one-liner and fall through (backward compat preserved)

## Files changed

| File | What changed |
|---|---|
| `src/research_hub/auto.py` | Pre-flight block before NLM steps; `_print_next_steps` `is_auth_error` logic |
| `tests/test_v1_nlm_preflight.py` | 4 new tests (new file) |
| `tests/test_v046_auto.py` | `mock_deps` fixture: stub `check_session_health` → `{ok: True}` |
| `CHANGELOG.md` | v1.1.0 entry |

## Test plan

- [x] `pytest tests/test_v046_auto.py tests/test_v1_nlm_preflight.py` — 13/13 passed
- [x] Full suite: 2952 passed, 1 pre-existing flaky (unrelated), 0 failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)