### PR TITLE
fix(skill): gap-to-topic §1 — make literature-triage-matrix a real step

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **`gap-to-topic` §1 named `literature-triage-matrix` as the default
+  prior-art tool but no step produced its matrix** (`skills/gap-to-topic/`,
+  plugin `0.3.1 → 0.3.2`).  The SKILL.md "orchestrates" paragraph + `Inputs`
+  + the §2 component input-contracts all referenced
+  `.research/literature_matrix.md` as an available input, yet the §1
+  numbered procedure only ran `search` — so an agent following §1 literally
+  never built the matrix (a "phantom input"; surfaced by a 2026-05-21
+  workflow audit).  §1 now has an explicit step 2 that feeds the
+  `search --adversarial --json` results to `literature-triage-matrix` to
+  produce the matrix; `.bib` and recall are renumbered to steps 3-4.
+  `references/dossier-template.md` Pipeline line updated.  Mirrored to
+  `src/research_hub/skills_data/gap-to-topic/`.
 - **`gap-to-topic` §1 `.bib` instruction was unworkable** (`skills/gap-to-topic/`,
   plugin `0.3.0 → 0.3.1`).  SKILL.md §1 step 2 and `references/dossier-template.md`
   told the skill to emit the §1 reference list via `cite --format bibtex`, but

--- a/skills/gap-to-topic/SKILL.md
+++ b/skills/gap-to-topic/SKILL.md
@@ -58,20 +58,22 @@ no-go. The dossier is a thinking tool, not a polished report.
 In priority order:
 
 1. A research area or a candidate idea, stated by the user in conversation.
-2. `.research/literature_matrix.md` if it exists — prior-art context.
+2. `.research/literature_matrix.md` — produced in §1 step 2, or reused
+   (appended to) if an earlier run already wrote one.
 3. `.research/claims.yml` if it exists — only when the user is *also*
    drafting a manuscript; its `status: gap` claims cross-link to §2.
 4. The user's free-text answers during the §0 and §3 conversational steps.
 
 This skill orchestrates other research-hub capabilities as tools:
-`search --adversarial --json` (§1 recall + the metadata the `.bib` is
-built from) and `literature-triage-matrix` (§0/§1 prior art). `paper gaps`
+`search --adversarial --json` (§1 step 1 — recall + the metadata the
+`.bib` is built from) and `literature-triage-matrix` (§1 step 2 — turns
+the search results into the prior-art comparison matrix). `paper gaps`
 is used only when a relevant ingested cluster already exists — at
-topic-selection time it usually does not, so `literature-triage-matrix`
-is the default. Note: `cite --format bibtex` is **not** used for the §1
-`.bib` — it resolves identifiers only against an already-ingested Zotero
-library, and at topic-selection time the candidate papers are not
-ingested (see §1 step 2).
+topic-selection time it usually does not, so the
+`search` → `literature-triage-matrix` path is the default. Note:
+`cite --format bibtex` is **not** used for the §1 `.bib` — it resolves
+identifiers only against an already-ingested Zotero library, and at
+topic-selection time the candidate papers are not ingested (see §1 step 3).
 
 ## Workflow
 
@@ -100,7 +102,17 @@ look open when it is not. So this gate is **adversarial**:
    full per-paper metadata (title, DOI / arXiv ID, year, authors, venue).
    If `--adversarial` is unavailable (older CLI), run several query
    phrasings by hand and record the reduced recall confidence in the dossier.
-2. Build the **complete reference list** (real DOIs / arXiv IDs) as the
+2. Feed the retrieved papers to `literature-triage-matrix` (as its
+   input #0 — a Markdown list of titles + DOIs / arXiv IDs) to produce
+   `.research/literature_matrix.md`: the structured prior-art comparison
+   (per paper — method, main claim, evidence, limitation, relevance).
+   This matrix is a **real workflow output** — it is what the openness
+   judgement in step 4 and the §2 gates read, not an assumed
+   pre-existing input. If a `literature_matrix.md` from an earlier run
+   exists, `literature-triage-matrix` appends to it; if the skill is
+   unavailable, reason directly over the `search --json` results and
+   record the reduced structure in the dossier.
+3. Build the **complete reference list** (real DOIs / arXiv IDs) as the
    `.bib` companion **from the `search --json` metadata** — this is the
    trust artifact; the researcher must be able to verify "open" themselves.
    Do **not** use `cite --format bibtex` here: `cite` resolves identifiers
@@ -108,7 +120,8 @@ look open when it is not. So this gate is **adversarial**:
    time the candidate papers are not ingested. Every entry must carry a
    resolvable DOI or arXiv ID; drop any paper whose identifier did not
    resolve (an unverifiable reference is not a trust artifact).
-3. Record the recall-confidence verdict as a **headline**, not a footnote.
+4. Record the recall-confidence verdict as a **headline**, not a footnote,
+   and reason the per-gap openness over the step-2 matrix.
 
 A gap is never declared "open" on the basis of "absent from my corpus" —
 absence in a corpus is not absence in the literature.

--- a/skills/gap-to-topic/references/dossier-template.md
+++ b/skills/gap-to-topic/references/dossier-template.md
@@ -12,7 +12,7 @@
 |---|---|
 | Area | <the research area> |
 | Compiled | <YYYY-MM-DD> |
-| Pipeline | research-hub: `search --adversarial --json` → gap-to-topic gates |
+| Pipeline | research-hub: `search --adversarial --json` → `literature-triage-matrix` → gap-to-topic gates |
 | Verdict grade | Screening-grade — assembles evidence; does NOT decide worth |
 
 ## §0 — Candidate breakthrough point(s)
@@ -78,7 +78,7 @@ The §1 reference list as BibTeX — the trust artifact that lets the
 researcher verify "open" independently. Built from the
 `search --adversarial --json` metadata (NOT from `cite --format bibtex`,
 which resolves only already-ingested Zotero items — see SKILL.md §1
-step 2). Every entry must have a resolvable DOI or arXiv ID.
+step 3). Every entry must have a resolvable DOI or arXiv ID.
 
 ### `<dossier>.gaps.yml`
 

--- a/src/research_hub/skills_data/gap-to-topic/SKILL.md
+++ b/src/research_hub/skills_data/gap-to-topic/SKILL.md
@@ -58,20 +58,22 @@ no-go. The dossier is a thinking tool, not a polished report.
 In priority order:
 
 1. A research area or a candidate idea, stated by the user in conversation.
-2. `.research/literature_matrix.md` if it exists — prior-art context.
+2. `.research/literature_matrix.md` — produced in §1 step 2, or reused
+   (appended to) if an earlier run already wrote one.
 3. `.research/claims.yml` if it exists — only when the user is *also*
    drafting a manuscript; its `status: gap` claims cross-link to §2.
 4. The user's free-text answers during the §0 and §3 conversational steps.
 
 This skill orchestrates other research-hub capabilities as tools:
-`search --adversarial --json` (§1 recall + the metadata the `.bib` is
-built from) and `literature-triage-matrix` (§0/§1 prior art). `paper gaps`
+`search --adversarial --json` (§1 step 1 — recall + the metadata the
+`.bib` is built from) and `literature-triage-matrix` (§1 step 2 — turns
+the search results into the prior-art comparison matrix). `paper gaps`
 is used only when a relevant ingested cluster already exists — at
-topic-selection time it usually does not, so `literature-triage-matrix`
-is the default. Note: `cite --format bibtex` is **not** used for the §1
-`.bib` — it resolves identifiers only against an already-ingested Zotero
-library, and at topic-selection time the candidate papers are not
-ingested (see §1 step 2).
+topic-selection time it usually does not, so the
+`search` → `literature-triage-matrix` path is the default. Note:
+`cite --format bibtex` is **not** used for the §1 `.bib` — it resolves
+identifiers only against an already-ingested Zotero library, and at
+topic-selection time the candidate papers are not ingested (see §1 step 3).
 
 ## Workflow
 
@@ -100,7 +102,17 @@ look open when it is not. So this gate is **adversarial**:
    full per-paper metadata (title, DOI / arXiv ID, year, authors, venue).
    If `--adversarial` is unavailable (older CLI), run several query
    phrasings by hand and record the reduced recall confidence in the dossier.
-2. Build the **complete reference list** (real DOIs / arXiv IDs) as the
+2. Feed the retrieved papers to `literature-triage-matrix` (as its
+   input #0 — a Markdown list of titles + DOIs / arXiv IDs) to produce
+   `.research/literature_matrix.md`: the structured prior-art comparison
+   (per paper — method, main claim, evidence, limitation, relevance).
+   This matrix is a **real workflow output** — it is what the openness
+   judgement in step 4 and the §2 gates read, not an assumed
+   pre-existing input. If a `literature_matrix.md` from an earlier run
+   exists, `literature-triage-matrix` appends to it; if the skill is
+   unavailable, reason directly over the `search --json` results and
+   record the reduced structure in the dossier.
+3. Build the **complete reference list** (real DOIs / arXiv IDs) as the
    `.bib` companion **from the `search --json` metadata** — this is the
    trust artifact; the researcher must be able to verify "open" themselves.
    Do **not** use `cite --format bibtex` here: `cite` resolves identifiers
@@ -108,7 +120,8 @@ look open when it is not. So this gate is **adversarial**:
    time the candidate papers are not ingested. Every entry must carry a
    resolvable DOI or arXiv ID; drop any paper whose identifier did not
    resolve (an unverifiable reference is not a trust artifact).
-3. Record the recall-confidence verdict as a **headline**, not a footnote.
+4. Record the recall-confidence verdict as a **headline**, not a footnote,
+   and reason the per-gap openness over the step-2 matrix.
 
 A gap is never declared "open" on the basis of "absent from my corpus" —
 absence in a corpus is not absence in the literature.

--- a/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
+++ b/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
@@ -12,7 +12,7 @@
 |---|---|
 | Area | <the research area> |
 | Compiled | <YYYY-MM-DD> |
-| Pipeline | research-hub: `search --adversarial --json` → gap-to-topic gates |
+| Pipeline | research-hub: `search --adversarial --json` → `literature-triage-matrix` → gap-to-topic gates |
 | Verdict grade | Screening-grade — assembles evidence; does NOT decide worth |
 
 ## §0 — Candidate breakthrough point(s)
@@ -78,7 +78,7 @@ The §1 reference list as BibTeX — the trust artifact that lets the
 researcher verify "open" independently. Built from the
 `search --adversarial --json` metadata (NOT from `cite --format bibtex`,
 which resolves only already-ingested Zotero items — see SKILL.md §1
-step 2). Every entry must have a resolvable DOI or arXiv ID.
+step 3). Every entry must have a resolvable DOI or arXiv ID.
 
 ### `<dossier>.gaps.yml`
 


### PR DESCRIPTION
## Problem

A workflow audit (2026-05-21) found a **phantom input** in the `gap-to-topic` skill. Three places — the SKILL.md "orchestrates" paragraph, the `Inputs` list, and the §2 component input-contracts (`dead-end-history.md` / `contribution-typing.md`) — all referenced `.research/literature_matrix.md` (the output of `literature-triage-matrix`) as an available input. But the §1 numbered procedure only ran `search`. An agent following §1 literally never built the matrix, yet the prose called `literature-triage-matrix` "the default" §0/§1 prior-art tool.

## Fix (option A — make it a real step)

- **§1 gains an explicit step 2** — feed the `search --adversarial --json` results to `literature-triage-matrix` (its input #0, a Markdown title+DOI list) to produce `.research/literature_matrix.md`. The `.bib` and recall-verdict steps renumber to **3** and **4**.
- The "orchestrates" paragraph now describes `literature-triage-matrix` as §1 step 2; `Inputs` #2 says the matrix is produced in §1 (or reused if an earlier run wrote one).
- `references/dossier-template.md` — Pipeline line updated; the `.bib` cross-reference renumbered `step 2 → step 3`.
- Mirrored byte-identical to `src/research_hub/skills_data/gap-to-topic/`.
- `.claude-plugin/plugin.json` `0.3.1 → 0.3.2` (skill-version-guard CI).

Doc-only; no code path changed. SKILL.md 166 lines (<500 spec limit).

## Verification

- `tests/test_v068_3_version_sync.py` — 3 passed (skills/ ↔ skills_data/ byte-parity).
- Independent `code-reviewer` → found one stale `step 2` cross-reference in `dossier-template.md`; fixed (`→ step 3`), re-verified all §1 step references consistent, parity clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)