### PR TITLE
fix(skill): gap-to-topic dossier — add tables for scannability

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **`gap-to-topic` dossier — added tables for scannability**
+  (`skills/gap-to-topic/`, plugin `0.3.3 → 0.3.4`).  Follow-up to the
+  reader-first redesign: the verdicts were still spread across prose bullets
+  in each gate section.  `references/dossier-template.md` now puts a
+  **Decision scorecard** table in the Bottom line (candidates × the 3 gates
+  + verdict, with a `✓`/`✗`/`~`/`—` cell convention), a **roster table** in
+  The candidates, and turns Appendix A (how it was produced) and Appendix B
+  (companion files) into tables.  Gate 1–3 bodies keep prose — the verdicts
+  now live once, in the scorecard, so the gate sections carry only the
+  evidence (no duplication).  SKILL.md "What it produces" updated.  Mirrored
+  to `src/research_hub/skills_data/gap-to-topic/`.
 - **`gap-to-topic` dossier was organised tool-first and code-first, not
   reader-first** (`skills/gap-to-topic/`, plugin `0.3.2 → 0.3.3`).  A review
   of a real dossier found it opened with a metadata table of pipeline / API

--- a/skills/gap-to-topic/SKILL.md
+++ b/skills/gap-to-topic/SKILL.md
@@ -43,8 +43,8 @@ keeps all tool / pipeline mechanics in two appendices at the end.
 
 | Section | What it covers |
 |---|---|
-| Bottom line | the answer up front — verdict per named candidate, in plain words |
-| The candidates | 1–N candidate topics, each given a readable name; opening type stated in plain words (method-limitation vs unoccupied-application) |
+| Bottom line | the answer up front — a plain-language summary plus a **Decision scorecard** table (candidates × the 3 gates + verdict) |
+| The candidates | 1–N candidate topics in a roster table, each given a readable name; opening type stated in plain words (method-limitation vs unoccupied-application) |
 | Gate 1 — Is the gap still open? | is the gap genuinely unoccupied — backed by a complete, verifiable reference list |
 | Gate 2 — Would it be a real contribution? | dead-end history + new-capability-vs-extension |
 | Gate 3 — Is it feasible? | can the data / resources be obtained in time and budget |

--- a/skills/gap-to-topic/references/dossier-template.md
+++ b/skills/gap-to-topic/references/dossier-template.md
@@ -5,11 +5,12 @@
 > is a thinking tool: surface uncertainty, do not polish it away.
 >
 > **Reader-first rules** (the dossier is for a researcher, not for the
-> pipeline): lead with the answer; name every candidate in plain words; state
-> each gate verdict in plain language *before* the evidence; keep all tool /
-> API / pipeline mechanics out of the body — they live in Appendix A. Formal
-> enum tokens (`partially-occupied`, `borderline`, …) belong in the
-> `.gaps.yml` companion, not the prose — gloss them in the body.
+> pipeline): lead with the answer; name every candidate in plain words; put
+> the gate verdicts in the **Decision scorecard** table so the whole 3-gate
+> test is scannable at a glance; keep all tool / API / pipeline mechanics out
+> of the body — they live in Appendix A. Formal enum tokens
+> (`partially-occupied`, `borderline`, …) belong in the `.gaps.yml`
+> companion, not the prose — gloss them in the body.
 
 ---
 
@@ -17,15 +18,26 @@
 
 ## Bottom line
 
-> *2–4 sentences, plain language, no jargon. What was evaluated, the verdict
-> for each named candidate (go / no-go / conditional), and the single most
-> important caveat. A reader must get the answer here without reading on.*
+> *2–4 sentences of plain-language prose — what was evaluated and the
+> verdict for each named candidate — followed by the Decision scorecard
+> table. A reader must get the whole answer here without reading on.*
 
 <e.g. "Two candidate topics were evaluated. **<Candidate 1 name>** is a
 no-go — the gap is already taken. **<Candidate 2 name>** is a conditional
-go — it is open and feasible, but rests on a medium-confidence search and
-one published caution. Whether to pursue it is your and your advisor's
-call.">
+go — open and feasible, but it rests on a medium-confidence search and one
+published caution. Whether to pursue it is your and your advisor's call.">
+
+### Decision scorecard
+
+> *Candidates × the 3 gates + the verdict. Cell convention: `✓` = passes,
+> `✗` = fails, `~` = borderline / qualified, `—` = not assessed (a
+> candidate that already failed an earlier gate). Each cell pairs the glyph
+> with one plain word. The Verdict column: No-go / Conditional go / Go.*
+
+| Candidate | Gate 1 · Open? | Gate 2 · A contribution? | Gate 3 · Feasible? | Verdict |
+|---|---|---|---|---|
+| 1 · <name> | <✓/✗/~ + word> | <✓/~/— + word> | <✓/~/✗/— + word> | **<No-go / Conditional go / Go>** |
+| 2 · <name> | … | … | … | **…** |
 
 | Field | Value |
 |---|---|
@@ -41,38 +53,33 @@ call.">
 ## The candidates
 
 > *1–N candidates, articulated WITH the researcher (Socratic — never
-> invented). Each gets a short readable NAME as its heading. State its
-> opening type in plain words: a method-limitation opening (an existing
-> method cannot do X) or an unoccupied-application opening (no one has
-> applied a capability to a domain). The machine id (`G1`, `G2`, …) is
-> noted once, parenthetically — it is a tag for the `.gaps.yml` companion,
-> not the reader's label.*
+> invented). List them in the roster table, then give a one-sentence
+> statement per candidate. Each candidate has a short readable name; the
+> machine id (`G1`, `G2`, …) is a tag for the `.gaps.yml` companion, not
+> the reader's label. Opening type: a method-limitation opening (an
+> existing method cannot do X) or an unoccupied-application opening (no one
+> has applied a capability to a domain).*
 
-### Candidate 1 — "<readable name>"
+| # | Candidate | Opening type | id |
+|---|---|---|---|
+| 1 | <readable name> | <unoccupied-application / method-limitation> opening | `G1` |
+| 2 | <readable name> | … | `G2` |
 
-<one-sentence statement of the candidate>. This is an
-<unoccupied-application opening | method-limitation opening>. *(Machine id:
-`G1`.)*
+**1 · <name>** — <one-sentence statement of the candidate>.
 
-### Candidate 2 — "<readable name>"
-
-<...>
+**2 · <name>** — <…>
 
 ## Gate 1 — Is the gap still open?
 
-> *Verdict FIRST, per candidate, in plain words. Then the evidence: the
-> closest prior work, and a one-sentence recall-confidence headline (how
-> much to trust "open"). The complete reference list is the `.bib`
-> companion; the structured comparison is `literature_matrix.md`. How the
-> search was run belongs in Appendix A, not here. "Absent from my corpus" is
-> never proof of "open".*
-
-- **Candidate 1 — <plain verdict>.** <e.g. "Occupied — the gap is already
-  taken." one-sentence why.>
-- **Candidate 2 — <plain verdict>.** <e.g. "Open, with medium confidence.">
+> *The verdict is in the Decision scorecard; this section is the EVIDENCE
+> behind it. Give the closest prior work (readable prose, real citations —
+> full list in the `.bib`), and a one-sentence recall-confidence headline
+> (how much to trust "open"). How the search was run belongs in Appendix A.
+> "Absent from my corpus" is never proof of "open".*
 
 **Closest prior work:** <the papers that bear on whether each gap is filled
-— readable prose, real citations; full list in the `.bib`.>
+— readable prose; full list in the `.bib`, structured comparison in
+`literature_matrix.md`.>
 
 **Recall confidence:** <one plain sentence — e.g. "Medium: one search
 backend was unavailable, so a missed paper is possible; re-check before
@@ -80,42 +87,43 @@ relying on an 'open' verdict.">
 
 ## Gate 2 — Would it be a real contribution?
 
-> *Per candidate, two plain-language questions. (1) Has the field already
-> tried this and hit a wall? — a gap can be open because the field gave up.
+> *The scorecard carries the verdict; here is the reasoning. Per assessed
+> candidate, two plain-language questions. (1) Has the field already tried
+> this and hit a wall? — a gap can be open because the field gave up.
 > (2) Would this be a new capability, or an extension of existing work? —
 > a descriptive lens, NOT a quality judgment; an extension can be well worth
-> doing. Gloss any verdict in plain words; the formal token goes to
-> `.gaps.yml`. A candidate that already failed Gate 1 is not assessed here.*
+> doing. A candidate that failed Gate 1 is not assessed here.*
 
-- **Candidate <n> — has the field hit a wall here?** <plain answer +
+- **<candidate> — has the field hit a wall here?** <plain answer +
   evidence; cite the paper(s).>
-- **Candidate <n> — new capability or extension?** <plain answer +
+- **<candidate> — new capability or extension?** <plain answer +
   one-sentence justification.>
 
 ## Gate 3 — Is it feasible?
 
-> *Front-loaded: feasibility must be known BEFORE the research framework is
-> built, before money is spent. Per candidate, in plain words: what data /
-> resources are needed, are they public, what do they cost, how long to
-> obtain. End with a plain verdict (feasible / feasible with effort /
-> blocked). A candidate that failed an earlier gate is not assessed.*
+> *The scorecard carries the verdict; here is the data/resource detail.
+> Front-loaded: feasibility must be known BEFORE the research framework is
+> built. Per assessed candidate, in plain words: what is needed, is it
+> public, what does it cost, how long to obtain — and the binding
+> constraint. A candidate that failed an earlier gate is not assessed.*
 
-- **Candidate <n> — what it needs:** <data / resources — public? cost? lead
+- **<candidate> — what it needs:** <data / resources — public? cost? lead
   time?>
-- **Candidate <n> — feasibility:** <plain verdict + the binding constraint.>
+- **<candidate> — the binding constraint:** <the one item that decides the
+  timeline.>
 
 ## The decision is yours
 
 > *State explicitly that the dossier stops here. It has assembled the three
 > gate verdicts; whether a gap is WORTH doing is the researcher's and
-> advisor's call. List, per candidate, the gate outcomes and any conditions
-> the human must resolve before committing.*
+> advisor's call. Per candidate, name the outcome and the conditions the
+> human must resolve before committing.*
 
 The three gates above are assembled evidence, not a verdict. A go requires
 all three to pass (open AND a contribution AND feasible); any gate failing
 is a no-go. **Whether <Candidate N> is worth pursuing is your and your
-advisor's decision.** <Per-candidate: the gate outcomes, and the conditions
-to resolve first.>
+advisor's decision.** <Per-candidate: the outcome, and the conditions to
+resolve first.>
 
 ---
 
@@ -123,31 +131,22 @@ to resolve first.>
 
 > *All tool / pipeline / API mechanics live here, out of the reader's way.*
 
-- **Pipeline:** research-hub `search --adversarial --json` →
-  `literature-triage-matrix` → gap-to-topic gates.
-- **Recall mechanics:** <N query phrasings searched, M unique papers;
-  which backends ran; any that were rate-limited / unavailable and the
-  effect on recall confidence.>
-- **Tool / version context:** <research-hub plugin version, run date, any
-  caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall.>
+| Item | Detail |
+|---|---|
+| Pipeline | research-hub `search --adversarial --json` → `literature-triage-matrix` → gap-to-topic gates |
+| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence> |
+| Tool / version | <research-hub plugin version, run date, caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall> |
 
 ## Appendix B — Companion files
 
-### `<dossier>.bib`
-
-The Gate 1 reference list as BibTeX — the trust artifact that lets the
-researcher verify "open" independently. Built from the
-`search --adversarial --json` metadata (NOT from `cite --format bibtex`,
-which resolves only already-ingested Zotero items — see SKILL.md §1
-step 3). Every entry must have a resolvable DOI or arXiv ID.
-
-### `<dossier>.gaps.yml`
-
-Structured export of the candidates + their gate verdicts + open questions,
-so a later pass (or a downstream skill) can list every candidate and its
-standing. This file keeps the machine ids and the formal enum tokens.
+| File | What it is |
+|---|---|
+| `<dossier>.bib` | The Gate 1 reference list as BibTeX — the trust artifact that lets the researcher verify "open" independently. Built from the `search --adversarial --json` metadata (NOT from `cite --format bibtex`, which resolves only already-ingested Zotero items — see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID. |
+| `<dossier>.gaps.yml` | Structured export of the candidates + gate verdicts + open questions, so a later pass (or a downstream skill) can list every candidate and its standing. Keeps the machine ids and the formal enum tokens. Schema below. |
+| `literature_matrix.md` | The structured prior-art comparison (`literature-triage-matrix` output): one row per paper — method, claim, evidence, limitation, relevance. |
 
 ```yaml
+# <dossier>.gaps.yml
 dossier: <topic area>
 generated: "YYYY-MM-DD"
 gaps:

--- a/src/research_hub/skills_data/gap-to-topic/SKILL.md
+++ b/src/research_hub/skills_data/gap-to-topic/SKILL.md
@@ -43,8 +43,8 @@ keeps all tool / pipeline mechanics in two appendices at the end.
 
 | Section | What it covers |
 |---|---|
-| Bottom line | the answer up front — verdict per named candidate, in plain words |
-| The candidates | 1–N candidate topics, each given a readable name; opening type stated in plain words (method-limitation vs unoccupied-application) |
+| Bottom line | the answer up front — a plain-language summary plus a **Decision scorecard** table (candidates × the 3 gates + verdict) |
+| The candidates | 1–N candidate topics in a roster table, each given a readable name; opening type stated in plain words (method-limitation vs unoccupied-application) |
 | Gate 1 — Is the gap still open? | is the gap genuinely unoccupied — backed by a complete, verifiable reference list |
 | Gate 2 — Would it be a real contribution? | dead-end history + new-capability-vs-extension |
 | Gate 3 — Is it feasible? | can the data / resources be obtained in time and budget |

--- a/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
+++ b/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
@@ -5,11 +5,12 @@
 > is a thinking tool: surface uncertainty, do not polish it away.
 >
 > **Reader-first rules** (the dossier is for a researcher, not for the
-> pipeline): lead with the answer; name every candidate in plain words; state
-> each gate verdict in plain language *before* the evidence; keep all tool /
-> API / pipeline mechanics out of the body — they live in Appendix A. Formal
-> enum tokens (`partially-occupied`, `borderline`, …) belong in the
-> `.gaps.yml` companion, not the prose — gloss them in the body.
+> pipeline): lead with the answer; name every candidate in plain words; put
+> the gate verdicts in the **Decision scorecard** table so the whole 3-gate
+> test is scannable at a glance; keep all tool / API / pipeline mechanics out
+> of the body — they live in Appendix A. Formal enum tokens
+> (`partially-occupied`, `borderline`, …) belong in the `.gaps.yml`
+> companion, not the prose — gloss them in the body.
 
 ---
 
@@ -17,15 +18,26 @@
 
 ## Bottom line
 
-> *2–4 sentences, plain language, no jargon. What was evaluated, the verdict
-> for each named candidate (go / no-go / conditional), and the single most
-> important caveat. A reader must get the answer here without reading on.*
+> *2–4 sentences of plain-language prose — what was evaluated and the
+> verdict for each named candidate — followed by the Decision scorecard
+> table. A reader must get the whole answer here without reading on.*
 
 <e.g. "Two candidate topics were evaluated. **<Candidate 1 name>** is a
 no-go — the gap is already taken. **<Candidate 2 name>** is a conditional
-go — it is open and feasible, but rests on a medium-confidence search and
-one published caution. Whether to pursue it is your and your advisor's
-call.">
+go — open and feasible, but it rests on a medium-confidence search and one
+published caution. Whether to pursue it is your and your advisor's call.">
+
+### Decision scorecard
+
+> *Candidates × the 3 gates + the verdict. Cell convention: `✓` = passes,
+> `✗` = fails, `~` = borderline / qualified, `—` = not assessed (a
+> candidate that already failed an earlier gate). Each cell pairs the glyph
+> with one plain word. The Verdict column: No-go / Conditional go / Go.*
+
+| Candidate | Gate 1 · Open? | Gate 2 · A contribution? | Gate 3 · Feasible? | Verdict |
+|---|---|---|---|---|
+| 1 · <name> | <✓/✗/~ + word> | <✓/~/— + word> | <✓/~/✗/— + word> | **<No-go / Conditional go / Go>** |
+| 2 · <name> | … | … | … | **…** |
 
 | Field | Value |
 |---|---|
@@ -41,38 +53,33 @@ call.">
 ## The candidates
 
 > *1–N candidates, articulated WITH the researcher (Socratic — never
-> invented). Each gets a short readable NAME as its heading. State its
-> opening type in plain words: a method-limitation opening (an existing
-> method cannot do X) or an unoccupied-application opening (no one has
-> applied a capability to a domain). The machine id (`G1`, `G2`, …) is
-> noted once, parenthetically — it is a tag for the `.gaps.yml` companion,
-> not the reader's label.*
+> invented). List them in the roster table, then give a one-sentence
+> statement per candidate. Each candidate has a short readable name; the
+> machine id (`G1`, `G2`, …) is a tag for the `.gaps.yml` companion, not
+> the reader's label. Opening type: a method-limitation opening (an
+> existing method cannot do X) or an unoccupied-application opening (no one
+> has applied a capability to a domain).*
 
-### Candidate 1 — "<readable name>"
+| # | Candidate | Opening type | id |
+|---|---|---|---|
+| 1 | <readable name> | <unoccupied-application / method-limitation> opening | `G1` |
+| 2 | <readable name> | … | `G2` |
 
-<one-sentence statement of the candidate>. This is an
-<unoccupied-application opening | method-limitation opening>. *(Machine id:
-`G1`.)*
+**1 · <name>** — <one-sentence statement of the candidate>.
 
-### Candidate 2 — "<readable name>"
-
-<...>
+**2 · <name>** — <…>
 
 ## Gate 1 — Is the gap still open?
 
-> *Verdict FIRST, per candidate, in plain words. Then the evidence: the
-> closest prior work, and a one-sentence recall-confidence headline (how
-> much to trust "open"). The complete reference list is the `.bib`
-> companion; the structured comparison is `literature_matrix.md`. How the
-> search was run belongs in Appendix A, not here. "Absent from my corpus" is
-> never proof of "open".*
-
-- **Candidate 1 — <plain verdict>.** <e.g. "Occupied — the gap is already
-  taken." one-sentence why.>
-- **Candidate 2 — <plain verdict>.** <e.g. "Open, with medium confidence.">
+> *The verdict is in the Decision scorecard; this section is the EVIDENCE
+> behind it. Give the closest prior work (readable prose, real citations —
+> full list in the `.bib`), and a one-sentence recall-confidence headline
+> (how much to trust "open"). How the search was run belongs in Appendix A.
+> "Absent from my corpus" is never proof of "open".*
 
 **Closest prior work:** <the papers that bear on whether each gap is filled
-— readable prose, real citations; full list in the `.bib`.>
+— readable prose; full list in the `.bib`, structured comparison in
+`literature_matrix.md`.>
 
 **Recall confidence:** <one plain sentence — e.g. "Medium: one search
 backend was unavailable, so a missed paper is possible; re-check before
@@ -80,42 +87,43 @@ relying on an 'open' verdict.">
 
 ## Gate 2 — Would it be a real contribution?
 
-> *Per candidate, two plain-language questions. (1) Has the field already
-> tried this and hit a wall? — a gap can be open because the field gave up.
+> *The scorecard carries the verdict; here is the reasoning. Per assessed
+> candidate, two plain-language questions. (1) Has the field already tried
+> this and hit a wall? — a gap can be open because the field gave up.
 > (2) Would this be a new capability, or an extension of existing work? —
 > a descriptive lens, NOT a quality judgment; an extension can be well worth
-> doing. Gloss any verdict in plain words; the formal token goes to
-> `.gaps.yml`. A candidate that already failed Gate 1 is not assessed here.*
+> doing. A candidate that failed Gate 1 is not assessed here.*
 
-- **Candidate <n> — has the field hit a wall here?** <plain answer +
+- **<candidate> — has the field hit a wall here?** <plain answer +
   evidence; cite the paper(s).>
-- **Candidate <n> — new capability or extension?** <plain answer +
+- **<candidate> — new capability or extension?** <plain answer +
   one-sentence justification.>
 
 ## Gate 3 — Is it feasible?
 
-> *Front-loaded: feasibility must be known BEFORE the research framework is
-> built, before money is spent. Per candidate, in plain words: what data /
-> resources are needed, are they public, what do they cost, how long to
-> obtain. End with a plain verdict (feasible / feasible with effort /
-> blocked). A candidate that failed an earlier gate is not assessed.*
+> *The scorecard carries the verdict; here is the data/resource detail.
+> Front-loaded: feasibility must be known BEFORE the research framework is
+> built. Per assessed candidate, in plain words: what is needed, is it
+> public, what does it cost, how long to obtain — and the binding
+> constraint. A candidate that failed an earlier gate is not assessed.*
 
-- **Candidate <n> — what it needs:** <data / resources — public? cost? lead
+- **<candidate> — what it needs:** <data / resources — public? cost? lead
   time?>
-- **Candidate <n> — feasibility:** <plain verdict + the binding constraint.>
+- **<candidate> — the binding constraint:** <the one item that decides the
+  timeline.>
 
 ## The decision is yours
 
 > *State explicitly that the dossier stops here. It has assembled the three
 > gate verdicts; whether a gap is WORTH doing is the researcher's and
-> advisor's call. List, per candidate, the gate outcomes and any conditions
-> the human must resolve before committing.*
+> advisor's call. Per candidate, name the outcome and the conditions the
+> human must resolve before committing.*
 
 The three gates above are assembled evidence, not a verdict. A go requires
 all three to pass (open AND a contribution AND feasible); any gate failing
 is a no-go. **Whether <Candidate N> is worth pursuing is your and your
-advisor's decision.** <Per-candidate: the gate outcomes, and the conditions
-to resolve first.>
+advisor's decision.** <Per-candidate: the outcome, and the conditions to
+resolve first.>
 
 ---
 
@@ -123,31 +131,22 @@ to resolve first.>
 
 > *All tool / pipeline / API mechanics live here, out of the reader's way.*
 
-- **Pipeline:** research-hub `search --adversarial --json` →
-  `literature-triage-matrix` → gap-to-topic gates.
-- **Recall mechanics:** <N query phrasings searched, M unique papers;
-  which backends ran; any that were rate-limited / unavailable and the
-  effect on recall confidence.>
-- **Tool / version context:** <research-hub plugin version, run date, any
-  caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall.>
+| Item | Detail |
+|---|---|
+| Pipeline | research-hub `search --adversarial --json` → `literature-triage-matrix` → gap-to-topic gates |
+| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence> |
+| Tool / version | <research-hub plugin version, run date, caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall> |
 
 ## Appendix B — Companion files
 
-### `<dossier>.bib`
-
-The Gate 1 reference list as BibTeX — the trust artifact that lets the
-researcher verify "open" independently. Built from the
-`search --adversarial --json` metadata (NOT from `cite --format bibtex`,
-which resolves only already-ingested Zotero items — see SKILL.md §1
-step 3). Every entry must have a resolvable DOI or arXiv ID.
-
-### `<dossier>.gaps.yml`
-
-Structured export of the candidates + their gate verdicts + open questions,
-so a later pass (or a downstream skill) can list every candidate and its
-standing. This file keeps the machine ids and the formal enum tokens.
+| File | What it is |
+|---|---|
+| `<dossier>.bib` | The Gate 1 reference list as BibTeX — the trust artifact that lets the researcher verify "open" independently. Built from the `search --adversarial --json` metadata (NOT from `cite --format bibtex`, which resolves only already-ingested Zotero items — see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID. |
+| `<dossier>.gaps.yml` | Structured export of the candidates + gate verdicts + open questions, so a later pass (or a downstream skill) can list every candidate and its standing. Keeps the machine ids and the formal enum tokens. Schema below. |
+| `literature_matrix.md` | The structured prior-art comparison (`literature-triage-matrix` output): one row per paper — method, claim, evidence, limitation, relevance. |
 
 ```yaml
+# <dossier>.gaps.yml
 dossier: <topic area>
 generated: "YYYY-MM-DD"
 gaps:


### PR DESCRIPTION
## Summary

Follow-up to the reader-first redesign ([#78](https://github.com/WenyuChiou/research-hub/pull/78)). The dossier verdicts were still spread across prose bullets inside each gate section — the whole 3-gate test was not scannable at a glance.

## Changes — `references/dossier-template.md`

- **Bottom line** gains a **Decision scorecard** table — candidates × the 3 gates + verdict, with a `✓` / `✗` / `~` / `—` cell convention.
- **The candidates** gains a **roster table** (#, name, opening type, id).
- **Appendix A** (how it was produced) and **Appendix B** (companion files) become tables.
- **Gate 1–3 bodies stay prose** — the verdicts now live once, in the scorecard, so the gate sections carry only the evidence (no duplication).

`SKILL.md` "What it produces" updated. Doc-only; no code path changed. Mirrored to `src/research_hub/skills_data/gap-to-topic/`. Plugin `0.3.3 → 0.3.4`.

## Verification

- `tests/test_v068_3_version_sync.py` — 3 passed (byte-parity).
- SKILL.md 179 lines (<500 spec limit).
- Independent `code-reviewer` → **APPROVE** — all tables well-formed, section order intact, no tool/pipeline mechanics leaked into body prose, cross-references resolve, no stale `0.3.3` survivor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)