### PR TITLE
fix(nlm): auto-detect login polls live page URL, not on-disk cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,23 @@ graph rebuild (link out to the real tools instead)._
   `search --adversarial --json` metadata, which the skill already has in hand
   at §1.  Mirrored to `src/research_hub/skills_data/gap-to-topic/`; plugin
   version bumped so the marketplace cache invalidates.
+- **`notebooklm login --auto-detect` now works** (`notebooklm/auth.py`).
+  The pre-fix implementation shelled out to the upstream `notebooklm login`
+  subprocess and polled the patchright Chromium profile's *on-disk* Cookies
+  SQLite for a `notebooklm.google.com` row. Chromium buffers cookies in
+  memory and flushes them to that store only on a lazy timer, so a
+  freshly-signed-in session stayed invisible on disk for minutes — the poll
+  loop always timed out without ever firing the save. `--auto-detect` now
+  drives the Chromium browser directly via Playwright (same stealth flags
+  the SDK uses) and polls the **live `page.url`**: the moment the page
+  settles on the NotebookLM host — and holds there for 3 consecutive polls,
+  so a mid-redirect flash never triggers a premature save — the session is
+  captured straight from the live browser context via `storage_state`. No
+  terminal ENTER, no subprocess, no disk-cookie race. Fail-closed: a
+  timeout, a browser-launch error, or a driver-start failure all return
+  non-zero without saving and never raise into the CLI. Removed the dead
+  disk-polling helpers (`_patchright_cookies_db`, `_has_notebooklm_cookie`,
+  `_cookies_db_modified_since`).
 
 - **`probe_cleared_failed_no_abstract` URL quality signal now triggers text
   fallback in the NLM bundle builder** (`notebooklm/bundle.py`).  Springer /

--- a/src/research_hub/notebooklm/auth.py
+++ b/src/research_hub/notebooklm/auth.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import asyncio
 import inspect
 import shutil
-import sqlite3
 import subprocess
 import sys
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -64,24 +64,28 @@ def login_nlm(
     """Open notebooklm-py's one-time login flow and save storage state.
 
     Three orchestration modes:
-    - default (no flag): interactive ENTER gate in a real terminal.
+    - default (no flag): interactive ENTER gate in a real terminal (runs
+      the upstream ``notebooklm login`` subprocess).
     - ``wait_file=PATH``: file-signal gate (see ``_login_with_wait_file``).
-    - ``auto_detect=True``: cookies-poll gate (see ``_login_with_auto_detect``).
-      Fully automatic: research-hub polls the patchright Chromium profile's
-      cookies for ``notebooklm.google.com`` after the user signs in and
-      lands on the NotebookLM homepage. No ENTER, no wait_file touch, no
-      click.confirm response needed.
+    - ``auto_detect=True``: live-page-poll gate (see
+      ``_login_with_auto_detect``). Fully automatic: research-hub drives a
+      Chromium browser itself and polls the live ``page.url``; the session
+      saves the moment the user lands on the NotebookLM homepage. No ENTER,
+      no wait_file touch, no subprocess.
     """
     del headless, timeout_sec, stable_hold_sec
     target = Path(state_file) if state_file is not None else Path(user_data_dir)
     target.parent.mkdir(parents=True, exist_ok=True)
-    cmd = [sys.executable, "-m", "notebooklm.notebooklm_cli", "login", "--storage", str(target)]
     if auto_detect:
-        rc = _login_with_auto_detect(cmd, int(wait_timeout), target)
-    elif wait_file is None:
-        rc = subprocess.run(cmd, check=False).returncode
+        # research-hub drives the browser itself and polls the live page
+        # URL -- no upstream subprocess (see _login_with_auto_detect).
+        rc = _login_with_auto_detect(target, int(wait_timeout))
     else:
-        rc = _login_with_wait_file(cmd, Path(wait_file), int(wait_timeout), target)
+        cmd = [sys.executable, "-m", "notebooklm.notebooklm_cli", "login", "--storage", str(target)]
+        if wait_file is None:
+            rc = subprocess.run(cmd, check=False).returncode
+        else:
+            rc = _login_with_wait_file(cmd, Path(wait_file), int(wait_timeout), target)
     if rc == 0:
         # G3 P1 #2: tighten newly-created state.json permissions.
         _tighten_state_file_perms(target)
@@ -169,146 +173,197 @@ def _login_with_wait_file(
                 pass
 
 
-def _patchright_cookies_db() -> Path:
-    """Resolve the path to the patchright Chromium profile's Cookies SQLite.
+# NotebookLM URLs used by the live-poll auto-detect login flow.
+_NLM_URL = "https://notebooklm.google.com/"
+_NLM_HOST = "notebooklm.google.com"
+_GOOGLE_ACCOUNTS_URL = "https://accounts.google.com/"
 
-    Modern Chromium (80+) stores cookies under ``Default/Network/Cookies``;
-    older versions used the legacy ``Default/Cookies`` path. Prefer modern;
-    fall back to legacy only if modern is missing AND legacy exists. If
-    neither exists yet (chromium still starting), return the modern path so
-    the next poll iteration finds it the moment chromium creates it.
 
-    Uses the notebooklm-py SDK's own ``get_browser_profile_dir`` helper to
-    locate the profile root so research-hub stays in lock-step with whatever
-    layout the SDK uses; falls back to the documented
+def _browser_profile_dir() -> Path:
+    """Resolve the persistent Chromium profile directory used for NLM login.
+
+    Uses the notebooklm-py SDK's own ``get_browser_profile_dir`` helper so
+    research-hub stays in lock-step with whatever profile layout the SDK
+    uses; falls back to the documented
     ``~/.notebooklm/profiles/default/browser_profile`` location if the
     helper is unavailable (older SDK).
     """
     try:
         from notebooklm.cli.session import get_browser_profile_dir
-        profile = Path(get_browser_profile_dir())
+        return Path(get_browser_profile_dir())
     except Exception:  # noqa: BLE001 - any SDK breakage falls through
-        profile = (
+        return (
             Path.home()
             / ".notebooklm"
             / "profiles"
             / "default"
             / "browser_profile"
         )
-    modern = profile / "Default" / "Network" / "Cookies"
-    legacy = profile / "Default" / "Cookies"
-    if modern.exists():
-        return modern
-    if legacy.exists():
-        return legacy
-    # Neither exists yet -- chromium will create the modern one.
-    return modern
 
 
-def _cookies_db_modified_since(cookies_db: Path, baseline_mtime: float) -> bool:
-    """True iff the Cookies SQLite has been written after baseline_mtime.
-    Pair with _has_notebooklm_cookie to prove the row is FRESH (the
-    user signed in in this session) rather than stale (left over from a
-    previous login that may have been revoked server-side). Tolerant of
-    a missing file (returns False)."""
-    try:
-        return cookies_db.stat().st_mtime > baseline_mtime
-    except OSError:
-        return False
+@contextmanager
+def _playwright_event_loop():
+    """Restore the default (Proactor) event-loop policy for Playwright on
+    Windows for the duration of the ``with`` block.
 
-
-def _has_notebooklm_cookie(cookies_db: Path) -> bool:
-    """True iff Chromium's Cookies SQLite contains at least one row with
-    ``host_key`` matching ``notebooklm.google.com``.
-
-    Tolerant of: file not yet existing (browser still starting); SQLite
-    lock contention (chromium writing); any other transient I/O error.
-    Each transient returns ``False`` so the calling loop simply polls
-    again on the next iteration. Opened read-only via the SQLite URI
-    ``mode=ro`` so we never contend with chromium's write locks.
+    notebooklm-py sets ``WindowsSelectorEventLoopPolicy`` globally (it fixes
+    an unrelated CLI hang), but Playwright's sync API needs the Proactor
+    loop to spawn the browser subprocess. No-op off Windows. Mirrors the
+    SDK's own ``_windows_playwright_event_loop`` so we do not depend on a
+    private SDK symbol.
     """
-    if not cookies_db.exists():
-        return False
+    if sys.platform != "win32":
+        yield
+        return
+    original = asyncio.get_event_loop_policy()
+    asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
     try:
-        uri = f"file:{cookies_db.as_posix()}?mode=ro"
-        with sqlite3.connect(uri, uri=True, timeout=2) as conn:
-            cur = conn.execute(
-                "SELECT 1 FROM cookies WHERE host_key LIKE ? LIMIT 1",
-                ("%notebooklm.google.com",),
-            )
-            return cur.fetchone() is not None
-    except sqlite3.Error:
-        return False
-    except Exception:  # noqa: BLE001 - defensive against unexpected I/O
-        return False
+        yield
+    finally:
+        asyncio.set_event_loop_policy(original)
+
+
+def _is_on_notebooklm_homepage(url: str) -> bool:
+    """True iff *url* is the live NotebookLM app (not a Google sign-in page).
+
+    While the user is signing in, ``page.url`` sits on ``accounts.google.com``
+    (or a NotebookLM ``/login`` interstitial). Once authenticated the page
+    settles on the ``notebooklm.google.com`` host. The ``/login`` guard
+    rejects the brief interstitial NotebookLM itself serves before bouncing
+    to Google.
+    """
+    return _NLM_HOST in url and "/login" not in url
 
 
 def _login_with_auto_detect(
-    cmd: list[str],
-    timeout: int,
     state_file: Path,
+    wait_timeout: int,
 ) -> int:
-    """Fully-automatic login: poll the patchright Chromium profile's
-    Cookies SQLite for a ``notebooklm.google.com`` host_key. When the
-    cookie appears, feed the subprocess ``\\n`` (any pending ``input()``
-    ENTER prompt) AND ``y\\n`` (any pending ``click.confirm`` "Save
-    authentication anyway?" prompt) in one write so the upstream save
-    fires whichever path the SDK actually takes.
+    """Fully-automatic login: research-hub drives the browser directly.
 
-    Fail-closed: if no notebooklm.google.com cookie appears within
-    ``timeout`` seconds the subprocess is killed and a non-zero exit
-    code is returned (nothing is saved).
+    Launches a Chromium persistent context (the same stealth flags the
+    notebooklm-py SDK uses for its own ``login`` command), navigates to
+    the NotebookLM homepage, then polls the LIVE ``page.url``. The moment
+    the page settles on the NotebookLM host -- and stays there for a few
+    consecutive polls, so a mid-redirect flash never triggers a premature
+    save -- the session is captured straight from the live browser context
+    via ``storage_state``. No terminal ENTER, no subprocess, no file signal.
+
+    Why not poll the on-disk Cookies SQLite (the pre-fix approach):
+    Chromium buffers cookies in memory and flushes them to the profile's
+    SQLite store on a lazy timer, so a freshly-signed-in session stays
+    invisible on disk for minutes. Polling ``page.url`` reads live browser
+    state and has no such race.
+
+    Fail-closed: if the homepage is not reached within *wait_timeout*
+    seconds the browser is closed and a non-zero code is returned
+    (nothing is saved).
     """
-    cookies_db = _patchright_cookies_db()
-    # W1 (PR-D review): anti-stale-cookie guard. Snapshot the Cookies
-    # file mtime BEFORE launching the subprocess. The detection trigger
-    # requires BOTH (a) a notebooklm.google.com row AND (b) the file was
-    # written after launch -- proving the user actually signed in in
-    # this session rather than us picking up a stale cookie left behind
-    # from a previous (possibly-revoked) login.
     try:
-        pre_launch_mtime = cookies_db.stat().st_mtime if cookies_db.exists() else 0.0
-    except OSError:
-        pre_launch_mtime = 0.0
-    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
-    deadline = time.monotonic() + max(1, timeout)
-    poll_interval = 1.0  # match _login_with_wait_file for consistency
+        from playwright.sync_api import Error as PlaywrightError
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print(
+            "  [nlm] Playwright is not installed; cannot run --auto-detect "
+            "login.\n        Install it with: pip install 'notebooklm[browser]'",
+            file=sys.stderr,
+        )
+        return 1
+
+    profile_dir = _browser_profile_dir()
     try:
-        while time.monotonic() < deadline:
-            if proc.poll() is not None:
-                return proc.returncode
-            if _has_notebooklm_cookie(cookies_db) and _cookies_db_modified_since(cookies_db, pre_launch_mtime):
-                try:
-                    if proc.stdin is not None:
-                        proc.stdin.write(b"\ny\n")
-                        proc.stdin.flush()
-                        proc.stdin.close()
-                except OSError:
-                    pass
-                try:
-                    return proc.wait(timeout=120)
-                except subprocess.TimeoutExpired:
-                    try:
-                        _tighten_state_file_perms(state_file)
-                    except Exception:  # noqa: BLE001 - best-effort
-                        pass
-                    _kill_proc(proc)
-                    return 1
-            time.sleep(poll_interval)
-        # detection never arrived -> fail-closed (nothing saved).
+        profile_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"  [nlm] cannot create browser profile dir: {exc}", file=sys.stderr)
+        return 1
+
+    launch_kwargs = {
+        "user_data_dir": str(profile_dir),
+        "headless": False,
+        # Same stealth flags notebooklm-py uses for its own login command.
+        "args": [
+            "--disable-blink-features=AutomationControlled",
+            "--password-store=basic",
+        ],
+        "ignore_default_args": ["--enable-automation"],
+    }
+    # The homepage URL must hold for this many consecutive polls before we
+    # trust the sign-in -- guards against capturing a transient flash while
+    # NotebookLM is still bouncing through a redirect.
+    stable_polls_needed = 3
+    poll_interval = 1.0
+
+    with _playwright_event_loop():
+        playwright = None
+        context = None
         try:
-            if proc.stdin is not None:
-                proc.stdin.close()
-        except OSError:
-            pass
-        _kill_proc(proc)
-        return 124
-    finally:
-        if proc.poll() is None:
+            # sync_playwright().start() spawns the Playwright driver
+            # process; doing it inside the try means a driver-start
+            # failure is caught and surfaced as rc 1, never raised
+            # into the CLI.
+            playwright = sync_playwright().start()
+            context = playwright.chromium.launch_persistent_context(**launch_kwargs)
+            page = context.pages[0] if context.pages else context.new_page()
             try:
-                proc.terminate()
-            except OSError:
+                page.goto(_NLM_URL, timeout=30_000)
+            except PlaywrightError:
+                # A navigation hiccup is non-fatal: the poll loop below
+                # re-reads page.url and recovers once the page settles.
                 pass
+
+            print(
+                "  [nlm] Browser opened. Sign in to NotebookLM in the window.\n"
+                "        The session saves automatically once the homepage "
+                "loads -- no ENTER needed.",
+            )
+
+            deadline = time.monotonic() + max(1, wait_timeout)
+            stable = 0
+            while time.monotonic() < deadline:
+                try:
+                    current_url = page.url
+                except PlaywrightError:
+                    # Page transiently unavailable (navigating); treat as
+                    # "not yet on homepage" and keep polling.
+                    current_url = ""
+                stable = stable + 1 if _is_on_notebooklm_homepage(current_url) else 0
+                if stable >= stable_polls_needed:
+                    # Force .google.com cookies for regional users (e.g. a
+                    # TW user lands on .google.com.tw); "commit" resolves
+                    # once Set-Cookie headers are processed. Mirrors the
+                    # SDK's own post-login double-navigation.
+                    for url in (_GOOGLE_ACCOUNTS_URL, _NLM_URL):
+                        try:
+                            page.goto(url, wait_until="commit")
+                        except PlaywrightError:
+                            pass
+                    context.storage_state(path=str(state_file))
+                    context.close()
+                    return 0
+                time.sleep(poll_interval)
+
+            # Homepage never reached within the deadline -> fail-closed.
+            context.close()
+            return 124
+        except Exception as exc:  # noqa: BLE001 - report and fail, never raise
+            print(
+                f"  [nlm] auto-detect login failed: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            if context is not None:
+                try:
+                    context.close()
+                except Exception:  # noqa: BLE001 - best-effort cleanup
+                    pass
+            return 1
+        finally:
+            # Always stop the driver process, whatever path we exit on.
+            if playwright is not None:
+                try:
+                    playwright.stop()
+                except Exception:  # noqa: BLE001 - best-effort cleanup
+                    pass
 
 
 def check_session_health(state_file: Path) -> dict[str, Any]:

--- a/tests/test_v1_nlm_login_auto_detect.py
+++ b/tests/test_v1_nlm_login_auto_detect.py
@@ -17,6 +17,8 @@ reads live browser state and has no such race.
 
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -113,16 +115,33 @@ class _FakeSyncPlaywright:
         return self._pw
 
 
-def _install_fake_playwright(monkeypatch, chromium: _FakeChromium) -> _FakePlaywright:
-    """Patch ``playwright.sync_api.sync_playwright`` so the function under
-    test gets our fake. The function does ``from playwright.sync_api import
-    sync_playwright`` at call time, so patching the module attribute is
-    sufficient. Returns the playwright handle so tests can assert ``stop()``
-    was called on it."""
-    import playwright.sync_api as pw_api
+class _FakePlaywrightError(Exception):
+    """Stand-in for ``playwright.sync_api.Error`` -- the real playwright
+    package is an optional dependency and is not installed in CI."""
 
+
+def _inject_playwright_module(monkeypatch, sync_playwright_factory):
+    """Inject a fake ``playwright.sync_api`` module into ``sys.modules``.
+
+    The function under test does ``from playwright.sync_api import
+    sync_playwright`` / ``import Error`` at call time. playwright is an
+    optional dependency (absent in CI), so we synthesise the module rather
+    than patching an attribute on a package that may not be importable.
+    """
+    fake_api = types.ModuleType("playwright.sync_api")
+    fake_api.sync_playwright = sync_playwright_factory
+    fake_api.Error = _FakePlaywrightError
+    pkg = sys.modules.get("playwright") or types.ModuleType("playwright")
+    monkeypatch.setitem(sys.modules, "playwright", pkg)
+    monkeypatch.setitem(sys.modules, "playwright.sync_api", fake_api)
+
+
+def _install_fake_playwright(monkeypatch, chromium: _FakeChromium) -> _FakePlaywright:
+    """Install a fake ``playwright.sync_api`` whose ``sync_playwright()``
+    yields a browser stack wrapping *chromium*. Returns the playwright
+    handle so tests can assert ``stop()`` was called on it."""
     fake = _FakeSyncPlaywright(chromium)
-    monkeypatch.setattr(pw_api, "sync_playwright", lambda: fake)
+    _inject_playwright_module(monkeypatch, lambda: fake)
     return fake._pw
 
 
@@ -279,8 +298,6 @@ def test_driver_start_failure_returns_one_and_does_not_raise(tmp_path, monkeypat
     """If the Playwright driver itself fails to start (``sync_playwright().
     start()`` raises), the failure is caught and surfaced as rc 1 rather
     than propagating into the CLI."""
-    import playwright.sync_api as pw_api
-
     state_file = tmp_path / "state.json"
     monkeypatch.setattr(auth, "_browser_profile_dir", lambda: tmp_path / "profile")
 
@@ -291,7 +308,7 @@ def test_driver_start_failure_returns_one_and_does_not_raise(tmp_path, monkeypat
         def stop(self):  # pragma: no cover - never reached (start failed)
             pass
 
-    monkeypatch.setattr(pw_api, "sync_playwright", lambda: _BrokenPlaywright())
+    _inject_playwright_module(monkeypatch, lambda: _BrokenPlaywright())
 
     rc = _login_with_auto_detect(state_file, wait_timeout=30)
 

--- a/tests/test_v1_nlm_login_auto_detect.py
+++ b/tests/test_v1_nlm_login_auto_detect.py
@@ -1,309 +1,312 @@
-"""PR-D: ``notebooklm login --auto-detect`` — fully-automatic zero-touch login.
+"""``notebooklm login --auto-detect`` -- fully-automatic zero-touch login.
 
-Replaces the half-automatic ``--wait-file`` flow (which still requires
-the user to ``touch`` a file after browser sign-in) with a cookies-poll
-that detects "user reached the NotebookLM homepage" by looking for a
-``notebooklm.google.com`` row in the patchright Chromium profile's
-Cookies SQLite. When detected, research-hub feeds both ``\\n`` (any
-pending ``input()`` ENTER) AND ``y\\n`` (any pending ``click.confirm``
-"Save anyway?" fallback) so the upstream save fires regardless of which
-prompt path the SDK takes. Fail-closed on timeout (nothing saved).
+research-hub drives a Chromium browser directly and polls the LIVE
+``page.url``. The moment the page settles on the NotebookLM host -- and
+holds there for a few consecutive polls -- the session is captured
+straight from the live browser context via ``storage_state``. No terminal
+ENTER, no upstream subprocess, no on-disk Cookies-SQLite race.
+
+Root-cause history: the pre-fix implementation shelled out to the
+upstream ``notebooklm login`` subprocess and polled the patchright
+Chromium profile's Cookies SQLite on disk. Chromium buffers cookies in
+memory and flushes to that SQLite store only on a lazy timer, so a
+freshly-signed-in session stayed invisible on disk for minutes and the
+poll loop timed out without ever firing the save. Polling ``page.url``
+reads live browser state and has no such race.
 """
 
 from __future__ import annotations
 
-import sqlite3
-import subprocess
 from pathlib import Path
 
 import pytest
 
 import research_hub.notebooklm.auth as auth
 from research_hub.notebooklm.auth import (
-    _has_notebooklm_cookie,
+    _browser_profile_dir,
+    _is_on_notebooklm_homepage,
     _login_with_auto_detect,
 )
 
 
-class _Stdin:
-    """Capture stub that survives .close() (real BytesIO does not)."""
-    def __init__(self):
-        self.buf = b""
-        self.closed = False
-    def write(self, b):
-        self.buf += b
-    def flush(self):
-        pass
-    def close(self):
-        self.closed = True
-    def getvalue(self):
-        return self.buf
-
-
-class _FakeProc:
-    def __init__(self, *, exits_with=None):
-        self.stdin = _Stdin()
-        self._exits_with = exits_with        # not None -> poll() returns it
-        self.returncode = None
-        self.terminated = False
-        self.killed = False
-
-    def poll(self):
-        if self.returncode is not None:
-            return self.returncode
-        if self._exits_with is not None:
-            self.returncode = self._exits_with
-            return self._exits_with
-        return None
-
-    def wait(self, timeout=None):
-        self.returncode = 0
-        return 0
-
-    def terminate(self):
-        self.terminated = True
-
-    def kill(self):
-        self.killed = True
-
-
 @pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
+    """Make the poll loop spin instantly -- detection / timeout is driven
+    by the mocked clock or the page-URL sequence, never by wall time."""
     monkeypatch.setattr(auth.time, "sleep", lambda *_a, **_k: None)
 
 
-def _build_cookies_db(path: Path, *, with_notebooklm: bool) -> None:
-    """Create a real (read-only-poll-compatible) Cookies SQLite stub."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(str(path)) as conn:
-        conn.execute(
-            "CREATE TABLE cookies (host_key TEXT, name TEXT, value TEXT)"
-        )
-        # always seed an unrelated row so the table is non-empty
-        conn.execute(
-            "INSERT INTO cookies VALUES ('accounts.google.com', 'NID', 'x')"
-        )
-        if with_notebooklm:
-            conn.execute(
-                "INSERT INTO cookies VALUES "
-                "('.notebooklm.google.com', 'AUTH', 'y')"
-            )
-        conn.commit()
+# ---------------------------------------------------------------------------
+# Playwright test doubles
+# ---------------------------------------------------------------------------
+
+class _FakePage:
+    """A page whose ``.url`` walks a fixed sequence, one step per read."""
+
+    def __init__(self, url_sequence):
+        self._urls = list(url_sequence)
+        self._idx = 0
+        self.goto_calls: list[str] = []
+
+    @property
+    def url(self) -> str:
+        value = self._urls[min(self._idx, len(self._urls) - 1)]
+        self._idx += 1
+        return value
+
+    def goto(self, url, **_kwargs):
+        self.goto_calls.append(url)
 
 
-# ---- _has_notebooklm_cookie unit tests ----
+class _FakeContext:
+    def __init__(self, page: _FakePage):
+        self.pages = [page]
+        self.storage_saved_to: str | None = None
+        self.closed = False
+
+    def new_page(self):
+        return self.pages[0]
+
+    def storage_state(self, path):
+        self.storage_saved_to = str(path)
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('{"cookies": [], "origins": []}', encoding="utf-8")
+
+    def close(self):
+        self.closed = True
 
 
-def test_has_notebooklm_cookie_missing_file_returns_false(tmp_path):
-    assert _has_notebooklm_cookie(tmp_path / "no-such.db") is False
+class _FakeChromium:
+    def __init__(self, context: _FakeContext | None, *, launch_error: Exception | None = None):
+        self._context = context
+        self._launch_error = launch_error
+        self.launch_kwargs: dict | None = None
+
+    def launch_persistent_context(self, **kwargs):
+        self.launch_kwargs = kwargs
+        if self._launch_error is not None:
+            raise self._launch_error
+        return self._context
 
 
-def test_has_notebooklm_cookie_no_matching_row_returns_false(tmp_path):
-    db = tmp_path / "Cookies"
-    _build_cookies_db(db, with_notebooklm=False)
-    assert _has_notebooklm_cookie(db) is False
+class _FakePlaywright:
+    """The handle ``sync_playwright().start()`` returns. ``.stop()`` tears
+    down the driver -- the function under test calls it in a ``finally``."""
+
+    def __init__(self, chromium: _FakeChromium):
+        self.chromium = chromium
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
 
 
-def test_has_notebooklm_cookie_matching_row_returns_true(tmp_path):
-    db = tmp_path / "Cookies"
-    _build_cookies_db(db, with_notebooklm=True)
-    assert _has_notebooklm_cookie(db) is True
+class _FakeSyncPlaywright:
+    """Mimics ``sync_playwright()`` -- ``.start()`` returns the playwright
+    handle (matching the manual start/stop API the function drives)."""
+
+    def __init__(self, chromium: _FakeChromium):
+        self._pw = _FakePlaywright(chromium)
+
+    def start(self) -> _FakePlaywright:
+        return self._pw
 
 
-def test_has_notebooklm_cookie_corrupt_file_returns_false(tmp_path):
-    """Defensive: a Cookies file that's not a SQLite DB (e.g., chromium
-    still writing initial bytes) returns False so the calling loop
-    simply polls again on the next iteration."""
-    db = tmp_path / "Cookies"
-    db.write_bytes(b"not a sqlite file")
-    assert _has_notebooklm_cookie(db) is False
+def _install_fake_playwright(monkeypatch, chromium: _FakeChromium) -> _FakePlaywright:
+    """Patch ``playwright.sync_api.sync_playwright`` so the function under
+    test gets our fake. The function does ``from playwright.sync_api import
+    sync_playwright`` at call time, so patching the module attribute is
+    sufficient. Returns the playwright handle so tests can assert ``stop()``
+    was called on it."""
+    import playwright.sync_api as pw_api
+
+    fake = _FakeSyncPlaywright(chromium)
+    monkeypatch.setattr(pw_api, "sync_playwright", lambda: fake)
+    return fake._pw
 
 
-# ---- _login_with_auto_detect integration tests ----
+# ---------------------------------------------------------------------------
+# _is_on_notebooklm_homepage -- pure unit tests
+# ---------------------------------------------------------------------------
+
+def test_homepage_url_is_recognised():
+    assert _is_on_notebooklm_homepage("https://notebooklm.google.com/") is True
 
 
-def _make_cookies_appear_mid_loop(tmp_path, monkeypatch):
-    """Patch ``_patchright_cookies_db`` to a tmp path; on the first
-    mocked ``time.sleep`` call (mid-poll-loop), materialise a Cookies
-    SQLite that contains the notebooklm.google.com row -- simulating
-    the user signing in and landing on the NotebookLM homepage."""
-    db = tmp_path / "browser_profile" / "Default" / "Cookies"
-    monkeypatch.setattr(auth, "_patchright_cookies_db", lambda: db)
-
-    def _sleep(*_a, **_k):
-        if not db.exists():
-            _build_cookies_db(db, with_notebooklm=True)
-
-    monkeypatch.setattr(auth.time, "sleep", _sleep)
-    return db
+def test_google_signin_url_is_not_homepage():
+    assert _is_on_notebooklm_homepage("https://accounts.google.com/signin") is False
 
 
-def test_cookie_detection_triggers_save(tmp_path, monkeypatch):
-    proc = _FakeProc()
-    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
-    _make_cookies_appear_mid_loop(tmp_path, monkeypatch)
+def test_notebooklm_login_interstitial_is_not_homepage():
+    """NotebookLM serves a brief ``/login`` interstitial before bouncing to
+    Google -- it is on the right host but the user is NOT signed in yet."""
+    assert _is_on_notebooklm_homepage("https://notebooklm.google.com/login") is False
 
-    rc = _login_with_auto_detect(["x"], timeout=30, state_file=tmp_path / "s")
+
+def test_empty_url_is_not_homepage():
+    assert _is_on_notebooklm_homepage("") is False
+
+
+# ---------------------------------------------------------------------------
+# _browser_profile_dir
+# ---------------------------------------------------------------------------
+
+def test_browser_profile_dir_uses_sdk_helper(tmp_path, monkeypatch):
+    from notebooklm.cli import session as nlm_session
+
+    profile = tmp_path / "sdk_profile"
+    monkeypatch.setattr(nlm_session, "get_browser_profile_dir", lambda: profile)
+
+    assert _browser_profile_dir() == profile
+
+
+def test_browser_profile_dir_falls_back_when_helper_unavailable(monkeypatch):
+    """If the SDK helper raises, fall back to the documented default path
+    under ``~/.notebooklm`` rather than crashing the login."""
+    from notebooklm.cli import session as nlm_session
+
+    def _boom():
+        raise RuntimeError("SDK changed")
+
+    monkeypatch.setattr(nlm_session, "get_browser_profile_dir", _boom)
+
+    result = _browser_profile_dir()
+
+    assert result == Path.home() / ".notebooklm" / "profiles" / "default" / "browser_profile"
+
+
+# ---------------------------------------------------------------------------
+# _login_with_auto_detect -- integration with a mocked browser
+# ---------------------------------------------------------------------------
+
+def test_reaching_homepage_saves_session(tmp_path, monkeypatch):
+    """The user signs in: page.url moves off accounts.google.com onto the
+    NotebookLM host. After it holds there for the required consecutive
+    polls, storage_state is captured and rc is 0."""
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(auth, "_browser_profile_dir", lambda: tmp_path / "profile")
+
+    # poll 1: still on Google sign-in. polls 2-4: on the NotebookLM host
+    # (3 consecutive -> stable threshold met -> save).
+    page = _FakePage([
+        "https://accounts.google.com/signin",
+        "https://notebooklm.google.com/",
+        "https://notebooklm.google.com/",
+        "https://notebooklm.google.com/",
+    ])
+    context = _FakeContext(page)
+    chromium = _FakeChromium(context)
+    fake = _install_fake_playwright(monkeypatch, chromium)
+
+    rc = _login_with_auto_detect(state_file, wait_timeout=30)
 
     assert rc == 0
-    # Both ENTER and "Save anyway? y" are fed so the upstream save fires
-    # whichever prompt path the SDK actually takes for this run.
-    assert proc.stdin.getvalue() == b"\ny\n"
-    assert not proc.terminated
+    assert context.storage_saved_to == str(state_file)
+    assert state_file.exists()
+    assert context.closed is True
+    # The driver is always torn down on the way out.
+    assert fake.stopped is True
+    # The post-login double-navigation forces .google.com regional cookies.
+    assert "https://accounts.google.com/" in page.goto_calls
+    assert page.goto_calls.count("https://notebooklm.google.com/") >= 1
+
+
+def test_transient_homepage_flash_does_not_trigger_premature_save(tmp_path, monkeypatch):
+    """A single mid-redirect flash onto the NotebookLM host must NOT fire a
+    save -- the URL has to hold for the consecutive-poll threshold. Here it
+    flashes once, drops back to Google, and never stabilises -> timeout."""
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(auth, "_browser_profile_dir", lambda: tmp_path / "profile")
+
+    page = _FakePage([
+        "https://notebooklm.google.com/",        # flash
+        "https://accounts.google.com/signin",    # back to sign-in
+        "https://accounts.google.com/signin",
+    ])
+    context = _FakeContext(page)
+    _install_fake_playwright(monkeypatch, _FakeChromium(context))
+
+    # Mocked clock: first call sets the deadline, later calls blow past it.
+    clock = iter([1000.0, 1000.5, 1001.0])
+    monkeypatch.setattr(auth.time, "monotonic", lambda: next(clock, 9_999.0))
+
+    rc = _login_with_auto_detect(state_file, wait_timeout=5)
+
+    assert rc == 124
+    assert context.storage_saved_to is None
+    assert not state_file.exists()
+    assert context.closed is True
 
 
 def test_timeout_is_fail_closed(tmp_path, monkeypatch):
-    """No cookie appears -> deadline expires -> proc killed, rc=124,
-    nothing fed to stdin (no save)."""
-    db = tmp_path / "browser_profile" / "Default" / "Cookies"
-    monkeypatch.setattr(auth, "_patchright_cookies_db", lambda: db)
-    proc = _FakeProc()
-    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
-    seq = iter([1000.0, 1000.0])
+    """The user never finishes signing in -> deadline expires -> context
+    closed, rc 124, nothing saved."""
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(auth, "_browser_profile_dir", lambda: tmp_path / "profile")
 
-    def _clock():
-        try:
-            return next(seq)
-        except StopIteration:
-            return 9_999.0
+    page = _FakePage(["https://accounts.google.com/signin"])
+    context = _FakeContext(page)
+    _install_fake_playwright(monkeypatch, _FakeChromium(context))
 
-    monkeypatch.setattr(auth.time, "monotonic", _clock)
+    clock = iter([1000.0, 2000.0])
+    monkeypatch.setattr(auth.time, "monotonic", lambda: next(clock, 9_999.0))
 
-    rc = _login_with_auto_detect(["x"], timeout=5, state_file=tmp_path / "s")
+    rc = _login_with_auto_detect(state_file, wait_timeout=30)
 
     assert rc == 124
-    assert proc.terminated
-    assert proc.stdin.getvalue() == b""
+    assert context.storage_saved_to is None
+    assert context.closed is True
 
 
-def test_upstream_self_exit_propagates(tmp_path, monkeypatch):
-    """Upstream SDK exits on its own (e.g., browser launch error) before
-    detection; that exit code propagates out without us feeding stdin."""
-    db = tmp_path / "browser_profile" / "Default" / "Cookies"
-    monkeypatch.setattr(auth, "_patchright_cookies_db", lambda: db)
-    proc = _FakeProc(exits_with=3)
-    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
-
-    rc = _login_with_auto_detect(["x"], timeout=30, state_file=tmp_path / "s")
-
-    assert rc == 3
-    assert proc.stdin.getvalue() == b""
-
-
-def test_post_signal_wait_timeout_tightens_and_fails(tmp_path, monkeypatch):
-    """Upstream saved storage_state but is slow to EXIT after the signal:
-    proc.wait() times out -> rc 1, BUT perms must still be tightened
-    (the file is on disk with default perms) and the proc killed.
-    Parity guarantee with ``_login_with_wait_file``'s equivalent test."""
+def test_browser_launch_error_returns_one_and_does_not_raise(tmp_path, monkeypatch):
+    """A browser-launch failure is reported and surfaces as rc 1 -- the
+    function never raises into the CLI, and the driver is still stopped."""
     state_file = tmp_path / "state.json"
+    monkeypatch.setattr(auth, "_browser_profile_dir", lambda: tmp_path / "profile")
 
-    class _SlowProc(_FakeProc):
-        def wait(self, timeout=None):
-            raise subprocess.TimeoutExpired(cmd=["x"], timeout=timeout)
+    chromium = _FakeChromium(None, launch_error=RuntimeError("chromium missing"))
+    fake = _install_fake_playwright(monkeypatch, chromium)
 
-    proc = _SlowProc()
-    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
-    _make_cookies_appear_mid_loop(tmp_path, monkeypatch)
-
-    tightened = {"called": False}
-    monkeypatch.setattr(
-        auth, "_tighten_state_file_perms",
-        lambda *_a, **_k: tightened.__setitem__("called", True),
-    )
-
-    rc = _login_with_auto_detect(["x"], timeout=30, state_file=state_file)
+    rc = _login_with_auto_detect(state_file, wait_timeout=30)
 
     assert rc == 1
-    assert tightened["called"] is True
-    assert proc.killed or proc.terminated
+    assert not state_file.exists()
+    assert fake.stopped is True
 
 
-def test_cookies_path_prefers_modern_network_subdir(tmp_path, monkeypatch):
-    """Hotfix regression: modern Chromium (80+) stores Cookies under
-    ``Default/Network/Cookies``. The pre-hotfix PR-D code hardcoded the
-    legacy ``Default/Cookies`` path -- auto-detect polling looked at the
-    wrong file, the user logged in but the save never fired."""
-    from notebooklm.cli import session as nlm_session
-    profile = tmp_path / "browser_profile"
-    (profile / "Default" / "Network").mkdir(parents=True)
-    (profile / "Default" / "Network" / "Cookies").write_bytes(b"modern")
-    monkeypatch.setattr(nlm_session, "get_browser_profile_dir", lambda: profile)
+def test_driver_start_failure_returns_one_and_does_not_raise(tmp_path, monkeypatch):
+    """If the Playwright driver itself fails to start (``sync_playwright().
+    start()`` raises), the failure is caught and surfaced as rc 1 rather
+    than propagating into the CLI."""
+    import playwright.sync_api as pw_api
 
-    result = auth._patchright_cookies_db()
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(auth, "_browser_profile_dir", lambda: tmp_path / "profile")
 
-    assert result == profile / "Default" / "Network" / "Cookies"
-    assert result.exists()
+    class _BrokenPlaywright:
+        def start(self):
+            raise RuntimeError("playwright driver did not start")
 
+        def stop(self):  # pragma: no cover - never reached (start failed)
+            pass
 
-def test_cookies_path_falls_back_to_legacy_when_only_legacy_exists(tmp_path, monkeypatch):
-    """A user on an old Chromium version with no Network/ subdir gets the
-    legacy ``Default/Cookies`` path. Defensive fallback."""
-    from notebooklm.cli import session as nlm_session
-    profile = tmp_path / "browser_profile"
-    (profile / "Default").mkdir(parents=True)
-    (profile / "Default" / "Cookies").write_bytes(b"legacy")
-    monkeypatch.setattr(nlm_session, "get_browser_profile_dir", lambda: profile)
+    monkeypatch.setattr(pw_api, "sync_playwright", lambda: _BrokenPlaywright())
 
-    result = auth._patchright_cookies_db()
+    rc = _login_with_auto_detect(state_file, wait_timeout=30)
 
-    assert result == profile / "Default" / "Cookies"
-
-
-def test_cookies_path_returns_modern_path_when_neither_exists_yet(
-    tmp_path, monkeypatch,
-) -> None:
-    """At browser startup neither path exists yet. Return the modern
-    path so the next poll iteration finds it the moment chromium writes
-    it (which it will, in the modern location)."""
-    from notebooklm.cli import session as nlm_session
-    profile = tmp_path / "browser_profile"
-    monkeypatch.setattr(nlm_session, "get_browser_profile_dir", lambda: profile)
-
-    result = auth._patchright_cookies_db()
-
-    assert result == profile / "Default" / "Network" / "Cookies"
-    assert not result.exists()    # neither path materialised yet
-
-
-def test_stale_cookie_pre_existing_does_not_false_trigger(tmp_path, monkeypatch):
-    """W1 (PR-D review): if the profile already has a stale
-    notebooklm.google.com cookie from a previous login (file mtime
-    pre-dates subprocess launch), the polling MUST NOT immediately
-    fire a save. Detection requires fresh writes in THIS session."""
-    db = tmp_path / "browser_profile" / "Default" / "Cookies"
-    _build_cookies_db(db, with_notebooklm=True)
-    # Backdate the mtime so the freshness check fails (no fresh writes).
-    import os
-    old = 1_000_000.0
-    os.utime(db, (old, old))
-
-    monkeypatch.setattr(auth, "_patchright_cookies_db", lambda: db)
-    proc = _FakeProc()
-    monkeypatch.setattr(auth.subprocess, "Popen", lambda *a, **k: proc)
-    # Force a quick timeout so the test doesn't actually wait.
-    seq = iter([2_000_000.0, 2_000_000.0])
-
-    def _clock():
-        try:
-            return next(seq)
-        except StopIteration:
-            return 9_999_999.0
-
-    monkeypatch.setattr(auth.time, "monotonic", _clock)
-
-    rc = _login_with_auto_detect(["x"], timeout=5, state_file=tmp_path / "s")
-
-    # The cookie IS present but the file mtime is older than our
-    # subprocess launch -> NOT a fresh sign-in -> timeout fail-closed.
-    assert rc == 124
-    assert proc.stdin.getvalue() == b""    # nothing fed -> no save
+    assert rc == 1
+    assert not state_file.exists()
 
 
 def test_dispatch_routes_to_auto_detect_when_flag_set(tmp_path, monkeypatch):
-    """`login_nlm(auto_detect=True, ...)` must dispatch to
-    `_login_with_auto_detect`, not `_login_with_wait_file` or a plain
-    `subprocess.run`. Anti-regression for the dispatch precedence."""
+    """``login_nlm(auto_detect=True, ...)`` must dispatch to
+    ``_login_with_auto_detect`` (with the new 2-arg signature), not to
+    ``_login_with_wait_file`` or a plain ``subprocess.run``."""
+    import subprocess
+
     called = {"wait_file": False, "auto_detect": False, "run": False}
+    captured: dict = {}
 
     def fake_run(*a, **k):
         called["run"] = True
@@ -313,8 +316,9 @@ def test_dispatch_routes_to_auto_detect_when_flag_set(tmp_path, monkeypatch):
         called["wait_file"] = True
         return 0
 
-    def fake_auto_detect(*a, **k):
+    def fake_auto_detect(state_file, wait_timeout):
         called["auto_detect"] = True
+        captured["args"] = (state_file, wait_timeout)
         return 0
 
     monkeypatch.setattr(auth.subprocess, "run", fake_run)
@@ -327,9 +331,12 @@ def test_dispatch_routes_to_auto_detect_when_flag_set(tmp_path, monkeypatch):
         tmp_path / "session_dir",
         state_file=state,
         auto_detect=True,
+        wait_timeout=600,
     )
 
     assert rc == 0
     assert called["auto_detect"] is True
     assert called["wait_file"] is False
     assert called["run"] is False
+    # Dispatched with the storage-state target and the timeout, no `cmd`.
+    assert captured["args"] == (state, 600)


### PR DESCRIPTION
## Problem

`research-hub notebooklm login --auto-detect` never completed. It shelled
out to the upstream `notebooklm login` subprocess and polled the patchright
Chromium profile's **on-disk** Cookies SQLite for a `notebooklm.google.com`
row. Chromium buffers cookies in memory and flushes them to that SQLite
store only on a lazy timer — so a freshly-signed-in session stayed
invisible on disk for minutes, the poll loop always hit its timeout, and
the save never fired. Every `--auto-detect` run ended in a fail-closed
timeout no matter how the user signed in.

Diagnostic on a real stuck session: the user was fully signed in (NotebookLM
homepage loaded in the browser) yet every cookie in the profile's on-disk
SQLite was 347 minutes stale.

## Fix

`--auto-detect` now drives the Chromium browser **directly** via Playwright
(same stealth flags the SDK uses for its own `login`:
`--disable-blink-features=AutomationControlled`, `--password-store=basic`,
`ignore_default_args=[--enable-automation]`), navigates to NotebookLM, and
polls the **live `page.url`**. The moment the URL settles on the
`notebooklm.google.com` host — and holds there for 3 consecutive polls,
guarding against a mid-redirect flash — it runs the SDK's post-login
double-navigation (forces regional `.google.com` cookies) and captures
`context.storage_state()` straight from the live browser context.

No terminal ENTER, no subprocess, no on-disk cookie race.

**Fail-closed throughout:** timeout (rc 124), browser-launch error (rc 1),
and Playwright driver-start failure (rc 1) all return non-zero without
saving and never raise into the CLI; the driver is always stopped in a
`finally`.

## Changes

- Rewrote `_login_with_auto_detect` — live `page.url` poll, signature
  `(state_file, wait_timeout)`.
- Added `_browser_profile_dir`, `_playwright_event_loop` (Windows
  event-loop policy swap, mirrors the SDK's private helper),
  `_is_on_notebooklm_homepage`.
- Removed dead disk-polling helpers (`_patchright_cookies_db`,
  `_has_notebooklm_cookie`, `_cookies_db_modified_since`) + unused
  `import sqlite3`.
- `login_nlm` dispatch: `cmd` built only for the non-auto-detect paths.
- Test file rewritten for the new mechanism — 12 tests, mocked Playwright
  (homepage-reached saves; transient flash does NOT save; timeout
  fail-closed; launch error; driver-start failure; dispatch routing).

## Verification

- 12/12 in `test_v1_nlm_login_auto_detect.py`
- 287 passed, 0 failed across all NLM/auth/login/keepalive/preflight tests
- code-review skill: APPROVE (the one P2 — uncaught driver-start failure —
  was fixed before commit; `sync_playwright().start()` now runs inside the
  try)

🤖 Generated with [Claude Code](https://claude.com/claude-code)