### PR TITLE
fix(fit-check): BM25 + distinctive-term relevance gate (no-LLM tier)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,26 @@ graph rebuild (link out to the real tools instead)._
   notes to **Appendix B**.  SKILL.md "What it produces" + the §0 step updated
   to match; `.gaps.yml` schema gains a `name:` field.  Mirrored to
   `src/research_hub/skills_data/gap-to-topic/`.
+- **fit-check no-LLM relevance gate rewritten — it was not screening topic
+  at all** (`fit_check.py`, `auto.py`).  The old `no_llm_fit_check` gate
+  split the topic into independent unigrams (`_extract_key_terms`), scored
+  each paper by `term_overlap` (fraction of those words present), and kept
+  it if `overlap >= 0.1` — i.e. matching **1 of 5** words.  A generic
+  hydrology paper trivially matched `water`/`model`/`resources` and passed,
+  while the discriminating phrase "large language model" was destroyed; the
+  `llm-water-resources` cluster ended up **38/43 off-topic**.  The gate now
+  parses the topic into **1–3-gram terms** (phrases survive intact), scores
+  papers with a pure-Python **BM25** whose IDF is self-calibrated on the
+  candidate batch, and applies a **hard gate**: a paper is kept only if it
+  matches a *distinctive* term — one appearing in fewer than 60 % of the
+  batch.  A generic hydrology paper matches no distinctive term and is
+  rejected.  Cold-start (batch < 5 papers, or no distinctive term, or no
+  topic terms) defers — keeps all, flags `relevance_unverified` — never
+  silently auto-passes and never blanket-rejects (the gate is
+  recall-biased).  New public API: `extract_topic_terms`, `bm25_scores`,
+  `screen_relevance`.  Grounded in a research sweep of ASReview (TF-IDF +
+  Naive Bayes) and BM25 screening practice.
+
 - **`gap-to-topic` §1 named `literature-triage-matrix` as the default
   prior-art tool but no step produced its matrix** (`skills/gap-to-topic/`,
   plugin `0.3.1 → 0.3.2`).  The SKILL.md "orchestrates" paragraph + `Inputs`

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -951,13 +951,12 @@ def _run_fit_check_step(
 
     if no_llm_fit_check:
         from research_hub.fit_check import (
-            _extract_key_terms,
             _read_definition_from_overview,
-            term_overlap,
+            screen_relevance,
         )
 
         if print_progress:
-            print("[fit-check] no-llm mode: using term-overlap rule-based scoring")
+            print("[fit-check] no-llm mode: BM25 + distinctive-term relevance gate")
 
         definition = topic
         try:
@@ -966,16 +965,23 @@ def _run_fit_check_step(
                 definition = existing
         except Exception:
             pass
-        key_terms = _extract_key_terms(definition)
 
+        # BM25 over 1..3-gram topic terms, IDF self-calibrated on this
+        # batch; a paper is kept only if it matches a *distinctive* topic
+        # term (one rare within the batch). Replaces the old
+        # `term_overlap >= 0.1` gate, which kept any paper sharing one
+        # common word and let generic hydrology papers flood an LLM cluster.
+        verdicts = screen_relevance(papers, definition)
         kept: list[dict] = []
-        for paper in papers:
-            text = paper.get("abstract") or paper.get("title") or ""
-            overlap = term_overlap(text, key_terms)
-            if overlap >= 0.1:
+        for paper, verdict in zip(papers, verdicts):
+            if verdict["kept"]:
                 provenance = dict(paper.get("provenance") or {})
-                provenance["fit_score"] = overlap
-                provenance["fit_check_mode"] = "term_overlap"
+                provenance["fit_score"] = verdict["score"]
+                provenance["fit_check_mode"] = "bm25_relevance"
+                provenance["fit_check_tier"] = verdict["tier"]
+                if verdict["tier"] == "cold-start":
+                    # Kept but unscreened -- mark for later re-screening.
+                    provenance["relevance_unverified"] = True
                 paper["provenance"] = provenance
                 kept.append(paper)
                 continue
@@ -985,11 +991,15 @@ def _run_fit_check_step(
                 cluster_slug=slug,
                 layer="L4",
                 reason="low_relevance",
-                details={"fit_score": overlap, "mode": "term_overlap"},
+                details={
+                    "fit_score": verdict["score"],
+                    "mode": "bm25_relevance",
+                    "detail": verdict["reason"],
+                },
             )
         _step_log(report, "fit_check", True, _elapsed(started, report),
                   f"kept {len(kept)}/{len(papers)}; quarantined {len(papers) - len(kept)} "
-                  "(threshold=0.1, mode=term_overlap)",
+                  "(mode=bm25_relevance)",
                   print_progress)
         return kept
 

--- a/src/research_hub/fit_check.py
+++ b/src/research_hub/fit_check.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -249,6 +250,206 @@ def term_overlap_batch(
             text = str(paper)
         scores.append(term_overlap(text.strip(), key_terms))
     return scores
+
+
+# ---------------------------------------------------------------------------
+# v1.x relevance gate -- BM25 + distinctive-term hard gate
+#
+# Replaces the naive ``term_overlap >= 0.1`` no-LLM gate. That gate split the
+# topic into independent unigrams and kept any paper matching 1-of-N common
+# words, so ``llm-water-resources`` filled with generic hydrology papers
+# ("water"/"model"/"resources" matched; the discriminating phrase "large
+# language model" was destroyed). Grounded in ASReview / BM25 practice:
+#   * the topic is parsed into 1..3-gram terms so phrases survive intact;
+#   * BM25 IDF is computed from the candidate batch itself, so a term
+#     present in every candidate ("water" in an all-water batch) carries
+#     ~0 weight while a distinctive term carries high weight;
+#   * HARD GATE -- a paper must contain >=1 *distinctive* term (a topic
+#     term appearing in fewer than _DISTINCTIVE_DF_RATIO of the batch); a
+#     generic hydrology paper matches no distinctive term -> rejected;
+#   * cold-start -- if no topic term is distinctive (uniform batch) the
+#     gate cannot discriminate, so every paper is kept and flagged
+#     `relevance_unverified` (never silently auto-pass, never blanket
+#     reject -- a screening gate is recall-biased).
+# ---------------------------------------------------------------------------
+
+_BM25_K1 = 1.2
+_BM25_B = 0.75
+# A topic term is "distinctive" when it appears in fewer than this fraction
+# of the candidate batch; above it the term is batch-wide context.
+_DISTINCTIVE_DF_RATIO = 0.6
+# Below this many candidates the batch is too small for IDF to discriminate
+# reliably -- treat as cold-start and defer (keep all, flag for re-screen).
+_MIN_BATCH_FOR_GATE = 5
+_TOPIC_STOPLIST = {
+    "this", "that", "with", "from", "into", "about", "which", "their",
+    "there", "where", "these", "those", "have", "been", "will", "would",
+    "could", "should", "also", "such", "than", "using", "based", "study",
+    "approach", "research", "the", "and", "for", "are", "was", "its",
+    "use", "per", "via",
+}
+
+
+def extract_topic_terms(definition: str, max_ngram: int = 3) -> list[str]:
+    """Extract 1..*max_ngram*-gram terms from a topic definition.
+
+    Unlike :func:`_extract_key_terms` (the legacy unigram split), multi-word
+    concepts such as "large language model" survive as single terms, so a
+    distinctive phrase is not diluted into its common component words.
+    """
+    words = [
+        w.lower()
+        for w in re.findall(r"[A-Za-z][A-Za-z0-9-]*", definition)
+        if len(w) >= 3 and w.lower() not in _TOPIC_STOPLIST
+    ]
+    seen: set[str] = set()
+    terms: list[str] = []
+    for n in range(1, max_ngram + 1):
+        for i in range(len(words) - n + 1):
+            gram = " ".join(words[i : i + n])
+            if gram not in seen:
+                seen.add(gram)
+                terms.append(gram)
+    return terms
+
+
+def _count_term(text: str, term: str) -> int:
+    """Word-boundary occurrence count of *term* (a word or phrase) in *text*."""
+    if not term:
+        return 0
+    return len(re.findall(rf"\b{re.escape(term)}\b", text))
+
+
+def bm25_scores(
+    docs: list[str],
+    query_terms: list[str],
+    k1: float = _BM25_K1,
+    b: float = _BM25_B,
+) -> tuple[list[float], dict[str, int]]:
+    """BM25 score of each doc against *query_terms*.
+
+    IDF is derived from *docs* itself (self-calibrating: a term in every doc
+    gets ~0 IDF, a rare term gets high IDF). Returns ``(per-doc score,
+    document-frequency per term)``.
+    """
+    n_docs = len(docs)
+    if n_docs == 0:
+        return [], {}
+    doc_lens = [max(1, len(re.findall(r"[a-z0-9-]+", d))) for d in docs]
+    avgdl = sum(doc_lens) / n_docs
+    tf_per_doc: list[dict[str, int]] = []
+    doc_freq: dict[str, int] = {term: 0 for term in query_terms}
+    for d in docs:
+        tf = {term: _count_term(d, term) for term in query_terms}
+        tf_per_doc.append(tf)
+        for term, count in tf.items():
+            if count > 0:
+                doc_freq[term] += 1
+    idf = {
+        term: math.log(
+            1 + (n_docs - doc_freq[term] + 0.5) / (doc_freq[term] + 0.5)
+        )
+        for term in query_terms
+    }
+    scores: list[float] = []
+    for tf, dl in zip(tf_per_doc, doc_lens):
+        score = 0.0
+        for term in query_terms:
+            f = tf[term]
+            if f == 0:
+                continue
+            score += idf[term] * (f * (k1 + 1)) / (
+                f + k1 * (1 - b + b * dl / avgdl)
+            )
+        scores.append(round(score, 4))
+    return scores, doc_freq
+
+
+def screen_relevance(candidates: list[dict], definition: str) -> list[dict]:
+    """Score and gate candidate papers for topic relevance (no-LLM tier).
+
+    Returns one verdict dict per candidate, in input order::
+
+        {"kept": bool, "score": float, "tier": str, "reason": str}
+
+    A paper is kept iff it contains at least one *distinctive* topic term
+    (one appearing in fewer than ``_DISTINCTIVE_DF_RATIO`` of the batch).
+    When the topic has no distinctive term in this batch (cold-start /
+    uniform batch) every paper is kept and flagged ``relevance_unverified``.
+    """
+    n = len(candidates)
+    docs = [
+        ((c.get("abstract") or "") + " " + (c.get("title") or "")).lower()
+        for c in candidates
+    ]
+    query_terms = extract_topic_terms(definition)
+    if not query_terms or n == 0:
+        return [
+            {
+                "kept": True,
+                "score": 0.0,
+                "tier": "cold-start",
+                "reason": "relevance_unverified: topic has no usable terms",
+            }
+            for _ in range(n)
+        ]
+    if n < _MIN_BATCH_FOR_GATE:
+        # Too few candidates for batch IDF to discriminate -- defer.
+        return [
+            {
+                "kept": True,
+                "score": 0.0,
+                "tier": "cold-start",
+                "reason": (
+                    f"relevance_unverified: batch too small to screen "
+                    f"({n} < {_MIN_BATCH_FOR_GATE})"
+                ),
+            }
+            for _ in range(n)
+        ]
+
+    scores, doc_freq = bm25_scores(docs, query_terms)
+    distinctive = {
+        term
+        for term in query_terms
+        if 0 < doc_freq.get(term, 0) < _DISTINCTIVE_DF_RATIO * n
+    }
+    if not distinctive:
+        # Uniform batch -- no term discriminates. Defer; never auto-reject.
+        return [
+            {
+                "kept": True,
+                "score": scores[i],
+                "tier": "cold-start",
+                "reason": (
+                    "relevance_unverified: no distinctive topic term in batch"
+                ),
+            }
+            for i in range(n)
+        ]
+
+    verdicts: list[dict] = []
+    for i, doc in enumerate(docs):
+        hits = sorted(t for t in distinctive if _count_term(doc, t) > 0)
+        if hits:
+            verdicts.append(
+                {
+                    "kept": True,
+                    "score": scores[i],
+                    "tier": "bm25",
+                    "reason": "matched distinctive term(s): " + ", ".join(hits),
+                }
+            )
+        else:
+            verdicts.append(
+                {
+                    "kept": False,
+                    "score": scores[i],
+                    "tier": "bm25",
+                    "reason": "no distinctive topic term matched",
+                }
+            )
+    return verdicts
 
 
 def parse_nlm_off_topic(briefing_md: str) -> list[str]:

--- a/tests/test_fit_check_relevance.py
+++ b/tests/test_fit_check_relevance.py
@@ -1,0 +1,201 @@
+"""BM25 + distinctive-term relevance gate (the no-LLM fit-check tier).
+
+Regression cover for the `llm-water-resources` contamination: the legacy
+gate (`term_overlap >= 0.1` over independent unigrams) kept any paper
+sharing one common word, so a cluster named for LLMs filled 88% with
+generic hydrology papers. The new gate parses the topic into 1..3-gram
+terms and requires a paper to match a *distinctive* term -- one rare
+within the candidate batch.
+"""
+
+from __future__ import annotations
+
+from research_hub.fit_check import (
+    bm25_scores,
+    extract_topic_terms,
+    screen_relevance,
+)
+
+_TOPIC = "large language model water resources"
+
+
+# ---------------------------------------------------------------------------
+# extract_topic_terms -- phrase preservation
+# ---------------------------------------------------------------------------
+
+def test_topic_terms_keep_multiword_phrase():
+    terms = extract_topic_terms(_TOPIC)
+    # The discriminating phrase survives intact (the legacy split destroyed it).
+    assert "large language model" in terms
+    assert "water resources" in terms
+    # ...and the unigrams are still present for fallback matching.
+    assert "language" in terms
+
+
+def test_topic_terms_drop_stopwords_and_short_words():
+    terms = extract_topic_terms("a study using the large language model")
+    assert "study" not in terms          # stoplisted
+    assert "using" not in terms          # stoplisted
+    assert "the" not in terms            # stoplisted
+    assert "large language model" in terms
+
+
+def test_topic_terms_empty_definition():
+    assert extract_topic_terms("") == []
+
+
+# ---------------------------------------------------------------------------
+# bm25_scores -- IDF self-calibration
+# ---------------------------------------------------------------------------
+
+def test_bm25_distinctive_term_outweighs_common_term():
+    """A term in every doc gets ~0 IDF; a rare term gets high IDF, so the
+    doc carrying the rare term scores far higher."""
+    docs = [
+        "water water water large language model",  # has the rare phrase
+        "water water water hydrology model",
+        "water water water streamflow model",
+        "water water water irrigation model",
+    ]
+    query = ["water", "large language model"]
+    scores, doc_freq = bm25_scores(docs, query)
+    assert doc_freq["water"] == 4                  # common -> in every doc
+    assert doc_freq["large language model"] == 1   # rare -> one doc
+    assert scores[0] == max(scores)                # rare-term doc wins
+    assert scores[0] > 2 * scores[1]
+
+
+def test_bm25_empty_docs():
+    scores, doc_freq = bm25_scores([], ["term"])
+    assert scores == []
+    assert doc_freq == {}
+
+
+# ---------------------------------------------------------------------------
+# screen_relevance -- the gate
+# ---------------------------------------------------------------------------
+
+# 3 genuine LLM x water-resources papers ...
+_GENUINE = [
+    {
+        "title": "Large Language Models as Calibration Agents in Hydrological Modeling",
+        "abstract": "We employ a large language model to calibrate a "
+                    "hydrological model for streamflow in water resources.",
+    },
+    {
+        "title": "Retrieval-augmented large language model for water resources decisions",
+        "abstract": "A large language model with retrieval augmentation "
+                    "supports water resources management decisions.",
+    },
+    {
+        "title": "Evaluating large language model agents for streamflow forecasting",
+        "abstract": "Large language model agents are evaluated for streamflow "
+                    "forecasting against a hydrological model baseline.",
+    },
+]
+
+# ... and 7 generic hydrology / ML papers with NO LLM term.
+_HYDROLOGY = [
+    {
+        "title": "Assessment of JULES Land Surface Model Coupled With CaMa-Flood",
+        "abstract": "The JULES land surface model coupled with CaMa-Flood "
+                    "routing for operational streamflow across water resources.",
+    },
+    {
+        "title": "Groundwater level prediction using deep learning RNN",
+        "abstract": "A recurrent neural network predicts groundwater level "
+                    "from water resources observations with a hydrological model.",
+    },
+    {
+        "title": "Machine learning hydrological model with deep feed forward network",
+        "abstract": "A deep feed forward neural network machine learning "
+                    "hydrological model for water resources management.",
+    },
+    {
+        "title": "Flood prediction using machine learning and deep learning models",
+        "abstract": "A systematic review of machine learning and deep learning "
+                    "models for flood prediction in water resources.",
+    },
+    {
+        "title": "An irrigation decision support system for water-saving farming",
+        "abstract": "A decision support system optimises irrigation scheduling "
+                    "for water resources efficiency on farms.",
+    },
+    {
+        "title": "Reference evapotranspiration estimation with limited data",
+        "abstract": "An empirical model estimates reference evapotranspiration "
+                    "for sustainable water resources with limited data.",
+    },
+    {
+        "title": "Streamflow drought prediction with wavelet decomposition",
+        "abstract": "Integrating wavelet decomposition with a hydrological "
+                    "model improves streamflow drought prediction.",
+    },
+]
+
+
+def test_off_topic_hydrology_papers_are_rejected():
+    """The core regression: in a realistic mixed batch the pure-hydrology
+    papers (no LLM term) are REJECTED while the genuine LLM papers are
+    KEPT -- the old gate kept everything sharing 'water'/'model'."""
+    batch = _GENUINE + _HYDROLOGY        # 10 papers -> gate is active
+    verdicts = screen_relevance(batch, _TOPIC)
+
+    genuine = verdicts[: len(_GENUINE)]
+    hydrology = verdicts[len(_GENUINE):]
+
+    assert all(v["kept"] for v in genuine), "genuine LLM papers must be kept"
+    assert not any(v["kept"] for v in hydrology), "hydrology papers must be rejected"
+    # Every genuine paper outscores every hydrology paper.
+    assert min(v["score"] for v in genuine) > max(v["score"] for v in hydrology)
+    assert all(v["tier"] == "bm25" for v in verdicts)
+    assert "no distinctive topic term" in hydrology[0]["reason"]
+
+
+def test_genuine_paper_verdict_cites_matched_term():
+    batch = _GENUINE + _HYDROLOGY
+    verdicts = screen_relevance(batch, _TOPIC)
+    assert "large language model" in verdicts[0]["reason"]
+
+
+def test_small_batch_defers_not_rejects():
+    """A handful of candidates is too few for IDF to discriminate -- the
+    gate must keep them all and flag cold-start, never blanket-reject."""
+    batch = _GENUINE                     # 3 papers -> below the gate floor
+    verdicts = screen_relevance(batch, _TOPIC)
+    assert all(v["kept"] for v in verdicts)
+    assert all(v["tier"] == "cold-start" for v in verdicts)
+    assert all("relevance_unverified" in v["reason"] for v in verdicts)
+
+
+def test_uniform_batch_with_no_distinctive_term_defers():
+    """When every candidate carries the topic phrase, nothing is
+    *distinctive* within the batch -- keep all, flag cold-start, never
+    blanket-reject genuine papers."""
+    batch = [
+        {"title": f"LLM study {i}",
+         "abstract": "A large language model agent for water resources."}
+        for i in range(8)
+    ]
+    verdicts = screen_relevance(batch, _TOPIC)
+    assert all(v["kept"] for v in verdicts)
+    assert all(v["tier"] == "cold-start" for v in verdicts)
+    assert all("no distinctive topic term" in v["reason"] for v in verdicts)
+
+
+def test_empty_definition_defers_all():
+    batch = _GENUINE + _HYDROLOGY
+    verdicts = screen_relevance(batch, "")
+    assert all(v["kept"] for v in verdicts)
+    assert all(v["tier"] == "cold-start" for v in verdicts)
+
+
+def test_empty_candidate_list():
+    assert screen_relevance([], _TOPIC) == []
+
+
+def test_verdict_shape():
+    [verdict] = screen_relevance([_GENUINE[0]], "")
+    assert set(verdict) == {"kept", "score", "tier", "reason"}
+    assert isinstance(verdict["kept"], bool)
+    assert isinstance(verdict["score"], float)


### PR DESCRIPTION
## Problem

The no-LLM fit-check gate was not screening topic relevance at all.
`_run_fit_check_step` (no-LLM branch) split the topic into independent
unigrams, scored each paper by `term_overlap` (fraction of those words
present), and kept it if **`overlap >= 0.1`** — matching **1 of 5** words.

A generic hydrology paper trivially matched `water` / `model` /
`resources` and passed; the discriminating phrase "large language model"
was destroyed into unigrams. Confirmed in production: **`llm-water-resources`
ended up 38/43 off-topic** — a cluster named for LLMs filled with generic
ML / hydrology papers. The 78 "quarantined" papers were mostly just
abstract-less (`term_overlap` 0.0), not judged off-topic.

## Fix — grounded in a research sweep

Researched how ASReview (the reference active-learning screener — default
**TF-IDF + Naive Bayes**) and BM25 screening practice handle this. The gate
is rebuilt as:

- **`extract_topic_terms`** — parses the topic into **1–3-gram** terms, so
  "large language model" survives as a phrase instead of three common words.
- **`bm25_scores`** — pure-Python **BM25** (k1=1.2, b=0.75, **no new deps**);
  IDF is self-calibrated on the candidate batch, so a term present in every
  candidate ("water" in an all-water batch) carries ~0 weight and a
  distinctive term carries high weight.
- **`screen_relevance`** — HARD GATE: a paper is kept only if it matches a
  **distinctive** term (one appearing in <60 % of the batch). A generic
  hydrology paper matches no distinctive term → rejected.
- **Cold-start** (no topic terms · batch <5 · no distinctive term in batch)
  → defers: keeps all, flags `relevance_unverified`. Never silently
  auto-passes, never blanket-rejects — the gate is recall-biased.

`auto._run_fit_check_step` calls `screen_relevance`; provenance records
`fit_check_mode=bm25_relevance` + tier. The legacy `term_overlap` /
`_extract_key_terms` are **untouched** (still used by discover.py /
pipeline.py / emit_prompt).

## Verification

- `tests/test_fit_check_relevance.py` — 12 tests: phrase preservation,
  BM25 IDF self-calibration, **the off-topic hydrology paper is rejected in
  a realistic mixed batch while genuine LLM papers are kept**, small-batch
  and uniform-batch cold-start defer.
- Smoke test on a realistic batch: genuine "LLM as Calibration Agents"
  paper kept (score 7.6), 3 hydrology papers rejected (~1.2).
- Full suite: **3025 passed, 0 failed**.
- code-review skill: APPROVE (no P0/P1).

Follow-ups (separate PRs, per `.ai/PLAN_fit_check_redesign.md`): title
XML-markup sanitizer; NLM upload URL→abstract fallback; re-screen the
`llm-water-resources` cluster with this fixed gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)