### PR TITLE
fix(nlm): auto-detect requires a Google session cookie, not just the URL

### DIFF
--- a/src/research_hub/notebooklm/auth.py
+++ b/src/research_hub/notebooklm/auth.py
@@ -224,15 +224,44 @@ def _playwright_event_loop():
 
 
 def _is_on_notebooklm_homepage(url: str) -> bool:
-    """True iff *url* is the live NotebookLM app (not a Google sign-in page).
+    """True iff *url* is on the NotebookLM host (not a Google sign-in page).
 
     While the user is signing in, ``page.url`` sits on ``accounts.google.com``
     (or a NotebookLM ``/login`` interstitial). Once authenticated the page
     settles on the ``notebooklm.google.com`` host. The ``/login`` guard
     rejects the brief interstitial NotebookLM itself serves before bouncing
     to Google.
+
+    NOTE: this URL check is necessary but NOT sufficient on its own -- a
+    fresh anonymous tab also sits on ``notebooklm.google.com`` for a moment
+    before it redirects to the sign-in page. The auto-detect loop pairs it
+    with ``_context_has_google_session`` so an unauthenticated tab is never
+    mistaken for a signed-in one.
     """
     return _NLM_HOST in url and "/login" not in url
+
+
+# Google master session cookies. Their presence in the live browser context
+# proves an authenticated sign-in completed -- an anonymous visitor to
+# notebooklm.google.com carries none of them (the pre-fix auto-detect saved
+# exactly such a 3-cookie anonymous session by trusting the URL alone).
+_SIGNED_IN_COOKIE_NAMES = frozenset({"SID", "__Secure-1PSID", "__Secure-3PSID"})
+
+
+def _context_has_google_session(context) -> bool:
+    """True iff the live browser context holds a Google master session
+    cookie -- the signal that the user has actually signed in.
+
+    Tolerant of a busy/navigating context: any error reading cookies
+    returns False so the calling loop simply polls again.
+    """
+    try:
+        return any(
+            cookie.get("name") in _SIGNED_IN_COOKIE_NAMES
+            for cookie in context.cookies()
+        )
+    except Exception:  # noqa: BLE001 - context busy/navigating -> retry next poll
+        return False
 
 
 def _login_with_auto_detect(
@@ -326,7 +355,17 @@ def _login_with_auto_detect(
                     # Page transiently unavailable (navigating); treat as
                     # "not yet on homepage" and keep polling.
                     current_url = ""
-                stable = stable + 1 if _is_on_notebooklm_homepage(current_url) else 0
+                # Two independent signals must BOTH hold before we trust the
+                # sign-in: the tab is on the NotebookLM host AND the context
+                # carries a Google session cookie. The URL alone is not
+                # enough -- a fresh anonymous tab briefly sits on
+                # notebooklm.google.com before redirecting to the sign-in
+                # page, and trusting the URL there saved an unauthenticated
+                # session.
+                signed_in = _is_on_notebooklm_homepage(
+                    current_url
+                ) and _context_has_google_session(context)
+                stable = stable + 1 if signed_in else 0
                 if stable >= stable_polls_needed:
                     # Force .google.com cookies for regional users (e.g. a
                     # TW user lands on .google.com.tw); "commit" resolves

--- a/tests/test_v1_nlm_login_auto_detect.py
+++ b/tests/test_v1_nlm_login_auto_detect.py
@@ -26,6 +26,7 @@ import pytest
 import research_hub.notebooklm.auth as auth
 from research_hub.notebooklm.auth import (
     _browser_profile_dir,
+    _context_has_google_session,
     _is_on_notebooklm_homepage,
     _login_with_auto_detect,
 )
@@ -61,13 +62,28 @@ class _FakePage:
 
 
 class _FakeContext:
-    def __init__(self, page: _FakePage):
+    """A browser context. *signed_in* controls whether ``cookies()`` reports
+    a Google master session cookie -- the signal the auto-detect loop pairs
+    with the page URL. Default True so existing success-path tests capture a
+    session; set False to simulate an unauthenticated tab."""
+
+    def __init__(self, page: _FakePage, *, signed_in: bool = True):
         self.pages = [page]
         self.storage_saved_to: str | None = None
         self.closed = False
+        self._signed_in = signed_in
 
     def new_page(self):
         return self.pages[0]
+
+    def cookies(self):
+        if self._signed_in:
+            return [
+                {"name": "SID", "value": "x", "domain": ".google.com"},
+                {"name": "__Secure-1PSID", "value": "y", "domain": ".google.com"},
+            ]
+        # Anonymous tab: notebooklm.google.com sets only analytics cookies.
+        return [{"name": "_ga", "value": "z", "domain": ".notebooklm.google.com"}]
 
     def storage_state(self, path):
         self.storage_saved_to = str(path)
@@ -168,6 +184,39 @@ def test_empty_url_is_not_homepage():
 
 
 # ---------------------------------------------------------------------------
+# _context_has_google_session -- the signed-in signal
+# ---------------------------------------------------------------------------
+
+class _CookieCtx:
+    def __init__(self, cookies, *, raises=False):
+        self._cookies = cookies
+        self._raises = raises
+
+    def cookies(self):
+        if self._raises:
+            raise RuntimeError("context busy")
+        return self._cookies
+
+
+def test_session_cookie_present_is_signed_in():
+    ctx = _CookieCtx([{"name": "SID", "value": "x"}, {"name": "_ga", "value": "y"}])
+    assert _context_has_google_session(ctx) is True
+
+
+def test_no_session_cookie_is_not_signed_in():
+    """An anonymous notebooklm.google.com tab carries only analytics
+    cookies -- no Google master session cookie."""
+    ctx = _CookieCtx([{"name": "_ga", "value": "y"}, {"name": "_gcl_au", "value": "z"}])
+    assert _context_has_google_session(ctx) is False
+
+
+def test_cookie_read_error_is_not_signed_in():
+    """A busy/navigating context that errors on cookies() is treated as
+    not-yet-signed-in so the loop simply polls again."""
+    assert _context_has_google_session(_CookieCtx([], raises=True)) is False
+
+
+# ---------------------------------------------------------------------------
 # _browser_profile_dir
 # ---------------------------------------------------------------------------
 
@@ -251,6 +300,35 @@ def test_transient_homepage_flash_does_not_trigger_premature_save(tmp_path, monk
     monkeypatch.setattr(auth.time, "monotonic", lambda: next(clock, 9_999.0))
 
     rc = _login_with_auto_detect(state_file, wait_timeout=5)
+
+    assert rc == 124
+    assert context.storage_saved_to is None
+    assert not state_file.exists()
+    assert context.closed is True
+
+
+def test_anonymous_tab_on_notebooklm_host_does_not_save(tmp_path, monkeypatch):
+    """Regression: a fresh anonymous tab sits on notebooklm.google.com for a
+    moment before redirecting to the sign-in page. The URL check alone
+    matched it and the pre-fix auto-detect saved a 3-cookie unauthenticated
+    session. Now the loop also requires a Google session cookie -- with
+    none present the save must NOT fire even though the URL looks right."""
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(auth, "_browser_profile_dir", lambda: tmp_path / "profile")
+
+    # URL is on the NotebookLM host the whole time ...
+    page = _FakePage(["https://notebooklm.google.com/"])
+    # ... but the context has NO Google session cookie (not signed in).
+    context = _FakeContext(page, signed_in=False)
+    _install_fake_playwright(monkeypatch, _FakeChromium(context))
+
+    # Clock lets the poll loop run several real iterations -- so the
+    # session-cookie check actually executes (and returns False) each
+    # pass -- before the deadline trips. (deadline = 1000 + 30 = 1030.)
+    clock = iter([1000.0, 1001.0, 1002.0, 1003.0, 1004.0, 2000.0])
+    monkeypatch.setattr(auth.time, "monotonic", lambda: next(clock, 9_999.0))
+
+    rc = _login_with_auto_detect(state_file, wait_timeout=30)
 
     assert rc == 124
     assert context.storage_saved_to is None


### PR DESCRIPTION
## Problem (regression from #74)

#74 rewrote `notebooklm login --auto-detect` to poll the live page URL.
But `_login_with_auto_detect` trusted the URL **alone** — being on the
`notebooklm.google.com` host counted as "signed in".

A fresh **anonymous** browser tab also sits on `notebooklm.google.com`
for a moment before it redirects to the Google sign-in page. The 3-poll
stability window captured that pre-redirect window and saved a 3-cookie
**unauthenticated** session (no `SID`, no `PSID`) over the user's
`state.json`. Confirmed in production: a wiped-profile `--auto-detect`
run overwrote `state.json` with 3 anonymous cookies; `check_session_health`
then failed with `Authentication expired or invalid`.

## Fix

The poll loop now requires **two independent signals** before trusting
the sign-in:

1. the tab is on the NotebookLM host (`_is_on_notebooklm_homepage`), **and**
2. the live browser context carries a Google master session cookie
   (`_context_has_google_session` — checks `context.cookies()` for
   `SID` / `__Secure-1PSID` / `__Secure-3PSID`).

An anonymous tab has none of those cookies, so it never accumulates
stable polls → fail-closed timeout, nothing saved. A genuine sign-in
sets `SID` → both signals hold → session captured.

`_context_has_google_session` swallows any cookie-read error (busy /
navigating context) and returns False, so a transient failure just
means "poll again".

## Verification

- Re-ran `--auto-detect` against a wiped profile: anonymous tab no longer
  false-triggers; after a real sign-in it captured a complete 51-cookie
  session (`SID` ✓ `PSIDRTS` ✓) and `check_session_health` → `ok: True`.
- 16/16 in `test_v1_nlm_login_auto_detect.py` — incl. 3 unit tests for
  the new helper and a regression test
  (`test_anonymous_tab_on_notebooklm_host_does_not_save`).
- code-review skill: APPROVE (one P2 — the regression test's mocked
  clock skipped the loop body — fixed before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)