### PR TITLE
fix(skill): gap-to-topic §1 .bib built from search --json, not cite

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **`gap-to-topic` §1 `.bib` instruction was unworkable** (`skills/gap-to-topic/`,
+  plugin `0.3.0 → 0.3.1`).  SKILL.md §1 step 2 and `references/dossier-template.md`
+  told the skill to emit the §1 reference list via `cite --format bibtex`, but
+  `cite` resolves identifiers only against an already-ingested Zotero library —
+  at topic-selection time the candidate papers are not ingested, so `cite`
+  returns "Could not resolve identifier" for every §1 DOI.  Surfaced by the
+  2026-05-21 dogfood run.  The `.bib` is now built from the
+  `search --adversarial --json` metadata, which the skill already has in hand
+  at §1.  Mirrored to `src/research_hub/skills_data/gap-to-topic/`; plugin
+  version bumped so the marketplace cache invalidates.
+
 - **`probe_cleared_failed_no_abstract` URL quality signal now triggers text
   fallback in the NLM bundle builder** (`notebooklm/bundle.py`).  Springer /
   Wiley paywall skeleton pages return HTTP 200 with no body; the URL quality

--- a/skills/gap-to-topic/SKILL.md
+++ b/skills/gap-to-topic/SKILL.md
@@ -64,10 +64,14 @@ In priority order:
 4. The user's free-text answers during the §0 and §3 conversational steps.
 
 This skill orchestrates other research-hub capabilities as tools:
-`search --adversarial` (§1 recall), `cite --format bibtex` (§1 `.bib`),
-and `literature-triage-matrix` (§0/§1 prior art). `paper gaps` is used
-only when a relevant ingested cluster already exists — at topic-selection
-time it usually does not, so `literature-triage-matrix` is the default.
+`search --adversarial --json` (§1 recall + the metadata the `.bib` is
+built from) and `literature-triage-matrix` (§0/§1 prior art). `paper gaps`
+is used only when a relevant ingested cluster already exists — at
+topic-selection time it usually does not, so `literature-triage-matrix`
+is the default. Note: `cite --format bibtex` is **not** used for the §1
+`.bib` — it resolves identifiers only against an already-ingested Zotero
+library, and at topic-selection time the candidate papers are not
+ingested (see §1 step 2).
 
 ## Workflow
 
@@ -91,13 +95,19 @@ gate runs per gap.
 Incomplete recall is the dominant failure mode: a missed paper makes a gap
 look open when it is not. So this gate is **adversarial**:
 
-1. Run `research-hub search --adversarial` on the gap — it searches several
-   query phrasings and reports a recall-confidence verdict. If `--adversarial`
-   is unavailable (older CLI), run several query phrasings by hand and record
-   the reduced recall confidence in the dossier.
-2. Emit the **complete reference list** (real DOIs / arXiv IDs) as the
-   `.bib` companion via `cite --format bibtex` — this is the trust artifact;
-   the researcher must be able to verify "open" themselves.
+1. Run `research-hub search --adversarial --json` on the gap — it searches
+   several query phrasings, reports a recall-confidence verdict, and emits
+   full per-paper metadata (title, DOI / arXiv ID, year, authors, venue).
+   If `--adversarial` is unavailable (older CLI), run several query
+   phrasings by hand and record the reduced recall confidence in the dossier.
+2. Build the **complete reference list** (real DOIs / arXiv IDs) as the
+   `.bib` companion **from the `search --json` metadata** — this is the
+   trust artifact; the researcher must be able to verify "open" themselves.
+   Do **not** use `cite --format bibtex` here: `cite` resolves identifiers
+   only against an already-ingested Zotero library, and at topic-selection
+   time the candidate papers are not ingested. Every entry must carry a
+   resolvable DOI or arXiv ID; drop any paper whose identifier did not
+   resolve (an unverifiable reference is not a trust artifact).
 3. Record the recall-confidence verdict as a **headline**, not a footnote.
 
 A gap is never declared "open" on the basis of "absent from my corpus" —

--- a/skills/gap-to-topic/references/dossier-template.md
+++ b/skills/gap-to-topic/references/dossier-template.md
@@ -12,7 +12,7 @@
 |---|---|
 | Area | <the research area> |
 | Compiled | <YYYY-MM-DD> |
-| Pipeline | research-hub: `search --adversarial` → `cite` → gap-to-topic gates |
+| Pipeline | research-hub: `search --adversarial --json` → gap-to-topic gates |
 | Verdict grade | Screening-grade — assembles evidence; does NOT decide worth |
 
 ## §0 — Candidate breakthrough point(s)
@@ -32,7 +32,7 @@
 > "open". The recall verdict is a headline, not a footnote.*
 
 - **Recall verdict:** <high / medium / low> — <N query phrasings searched,
-  M unique papers; from `search --adversarial`>
+  M unique papers; from `search --adversarial --json`>
 - **Closest prior work:** <papers that bear on whether the gap is filled>
 - **Per-gap openness:** [G1] open / partially-occupied / occupied — ...
 
@@ -75,9 +75,10 @@ any gate failing is a no-go.
 ### `<dossier>.bib`
 
 The §1 reference list as BibTeX — the trust artifact that lets the
-researcher verify "open" independently. Generated via
-`research-hub cite --format bibtex`. Every entry must have a resolvable
-DOI or arXiv ID.
+researcher verify "open" independently. Built from the
+`search --adversarial --json` metadata (NOT from `cite --format bibtex`,
+which resolves only already-ingested Zotero items — see SKILL.md §1
+step 2). Every entry must have a resolvable DOI or arXiv ID.
 
 ### `<dossier>.gaps.yml`
 

--- a/src/research_hub/skills_data/gap-to-topic/SKILL.md
+++ b/src/research_hub/skills_data/gap-to-topic/SKILL.md
@@ -64,10 +64,14 @@ In priority order:
 4. The user's free-text answers during the §0 and §3 conversational steps.
 
 This skill orchestrates other research-hub capabilities as tools:
-`search --adversarial` (§1 recall), `cite --format bibtex` (§1 `.bib`),
-and `literature-triage-matrix` (§0/§1 prior art). `paper gaps` is used
-only when a relevant ingested cluster already exists — at topic-selection
-time it usually does not, so `literature-triage-matrix` is the default.
+`search --adversarial --json` (§1 recall + the metadata the `.bib` is
+built from) and `literature-triage-matrix` (§0/§1 prior art). `paper gaps`
+is used only when a relevant ingested cluster already exists — at
+topic-selection time it usually does not, so `literature-triage-matrix`
+is the default. Note: `cite --format bibtex` is **not** used for the §1
+`.bib` — it resolves identifiers only against an already-ingested Zotero
+library, and at topic-selection time the candidate papers are not
+ingested (see §1 step 2).
 
 ## Workflow
 
@@ -91,13 +95,19 @@ gate runs per gap.
 Incomplete recall is the dominant failure mode: a missed paper makes a gap
 look open when it is not. So this gate is **adversarial**:
 
-1. Run `research-hub search --adversarial` on the gap — it searches several
-   query phrasings and reports a recall-confidence verdict. If `--adversarial`
-   is unavailable (older CLI), run several query phrasings by hand and record
-   the reduced recall confidence in the dossier.
-2. Emit the **complete reference list** (real DOIs / arXiv IDs) as the
-   `.bib` companion via `cite --format bibtex` — this is the trust artifact;
-   the researcher must be able to verify "open" themselves.
+1. Run `research-hub search --adversarial --json` on the gap — it searches
+   several query phrasings, reports a recall-confidence verdict, and emits
+   full per-paper metadata (title, DOI / arXiv ID, year, authors, venue).
+   If `--adversarial` is unavailable (older CLI), run several query
+   phrasings by hand and record the reduced recall confidence in the dossier.
+2. Build the **complete reference list** (real DOIs / arXiv IDs) as the
+   `.bib` companion **from the `search --json` metadata** — this is the
+   trust artifact; the researcher must be able to verify "open" themselves.
+   Do **not** use `cite --format bibtex` here: `cite` resolves identifiers
+   only against an already-ingested Zotero library, and at topic-selection
+   time the candidate papers are not ingested. Every entry must carry a
+   resolvable DOI or arXiv ID; drop any paper whose identifier did not
+   resolve (an unverifiable reference is not a trust artifact).
 3. Record the recall-confidence verdict as a **headline**, not a footnote.
 
 A gap is never declared "open" on the basis of "absent from my corpus" —

--- a/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
+++ b/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
@@ -12,7 +12,7 @@
 |---|---|
 | Area | <the research area> |
 | Compiled | <YYYY-MM-DD> |
-| Pipeline | research-hub: `search --adversarial` → `cite` → gap-to-topic gates |
+| Pipeline | research-hub: `search --adversarial --json` → gap-to-topic gates |
 | Verdict grade | Screening-grade — assembles evidence; does NOT decide worth |
 
 ## §0 — Candidate breakthrough point(s)
@@ -32,7 +32,7 @@
 > "open". The recall verdict is a headline, not a footnote.*
 
 - **Recall verdict:** <high / medium / low> — <N query phrasings searched,
-  M unique papers; from `search --adversarial`>
+  M unique papers; from `search --adversarial --json`>
 - **Closest prior work:** <papers that bear on whether the gap is filled>
 - **Per-gap openness:** [G1] open / partially-occupied / occupied — ...
 
@@ -75,9 +75,10 @@ any gate failing is a no-go.
 ### `<dossier>.bib`
 
 The §1 reference list as BibTeX — the trust artifact that lets the
-researcher verify "open" independently. Generated via
-`research-hub cite --format bibtex`. Every entry must have a resolvable
-DOI or arXiv ID.
+researcher verify "open" independently. Built from the
+`search --adversarial --json` metadata (NOT from `cite --format bibtex`,
+which resolves only already-ingested Zotero items — see SKILL.md §1
+step 2). Every entry must have a resolvable DOI or arXiv ID.
 
 ### `<dossier>.gaps.yml`
 


### PR DESCRIPTION
## Problem

The 2026-05-21 `gap-to-topic` dogfood run found the skill's §1 instruction unworkable. SKILL.md §1 step 2 and `references/dossier-template.md` told the skill to emit the §1 reference `.bib` via `research-hub cite --format bibtex` — but `cite` resolves identifiers only against an **already-ingested** Zotero library. At topic-selection time the candidate papers are not ingested, so `cite` returns `Could not resolve identifier` for every §1 DOI. The §1 trust artifact could never be produced as documented.

## Fix

Build the §1 `.bib` from the `search --adversarial --json` metadata (title / DOI / arXiv ID / year / authors / venue), which the skill already has in hand at §1. No code path changed — doc-only.

- `skills/gap-to-topic/SKILL.md` — §1 step 1–2 rewritten; tools paragraph updated; explicit "do NOT use `cite` here" note + reason.
- `skills/gap-to-topic/references/dossier-template.md` — pipeline line + companion-file note + recall-verdict placeholder.
- Mirrored byte-identical to `src/research_hub/skills_data/gap-to-topic/`.
- `.claude-plugin/plugin.json` `0.3.0 → 0.3.1` (skill-version-guard CI requires a bump for any `skills/` change so the marketplace cache invalidates).
- `CHANGELOG.md` `[Unreleased]` entry.

## Verification

- `tests/test_v068_3_version_sync.py` — 3 passed (skills/ ↔ skills_data/ byte-parity + skill-dir-name invariant).
- 124 skill/version/plugin tests passed.
- Independent `code-reviewer` → **APPROVE** (parity clean, no surviving prescriptive `cite` instruction, version bump consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)