### PR TITLE
feat(search): adversarial-recall search — search --adversarial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ graph rebuild (link out to the real tools instead)._
   *"session expired → login first"* from *"transient error → retry"*.
   Health-check errors are caught so existing behaviour is preserved when
   the auth module is unavailable.
+- **Adversarial-recall search — `research-hub search --adversarial`.**
+  A single query phrasing systematically misses papers that use other
+  vocabulary; in topic-scoping search a missed paper makes a research gap
+  look open when it is not. `--adversarial` expands the query into several
+  phrasings (LLM-generated when an LLM CLI is on PATH, deterministic
+  fallback otherwise), searches each, unions the results by `dedup_key`,
+  and prints a recall-confidence verdict (`high`/`medium`/`low`, derived
+  from query saturation) to stderr. New `search/query_expansion.py`;
+  `adversarial_search()` + `RecallReport` added to `search/fallback.py`;
+  `tests/test_search_adversarial.py` (18 cases).
 - **Summary quality improvements** (4 changes):
   - `link_updater.find_related_in_cluster` capped at **10 results** (was
     unbounded) — prevents mega-hub nodes in the Obsidian graph for large

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -2985,24 +2985,52 @@ def _search(
     emit_json: bool = False,
     to_papers_input: bool = False,
     cluster_slug: str | None = None,
+    adversarial: bool = False,
+    max_variants: int = 5,
 ) -> int:
     cfg = get_config()
     index = DedupIndex.load(cfg.research_hub_dir / "dedup_index.json")
-    from research_hub.search import search_papers as _search_papers
 
-    results = _search_papers(
-        query,
-        limit=limit,
-        year_from=year_from,
-        year_to=year_to,
-        min_citations=min_citations,
-        backends=backends,
-        exclude_types=exclude_types,
-        exclude_terms=exclude_terms,
-        min_confidence=min_confidence,
-        rank_by=rank_by,
-        backend_trace=backend_trace,
-    )
+    if adversarial:
+        from research_hub.search import adversarial_search as _adversarial_search
+
+        results, recall = _adversarial_search(
+            query,
+            limit=limit,
+            max_variants=max_variants,
+            year_from=year_from,
+            year_to=year_to,
+            min_citations=min_citations,
+            backends=backends,
+            exclude_types=exclude_types,
+            exclude_terms=exclude_terms,
+            min_confidence=min_confidence,
+            rank_by=rank_by,
+            backend_trace=backend_trace,
+        )
+        print(
+            f"[recall] {recall.queries_run} query phrasings searched -> "
+            f"{recall.total_unique} unique papers; "
+            f"confidence={recall.confidence}"
+            f"{' (saturated)' if recall.saturated else ''}",
+            file=sys.stderr,
+        )
+    else:
+        from research_hub.search import search_papers as _search_papers
+
+        results = _search_papers(
+            query,
+            limit=limit,
+            year_from=year_from,
+            year_to=year_to,
+            min_citations=min_citations,
+            backends=backends,
+            exclude_types=exclude_types,
+            exclude_terms=exclude_terms,
+            min_confidence=min_confidence,
+            rank_by=rank_by,
+            backend_trace=backend_trace,
+        )
     from research_hub.dedup import normalize_doi
 
     ingested = {normalize_doi(doi) for doi in index.doi_to_hits.keys() if doi}
@@ -5909,6 +5937,19 @@ def build_parser() -> argparse.ArgumentParser:
         default="smart",
         help="Ranking strategy. smart = 2*confidence + recency + relevance (default). citation = legacy v0.15 behavior. year = recency only.",
     )
+    search_parser.add_argument(
+        "--adversarial",
+        action="store_true",
+        help="Adversarial recall: search several LLM-generated query phrasings, "
+        "union the results, and print a recall-confidence verdict to stderr. "
+        "Trades speed for completeness — use when a missed paper is costly.",
+    )
+    search_parser.add_argument(
+        "--max-variants",
+        type=int,
+        default=5,
+        help="With --adversarial: max alternative query phrasings to search (default 5).",
+    )
     search_parser.add_argument("--json", action="store_true", help="Emit JSON array")
     search_parser.add_argument(
         "--to-papers-input",
@@ -7852,6 +7893,8 @@ def _main_dispatch(args, parser) -> int:
             emit_json=args.json,
             to_papers_input=args.to_papers_input,
             cluster_slug=args.cluster,
+            adversarial=args.adversarial,
+            max_variants=args.max_variants,
         )
     if args.command == "websearch":
         return _websearch(

--- a/src/research_hub/search/__init__.py
+++ b/src/research_hub/search/__init__.py
@@ -9,7 +9,12 @@ from research_hub.search.crossref import CrossrefBackend
 from research_hub.search.dblp import DblpBackend
 from research_hub.search.enrich import classify_candidate, enrich_candidates
 from research_hub.search.eric import EricBackend
-from research_hub.search.fallback import iter_new_results, search_papers
+from research_hub.search.fallback import (
+    RecallReport,
+    adversarial_search,
+    iter_new_results,
+    search_papers,
+)
 from research_hub.search.kci import KciBackend
 from research_hub.search.nasa_ads import NasaAdsBackend
 from research_hub.search.openalex import OpenAlexBackend
@@ -36,6 +41,8 @@ __all__ = [
     "KciBackend",
     "WebSearchBackend",
     "search_papers",
+    "adversarial_search",
+    "RecallReport",
     "iter_new_results",
     "enrich_candidates",
     "classify_candidate",

--- a/src/research_hub/search/fallback.py
+++ b/src/research_hub/search/fallback.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
+from dataclasses import dataclass
 import logging
 from collections.abc import Iterable, Sequence
 
@@ -212,6 +213,111 @@ def search_papers(
     )
     ranked = rank(filtered, rank_by=rank_by, relevance_query=query)
     return ranked[:limit]
+
+
+@dataclass
+class RecallReport:
+    """Recall-confidence summary for an adversarial (multi-query) search.
+
+    `confidence` answers: how likely is it that the union of results is the
+    near-complete set of relevant papers? It is derived from saturation —
+    whether later query phrasings stopped contributing new papers.
+    """
+
+    queries_run: int
+    variants: list[str]
+    new_per_query: list[int]  # unique papers each successive variant added
+    total_unique: int
+    saturated: bool
+    confidence: str  # "high" | "medium" | "low"
+
+
+# Recall-confidence bands: the share of total unique papers the LAST query
+# variant still contributed. A small share => the corpus is saturated.
+# Magic numbers by design — expect to recalibrate after real-world runs.
+_RECALL_HIGH_THRESHOLD = 0.05
+_RECALL_MED_THRESHOLD = 0.20
+
+
+def _recall_confidence(new_per_query: list[int]) -> tuple[str, bool]:
+    """Estimate recall confidence from the per-variant new-paper counts.
+
+    Saturation: the last variant added (almost) nothing new -> the corpus is
+    likely exhausted -> high confidence. If every variant keeps adding a
+    meaningful share, the corpus is not exhausted -> low confidence. Fewer
+    than two variants, or zero papers found at all, give no saturation
+    signal -> low confidence (zero results is "found nothing", not "thorough").
+    """
+    if len(new_per_query) < 2:
+        return "low", False
+    total = sum(new_per_query)
+    if total == 0:
+        return "low", False
+    last_share = new_per_query[-1] / total
+    if last_share <= _RECALL_HIGH_THRESHOLD:
+        return "high", True
+    if last_share <= _RECALL_MED_THRESHOLD:
+        return "medium", False
+    return "low", False
+
+
+def adversarial_search(
+    query: str,
+    *,
+    limit: int = 20,
+    max_variants: int = 5,
+    llm_cli: str | None = None,
+    per_query_limit: int | None = None,
+    **search_kwargs,
+) -> tuple[list[SearchResult], RecallReport]:
+    """Search under several query phrasings, union the results, and report
+    how confident we can be that recall is complete.
+
+    A single query phrasing systematically misses papers that use other
+    vocabulary — and a missed paper makes a research gap look open when it is
+    not. This runs `search_papers` once per expanded phrasing, unions by
+    `dedup_key`, re-ranks, and returns a `RecallReport` alongside the results.
+
+    `search_kwargs` is forwarded to `search_papers` (year_from, year_to,
+    backends, exclude_types, exclude_terms, min_confidence, min_citations,
+    rank_by, backend_trace).
+    """
+    from research_hub.search._rank import rank
+    from research_hub.search.query_expansion import expand_query
+
+    variants = expand_query(query, max_variants=max_variants, llm_cli=llm_cli)
+    if not variants:
+        return [], RecallReport(0, [], [], 0, False, "low")
+    if per_query_limit is None:
+        per_query_limit = max(limit * 3, 30)
+
+    rank_by = search_kwargs.pop("rank_by", "smart")
+    logger.info(
+        "adversarial_search: %d query phrasings (per_query_limit=%d) — "
+        "favours completeness over speed",
+        len(variants),
+        per_query_limit,
+    )
+    seen: dict[str, SearchResult] = {}
+    new_per_query: list[int] = []
+    for variant in variants:
+        before = len(seen)
+        hits = search_papers(variant, limit=per_query_limit, **search_kwargs)
+        for result in hits:
+            seen.setdefault(result.dedup_key, result)
+        new_per_query.append(len(seen) - before)
+
+    confidence, saturated = _recall_confidence(new_per_query)
+    report = RecallReport(
+        queries_run=len(variants),
+        variants=variants,
+        new_per_query=new_per_query,
+        total_unique=len(seen),
+        saturated=saturated,
+        confidence=confidence,
+    )
+    ranked = rank(list(seen.values()), rank_by=rank_by, relevance_query=query)
+    return ranked[:limit], report
 
 
 def iter_new_results(

--- a/src/research_hub/search/query_expansion.py
+++ b/src/research_hub/search/query_expansion.py
@@ -1,0 +1,117 @@
+"""Query expansion for adversarial-recall search.
+
+Turns one search query into several phrasings of the same search intent, so
+a paper that uses different vocabulary than the user's query is still
+retrieved. Incomplete recall is the dominant failure mode in topic-scoping
+search: a missed paper makes a research gap look open when it is not.
+
+LLM-preferred with a deterministic fallback — mirrors the graceful-degrade
+pattern of the `auto`-pipeline fit-check (no LLM CLI on PATH -> still works,
+at reduced expansion quality).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+_EXPANSION_PROMPT = """You are helping make an academic literature search exhaustive.
+
+Given ONE search query, produce {n} ALTERNATIVE phrasings of the SAME search
+intent. Vary: method-name vs problem-name framing, broad vs narrow scope, and
+common synonyms / terminology a different research community would use. Do NOT
+change the topic or drift to a related-but-different one.
+
+Output one phrasing per line. No numbering, no quotes, no commentary.
+
+QUERY: {query}"""
+
+# strips a leading list marker ("- ", "* ", "1. ", "42) ") from an LLM line.
+# Requires whitespace AFTER the marker, so a digit-prefixed phrasing like
+# "3D flood model" or "10x speedup" is never mistaken for a numbered item.
+_LIST_MARKER = re.compile(r"^(?:\s*[-*]\s+|\s*\d+[.)]\s+)")
+
+
+def _deterministic_variants(query: str, max_variants: int) -> list[str]:
+    """Rule-based fallback used when no LLM CLI is available.
+
+    Weaker than LLM expansion (it cannot rephrase), but reproducible and
+    dependency-free: it only narrows (quote the phrase) and broadens (drop a
+    boundary word).
+    """
+    words = query.split()
+    candidates: list[str] = []
+    if len(words) > 1:
+        candidates.append(f'"{query}"')           # narrow: exact phrase
+    if len(words) > 2:
+        candidates.append(" ".join(words[:-1]))   # broaden: drop last word
+        candidates.append(" ".join(words[1:]))    # broaden: drop first word
+    seen = {query.lower()}
+    out: list[str] = []
+    for cand in candidates:
+        if cand.lower() not in seen:
+            seen.add(cand.lower())
+            out.append(cand)
+    return out[:max_variants]
+
+
+def expand_query(
+    query: str,
+    *,
+    max_variants: int = 5,
+    llm_cli: str | None = None,
+    _invoke=None,
+    _detect=None,
+) -> list[str]:
+    """Return ``[original_query, *alternative_phrasings]``.
+
+    Element 0 is always the original query verbatim. Alternatives come from
+    an LLM CLI when one is available, otherwise from the deterministic
+    fallback. This function never raises: any LLM failure is logged and the
+    fallback is used. ``_invoke`` / ``_detect`` are injection points for tests.
+    """
+    query = query.strip()
+    if not query:
+        return []
+    result = [query]
+    if max_variants <= 0:
+        return result
+
+    from research_hub.llm_cli import detect_llm_cli, invoke_llm_cli
+
+    detect = _detect or detect_llm_cli
+    invoke = _invoke or invoke_llm_cli
+
+    cli = llm_cli or detect()
+    if cli:
+        try:
+            prompt = _EXPANSION_PROMPT.format(n=max_variants, query=query)
+            raw = invoke(cli, prompt, timeout_sec=60.0)
+            for line in raw.splitlines():
+                cleaned = _LIST_MARKER.sub("", line).strip().strip('"').strip()
+                if not cleaned or cleaned.lower() == query.lower():
+                    continue
+                if cleaned not in result:
+                    result.append(cleaned)
+                if len(result) > max_variants:
+                    break
+            if len(result) > 1:
+                return result[: max_variants + 1]
+            logger.warning(
+                "query expansion: LLM CLI %s returned no usable variants; "
+                "using deterministic fallback",
+                cli,
+            )
+        except Exception as exc:  # noqa: BLE001 - never let expansion break search
+            logger.warning(
+                "query expansion via %s failed (%s); using deterministic fallback",
+                cli,
+                exc,
+            )
+
+    for variant in _deterministic_variants(query, max_variants):
+        if variant not in result:
+            result.append(variant)
+    return result[: max_variants + 1]

--- a/tests/test_search_adversarial.py
+++ b/tests/test_search_adversarial.py
@@ -1,0 +1,215 @@
+"""Adversarial-recall search — query expansion + recall report.
+
+Covers `research_hub.search.query_expansion.expand_query` and the
+`adversarial_search` / `_recall_confidence` additions to `fallback.py`.
+"""
+
+from __future__ import annotations
+
+from research_hub.search import fallback
+from research_hub.search.base import SearchResult
+from research_hub.search.fallback import (
+    RecallReport,
+    _recall_confidence,
+    adversarial_search,
+)
+from research_hub.search.query_expansion import _deterministic_variants, expand_query
+
+
+# --- expand_query -----------------------------------------------------------
+
+def test_expand_query_original_is_always_first():
+    out = expand_query("anchoring bias in LLMs", max_variants=3, _detect=lambda: None)
+    assert out[0] == "anchoring bias in LLMs"
+
+
+def test_expand_query_empty_returns_empty():
+    assert expand_query("", _detect=lambda: None) == []
+    assert expand_query("   ", _detect=lambda: None) == []
+
+
+def test_expand_query_uses_llm_when_available():
+    def fake_invoke(cli, prompt, timeout_sec=60.0):
+        return "LLM cognitive bias\nanchoring effect in language models\n"
+
+    out = expand_query(
+        "anchoring bias in LLMs", max_variants=5,
+        _detect=lambda: "claude", _invoke=fake_invoke,
+    )
+    assert out[0] == "anchoring bias in LLMs"
+    assert "LLM cognitive bias" in out
+    assert "anchoring effect in language models" in out
+
+
+def test_expand_query_falls_back_on_llm_failure():
+    def boom(cli, prompt, timeout_sec=60.0):
+        raise RuntimeError("llm cli unavailable")
+
+    out = expand_query(
+        "anchoring bias in large models", max_variants=5,
+        _detect=lambda: "claude", _invoke=boom,
+    )
+    assert out[0] == "anchoring bias in large models"
+    assert len(out) > 1  # deterministic fallback supplied variants
+
+
+def test_expand_query_strips_llm_list_markers():
+    def fake_invoke(cli, prompt, timeout_sec=60.0):
+        return "1. first variant\n- second variant\n* third variant\n"
+
+    out = expand_query(
+        "x y z", max_variants=5, _detect=lambda: "claude", _invoke=fake_invoke,
+    )
+    assert "first variant" in out
+    assert "second variant" in out
+    assert "1. first variant" not in out
+
+
+def test_expand_query_caps_variant_count():
+    def fake_invoke(cli, prompt, timeout_sec=60.0):
+        return "\n".join(f"variant {i}" for i in range(20))
+
+    out = expand_query(
+        "topic", max_variants=4, _detect=lambda: "claude", _invoke=fake_invoke,
+    )
+    assert len(out) == 5  # original + 4
+
+
+def test_deterministic_variants_narrow_and_broaden():
+    variants = _deterministic_variants("agent based flood model", max_variants=5)
+    assert '"agent based flood model"' in variants          # narrowed
+    assert "agent based flood" in variants                   # broadened (drop last)
+    assert "based flood model" in variants                   # broadened (drop first)
+
+
+# --- _recall_confidence -----------------------------------------------------
+
+def test_recall_confidence_single_query_is_low():
+    confidence, saturated = _recall_confidence([40])
+    assert confidence == "low"
+    assert saturated is False
+
+
+def test_recall_confidence_saturated_is_high():
+    confidence, saturated = _recall_confidence([40, 8, 3, 0])
+    assert confidence == "high"
+    assert saturated is True
+
+
+def test_recall_confidence_medium_band():
+    # last variant still adds ~12% -> medium
+    confidence, saturated = _recall_confidence([40, 20, 15, 10])
+    assert confidence == "medium"
+    assert saturated is False
+
+
+def test_recall_confidence_unsaturated_is_low():
+    confidence, saturated = _recall_confidence([40, 38, 35, 33])
+    assert confidence == "low"
+    assert saturated is False
+
+
+# --- adversarial_search -----------------------------------------------------
+
+def _result(doi: str, title: str = "paper") -> SearchResult:
+    return SearchResult(title=title, doi=doi)
+
+
+def test_adversarial_search_unions_and_dedups(monkeypatch):
+    monkeypatch.setattr(
+        "research_hub.search.query_expansion.expand_query",
+        lambda query, **kwargs: ["q1", "q2"],
+    )
+    per_variant = {
+        "q1": [_result("10.1/a"), _result("10.1/b")],
+        "q2": [_result("10.1/b"), _result("10.1/c")],  # b overlaps q1
+    }
+    monkeypatch.setattr(fallback, "search_papers", lambda variant, **kw: per_variant[variant])
+
+    results, report = adversarial_search("q1", limit=10)
+
+    assert sorted(r.doi for r in results) == ["10.1/a", "10.1/b", "10.1/c"]
+    assert report.queries_run == 2
+    assert report.total_unique == 3
+    assert report.new_per_query == [2, 1]  # q2 added only 'c'
+
+
+def test_adversarial_search_returns_recall_report(monkeypatch):
+    monkeypatch.setattr(
+        "research_hub.search.query_expansion.expand_query",
+        lambda query, **kwargs: ["q1", "q2", "q3"],
+    )
+    monkeypatch.setattr(
+        fallback, "search_papers",
+        lambda variant, **kw: [_result(f"10.1/{variant}")],
+    )
+
+    results, report = adversarial_search("q1", limit=10)
+
+    assert isinstance(report, RecallReport)
+    assert report.queries_run == 3
+    assert report.total_unique == 3
+    assert report.variants == ["q1", "q2", "q3"]
+
+
+def test_adversarial_search_empty_expansion_is_safe(monkeypatch):
+    monkeypatch.setattr(
+        "research_hub.search.query_expansion.expand_query",
+        lambda query, **kwargs: [],
+    )
+    results, report = adversarial_search("", limit=10)
+    assert results == []
+    assert report.queries_run == 0
+    assert report.confidence == "low"
+
+
+# --- regression tests (2026-05-21 code review) ------------------------------
+
+def test_expand_query_does_not_strip_digit_prefixed_variants():
+    """Regression: the list-marker regex must not eat a leading digit.
+    '3D flood model' / '10x faster training' are valid phrasings, not
+    numbered list items."""
+    def fake_invoke(cli, prompt, timeout_sec=60.0):
+        return "3D flood model\n10x faster training\n"
+
+    out = expand_query(
+        "flood simulation", max_variants=5,
+        _detect=lambda: "claude", _invoke=fake_invoke,
+    )
+    assert "3D flood model" in out
+    assert "10x faster training" in out
+
+
+def test_expand_query_still_strips_numbered_list_markers():
+    """The fixed regex must still strip genuine '1. ' / '2) ' markers."""
+    def fake_invoke(cli, prompt, timeout_sec=60.0):
+        return "1. first variant\n2) second variant\n"
+
+    out = expand_query(
+        "topic", max_variants=5, _detect=lambda: "claude", _invoke=fake_invoke,
+    )
+    assert "first variant" in out
+    assert "second variant" in out
+    assert not any(v.startswith(("1.", "2)")) for v in out)
+
+
+def test_recall_confidence_zero_results_is_low():
+    """Regression: every variant returning zero papers is 'found nothing',
+    not 'thorough search' — must be low confidence, not high."""
+    confidence, saturated = _recall_confidence([0, 0, 0])
+    assert confidence == "low"
+    assert saturated is False
+
+
+def test_adversarial_search_all_empty_is_low_confidence(monkeypatch):
+    """Variants expand fine but every search returns nothing -> low."""
+    monkeypatch.setattr(
+        "research_hub.search.query_expansion.expand_query",
+        lambda query, **kwargs: ["q1", "q2", "q3"],
+    )
+    monkeypatch.setattr(fallback, "search_papers", lambda variant, **kw: [])
+
+    results, report = adversarial_search("q1", limit=10)
+    assert results == []
+    assert report.total_unique == 0
+    assert report.confidence == "low"


### PR DESCRIPTION
## What

Adds `research-hub search --adversarial` — multi-phrasing search with a recall-confidence verdict.

## Why

Incomplete recall is the #1 failure mode in topic-scoping literature search: a single query phrasing systematically misses papers that use other vocabulary, and a missed paper makes a research gap look open when it is not. (Derived from a first-principles investigation of what researchers need from a literature-review deliverable.)

## How

`--adversarial`:
1. expands the query into several phrasings — LLM-generated when an LLM CLI is on PATH, deterministic rule-based fallback otherwise (graceful-degrade, mirroring the `auto` fit-check pattern);
2. runs `search_papers` per phrasing, unions by `dedup_key`, re-ranks;
3. prints a recall-confidence verdict (`high`/`medium`/`low`, from query saturation) to **stderr** — so `--adversarial --json` still emits a clean JSON array on stdout.

## Files

- **NEW** `search/query_expansion.py` — `expand_query()`
- `search/fallback.py` — `adversarial_search()` + `RecallReport` + `_recall_confidence()`
- `search/__init__.py` — exports
- `cli.py` — `--adversarial` / `--max-variants` flags + wiring
- **NEW** `tests/test_search_adversarial.py` — 18 cases

## Review

`code-reviewer` subagent — initial **REQUEST CHANGES**, two real bugs fixed:
- the list-marker regex destroyed digit-prefixed phrasings (`3D flood model` → `D flood model`) — now strips only genuine list markers;
- `_recall_confidence` reported zero-result searches as high-confidence — now returns low.
Both regression-tested; saturation thresholds named as constants; a latency note added. 18/18 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)