### PR TITLE
fix(fit-check): gap-split gate + plural-tolerant matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ graph rebuild (link out to the real tools instead)._
   now live once, in the scorecard, so the gate sections carry only the
   evidence (no duplication).  SKILL.md "What it produces" updated.  Mirrored
   to `src/research_hub/skills_data/gap-to-topic/`.
+- **fit-check no-LLM gate over-rejected on-topic papers** (`fit_check.py`).
+  Follow-up to the BM25 relevance gate. Two flaws surfaced on a real
+  focused-search run (an `auto` for "large language model social
+  interaction" quarantined 13/25 papers — several squarely on-topic, e.g.
+  "LLM-enabled Social Agents"):
+  (1) `_count_term` matched terms exactly, so the singular topic term
+  "large language model" never matched the plural "large language models"
+  that papers actually use — wrecking the document-frequency counts;
+  (2) the "must match a distinctive term" hard gate is wrong for a focused
+  batch — no single term is in every paper, so the gate always found some
+  rare term and rejected papers using other vocabulary ("LLM" vs "large
+  language model").
+  Fixes: `_count_term` now tolerates a regular plural (`(?:es|s)?`); and
+  the gate is rebuilt as a **bimodal-gap split** — papers are rejected only
+  when the sorted BM25 scores show a clear gap whose upper cluster
+  out-scores the lower by >= 2x (the contamination signature). A focused,
+  uniformly-relevant batch rises smoothly with no such gap and is kept
+  whole. Recall-biased: never rejects on a batch it cannot clearly split.
+
 - **`gap-to-topic` dossier was organised tool-first and code-first, not
   reader-first** (`skills/gap-to-topic/`, plugin `0.3.2 → 0.3.3`).  A review
   of a real dossier found it opened with a metadata table of pipeline / API

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -956,7 +956,7 @@ def _run_fit_check_step(
         )
 
         if print_progress:
-            print("[fit-check] no-llm mode: BM25 + distinctive-term relevance gate")
+            print("[fit-check] no-llm mode: BM25 bimodal-gap relevance gate")
 
         definition = topic
         try:
@@ -967,10 +967,11 @@ def _run_fit_check_step(
             pass
 
         # BM25 over 1..3-gram topic terms, IDF self-calibrated on this
-        # batch; a paper is kept only if it matches a *distinctive* topic
-        # term (one rare within the batch). Replaces the old
-        # `term_overlap >= 0.1` gate, which kept any paper sharing one
-        # common word and let generic hydrology papers flood an LLM cluster.
+        # batch; a paper is rejected only when the batch's scores show a
+        # clear bimodal split and the paper sits in the low cluster.
+        # Replaces the old `term_overlap >= 0.1` gate, which kept any paper
+        # sharing one common word and let generic hydrology papers flood
+        # an LLM cluster.
         verdicts = screen_relevance(papers, definition)
         kept: list[dict] = []
         for paper, verdict in zip(papers, verdicts):

--- a/src/research_hub/fit_check.py
+++ b/src/research_hub/fit_check.py
@@ -253,7 +253,7 @@ def term_overlap_batch(
 
 
 # ---------------------------------------------------------------------------
-# v1.x relevance gate -- BM25 + distinctive-term hard gate
+# v1.x relevance gate -- BM25 + bimodal-gap split
 #
 # Replaces the naive ``term_overlap >= 0.1`` no-LLM gate. That gate split the
 # topic into independent unigrams and kept any paper matching 1-of-N common
@@ -261,25 +261,37 @@ def term_overlap_batch(
 # ("water"/"model"/"resources" matched; the discriminating phrase "large
 # language model" was destroyed). Grounded in ASReview / BM25 practice:
 #   * the topic is parsed into 1..3-gram terms so phrases survive intact;
-#   * BM25 IDF is computed from the candidate batch itself, so a term
-#     present in every candidate ("water" in an all-water batch) carries
-#     ~0 weight while a distinctive term carries high weight;
-#   * HARD GATE -- a paper must contain >=1 *distinctive* term (a topic
-#     term appearing in fewer than _DISTINCTIVE_DF_RATIO of the batch); a
-#     generic hydrology paper matches no distinctive term -> rejected;
-#   * cold-start -- if no topic term is distinctive (uniform batch) the
-#     gate cannot discriminate, so every paper is kept and flagged
-#     `relevance_unverified` (never silently auto-pass, never blanket
-#     reject -- a screening gate is recall-biased).
+#   * each paper gets a BM25 score against the topic terms, IDF computed
+#     from the candidate batch itself, so a term present in every candidate
+#     ("water" in an all-water batch) carries ~0 weight while a distinctive
+#     term carries high weight;
+#   * a paper is rejected ONLY when the batch's BM25 scores show a clear
+#     bimodal split -- one large gap spanning most of the score range --
+#     and the paper sits in the low cluster. That is the contamination
+#     signature (a few on-topic papers far above many off-topic ones).
+#   * a focused search returns a smoothly-spread, all-relevant batch with
+#     no dominant gap -> nothing is rejected (kept + flagged
+#     `relevance_unverified`). Recall-biased: never blanket-reject, never
+#     reject on a batch that does not clearly separate.
+#
+# History: an earlier revision used a "must match a distinctive term" hard
+# gate. It over-rejected genuinely on-topic papers in focused-search
+# batches (where no single term is in every paper, so the gate always
+# found a "distinctive" term and rejected papers using other vocabulary --
+# e.g. "LLM" vs "large language model"). The gap-split below replaces it.
 # ---------------------------------------------------------------------------
 
 _BM25_K1 = 1.2
 _BM25_B = 0.75
-# A topic term is "distinctive" when it appears in fewer than this fraction
-# of the candidate batch; above it the term is batch-wide context.
-_DISTINCTIVE_DF_RATIO = 0.6
-# Below this many candidates the batch is too small for IDF to discriminate
-# reliably -- treat as cold-start and defer (keep all, flag for re-screen).
+# At the largest gap between consecutive sorted BM25 scores, the score
+# just ABOVE the gap must be at least this multiple of the score just
+# BELOW it for the batch to count as a real on/off-topic split. This
+# multiplicative test is scale-free -- robust to within-cluster spread,
+# unlike a fraction-of-range test. A focused, uniformly-relevant batch
+# rises smoothly (no adjacent ~2x jump) -> no split -> keep all.
+_GAP_RATIO = 2.0
+# Below this many candidates the batch is too small to read a score
+# distribution -- treat as cold-start and defer (keep all, flag).
 _MIN_BATCH_FOR_GATE = 5
 _TOPIC_STOPLIST = {
     "this", "that", "with", "from", "into", "about", "which", "their",
@@ -314,10 +326,18 @@ def extract_topic_terms(definition: str, max_ngram: int = 3) -> list[str]:
 
 
 def _count_term(text: str, term: str) -> int:
-    """Word-boundary occurrence count of *term* (a word or phrase) in *text*."""
+    """Word-boundary occurrence count of *term* (a word or phrase) in *text*.
+
+    Tolerant of a regular plural: a trailing ``s``/``es`` on the term's
+    final word is optional, so the topic term "large language model" also
+    matches "large language models" — the form papers actually use
+    ("Large Language Models (LLMs)..."). Without this, exact singular
+    matching scrambled the document-frequency counts and the
+    distinctive-term gate then rejected genuinely on-topic papers.
+    """
     if not term:
         return 0
-    return len(re.findall(rf"\b{re.escape(term)}\b", text))
+    return len(re.findall(rf"\b{re.escape(term)}(?:es|s)?\b", text))
 
 
 def bm25_scores(
@@ -365,6 +385,20 @@ def bm25_scores(
     return scores, doc_freq
 
 
+def _cold_start(n: int, reason: str, scores: list[float] | None = None) -> list[dict]:
+    """Keep-all verdict list (recall-biased defer) for a batch the gate
+    cannot screen."""
+    return [
+        {
+            "kept": True,
+            "score": (scores[i] if scores is not None else 0.0),
+            "tier": "cold-start",
+            "reason": f"relevance_unverified: {reason}",
+        }
+        for i in range(n)
+    ]
+
+
 def screen_relevance(candidates: list[dict], definition: str) -> list[dict]:
     """Score and gate candidate papers for topic relevance (no-LLM tier).
 
@@ -372,10 +406,15 @@ def screen_relevance(candidates: list[dict], definition: str) -> list[dict]:
 
         {"kept": bool, "score": float, "tier": str, "reason": str}
 
-    A paper is kept iff it contains at least one *distinctive* topic term
-    (one appearing in fewer than ``_DISTINCTIVE_DF_RATIO`` of the batch).
-    When the topic has no distinctive term in this batch (cold-start /
-    uniform batch) every paper is kept and flagged ``relevance_unverified``.
+    Each paper gets a BM25 score against the topic terms. A paper is
+    rejected ONLY when the batch's sorted scores show a clear bimodal
+    split -- a gap where the score just above it is at least ``_GAP_RATIO``
+    times the score just below it -- and the paper sits in the low cluster
+    (the contamination signature: a few on-topic papers far above many
+    off-topic ones). A focused, uniformly-relevant batch rises smoothly
+    with no such gap, so every paper is kept and flagged
+    ``relevance_unverified`` -- the gate is recall-biased and never rejects
+    on a batch it cannot clearly split.
     """
     n = len(candidates)
     docs = [
@@ -384,69 +423,60 @@ def screen_relevance(candidates: list[dict], definition: str) -> list[dict]:
     ]
     query_terms = extract_topic_terms(definition)
     if not query_terms or n == 0:
-        return [
-            {
-                "kept": True,
-                "score": 0.0,
-                "tier": "cold-start",
-                "reason": "relevance_unverified: topic has no usable terms",
-            }
-            for _ in range(n)
-        ]
+        return _cold_start(n, "topic has no usable terms")
     if n < _MIN_BATCH_FOR_GATE:
-        # Too few candidates for batch IDF to discriminate -- defer.
-        return [
-            {
-                "kept": True,
-                "score": 0.0,
-                "tier": "cold-start",
-                "reason": (
-                    f"relevance_unverified: batch too small to screen "
-                    f"({n} < {_MIN_BATCH_FOR_GATE})"
-                ),
-            }
-            for _ in range(n)
-        ]
+        return _cold_start(
+            n, f"batch too small to screen ({n} < {_MIN_BATCH_FOR_GATE})"
+        )
 
-    scores, doc_freq = bm25_scores(docs, query_terms)
-    distinctive = {
-        term
-        for term in query_terms
-        if 0 < doc_freq.get(term, 0) < _DISTINCTIVE_DF_RATIO * n
-    }
-    if not distinctive:
-        # Uniform batch -- no term discriminates. Defer; never auto-reject.
-        return [
-            {
-                "kept": True,
-                "score": scores[i],
-                "tier": "cold-start",
-                "reason": (
-                    "relevance_unverified: no distinctive topic term in batch"
-                ),
-            }
-            for i in range(n)
-        ]
+    scores, _doc_freq = bm25_scores(docs, query_terms)
+    order = sorted(range(n), key=lambda i: scores[i])
+    sorted_scores = [scores[i] for i in order]
+    if sorted_scores[-1] - sorted_scores[0] <= 0:
+        # Every paper scored identically -- no split is possible.
+        return _cold_start(n, "uniform BM25 scores -- batch not separable", scores)
 
+    # Largest gap between consecutive sorted scores.
+    _gap, gap_idx = max(
+        (sorted_scores[i + 1] - sorted_scores[i], i) for i in range(n - 1)
+    )
+    low_top = sorted_scores[gap_idx]        # highest score below the gap
+    high_bot = sorted_scores[gap_idx + 1]   # lowest score above the gap
+    # Scale-free split test: the cluster above the gap must out-score the
+    # cluster below it by at least _GAP_RATIO x. A uniformly-relevant batch
+    # rises smoothly and never clears this bar.
+    if high_bot < _GAP_RATIO * low_top:
+        return _cold_start(
+            n, "no clear relevance gap -- batch treated as on-topic", scores
+        )
+
+    # Clear bimodal split: sorted positions 0..gap_idx are the low cluster.
+    low = set(order[: gap_idx + 1])
+    cutoff = low_top
     verdicts: list[dict] = []
-    for i, doc in enumerate(docs):
-        hits = sorted(t for t in distinctive if _count_term(doc, t) > 0)
-        if hits:
-            verdicts.append(
-                {
-                    "kept": True,
-                    "score": scores[i],
-                    "tier": "bm25",
-                    "reason": "matched distinctive term(s): " + ", ".join(hits),
-                }
-            )
-        else:
+    for i in range(n):
+        if i in low:
             verdicts.append(
                 {
                     "kept": False,
                     "score": scores[i],
                     "tier": "bm25",
-                    "reason": "no distinctive topic term matched",
+                    "reason": (
+                        f"below the relevance gap (score {scores[i]:.2f} "
+                        f"<= {cutoff:.2f}; off-topic cluster)"
+                    ),
+                }
+            )
+        else:
+            verdicts.append(
+                {
+                    "kept": True,
+                    "score": scores[i],
+                    "tier": "bm25",
+                    "reason": (
+                        f"above the relevance gap (score {scores[i]:.2f} "
+                        f"> {cutoff:.2f})"
+                    ),
                 }
             )
     return verdicts

--- a/tests/test_fit_check_relevance.py
+++ b/tests/test_fit_check_relevance.py
@@ -1,11 +1,20 @@
-"""BM25 + distinctive-term relevance gate (the no-LLM fit-check tier).
+"""BM25 relevance gate (the no-LLM fit-check tier).
 
-Regression cover for the `llm-water-resources` contamination: the legacy
-gate (`term_overlap >= 0.1` over independent unigrams) kept any paper
-sharing one common word, so a cluster named for LLMs filled 88% with
-generic hydrology papers. The new gate parses the topic into 1..3-gram
-terms and requires a paper to match a *distinctive* term -- one rare
-within the candidate batch.
+History — two failure modes this gate has had to survive:
+
+  1. The legacy gate (`term_overlap >= 0.1` over independent unigrams) kept
+     any paper sharing one common word, so an LLM cluster filled 88% with
+     generic hydrology papers.
+  2. The first redesign used a "must match a distinctive term" hard gate.
+     It over-rejected genuinely on-topic papers in a focused-search batch
+     (no single term is in every paper, so the gate always found a
+     "distinctive" term and rejected papers using other vocabulary).
+
+The current gate scores every paper with BM25 (IDF self-calibrated on the
+batch) and rejects a paper ONLY when the sorted scores show a clear
+bimodal split -- a gap where the cluster above out-scores the cluster
+below by >= 2x. A focused, uniformly-relevant batch rises smoothly and is
+kept whole.
 """
 
 from __future__ import annotations
@@ -25,18 +34,16 @@ _TOPIC = "large language model water resources"
 
 def test_topic_terms_keep_multiword_phrase():
     terms = extract_topic_terms(_TOPIC)
-    # The discriminating phrase survives intact (the legacy split destroyed it).
     assert "large language model" in terms
     assert "water resources" in terms
-    # ...and the unigrams are still present for fallback matching.
     assert "language" in terms
 
 
 def test_topic_terms_drop_stopwords_and_short_words():
     terms = extract_topic_terms("a study using the large language model")
-    assert "study" not in terms          # stoplisted
-    assert "using" not in terms          # stoplisted
-    assert "the" not in terms            # stoplisted
+    assert "study" not in terms
+    assert "using" not in terms
+    assert "the" not in terms
     assert "large language model" in terms
 
 
@@ -45,24 +52,33 @@ def test_topic_terms_empty_definition():
 
 
 # ---------------------------------------------------------------------------
-# bm25_scores -- IDF self-calibration
+# bm25_scores -- IDF self-calibration + plural-tolerant matching
 # ---------------------------------------------------------------------------
 
 def test_bm25_distinctive_term_outweighs_common_term():
-    """A term in every doc gets ~0 IDF; a rare term gets high IDF, so the
-    doc carrying the rare term scores far higher."""
     docs = [
-        "water water water large language model",  # has the rare phrase
+        "water water water large language model",
         "water water water hydrology model",
         "water water water streamflow model",
         "water water water irrigation model",
     ]
-    query = ["water", "large language model"]
-    scores, doc_freq = bm25_scores(docs, query)
-    assert doc_freq["water"] == 4                  # common -> in every doc
-    assert doc_freq["large language model"] == 1   # rare -> one doc
-    assert scores[0] == max(scores)                # rare-term doc wins
+    scores, doc_freq = bm25_scores(docs, ["water", "large language model"])
+    assert doc_freq["water"] == 4
+    assert doc_freq["large language model"] == 1
+    assert scores[0] == max(scores)
     assert scores[0] > 2 * scores[1]
+
+
+def test_bm25_matches_plural_form():
+    """Papers write "Large Language Models" (plural); the singular topic
+    term must still match it, or document-frequency counts go wrong."""
+    docs = [
+        "we study large language models for tasks",   # plural
+        "a large language model is used here",        # singular
+        "hydrology and streamflow only",              # neither
+    ]
+    _scores, doc_freq = bm25_scores(docs, ["large language model"])
+    assert doc_freq["large language model"] == 2     # both plural & singular
 
 
 def test_bm25_empty_docs():
@@ -72,7 +88,7 @@ def test_bm25_empty_docs():
 
 
 # ---------------------------------------------------------------------------
-# screen_relevance -- the gate
+# screen_relevance -- the gap-split gate
 # ---------------------------------------------------------------------------
 
 # 3 genuine LLM x water-resources papers ...
@@ -83,7 +99,7 @@ _GENUINE = [
                     "hydrological model for streamflow in water resources.",
     },
     {
-        "title": "Retrieval-augmented large language model for water resources decisions",
+        "title": "Retrieval-augmented large language models for water resources decisions",
         "abstract": "A large language model with retrieval augmentation "
                     "supports water resources management decisions.",
     },
@@ -134,58 +150,61 @@ _HYDROLOGY = [
 ]
 
 
-def test_off_topic_hydrology_papers_are_rejected():
-    """The core regression: in a realistic mixed batch the pure-hydrology
-    papers (no LLM term) are REJECTED while the genuine LLM papers are
-    KEPT -- the old gate kept everything sharing 'water'/'model'."""
-    batch = _GENUINE + _HYDROLOGY        # 10 papers -> gate is active
+def test_contaminated_batch_rejects_the_off_topic_cluster():
+    """The core regression: a contaminated batch (a few LLM-water papers
+    far out-scoring many generic hydrology papers) shows a clear >=2x gap
+    -> the hydrology cluster is rejected, the LLM papers kept."""
+    batch = _GENUINE + _HYDROLOGY        # 10 papers
     verdicts = screen_relevance(batch, _TOPIC)
 
     genuine = verdicts[: len(_GENUINE)]
     hydrology = verdicts[len(_GENUINE):]
-
-    assert all(v["kept"] for v in genuine), "genuine LLM papers must be kept"
+    assert all(v["kept"] for v in genuine), "LLM-water papers must be kept"
     assert not any(v["kept"] for v in hydrology), "hydrology papers must be rejected"
-    # Every genuine paper outscores every hydrology paper.
     assert min(v["score"] for v in genuine) > max(v["score"] for v in hydrology)
     assert all(v["tier"] == "bm25" for v in verdicts)
-    assert "no distinctive topic term" in hydrology[0]["reason"]
+    assert "below the relevance gap" in hydrology[0]["reason"]
+    assert "above the relevance gap" in genuine[0]["reason"]
 
 
-def test_genuine_paper_verdict_cites_matched_term():
-    batch = _GENUINE + _HYDROLOGY
-    verdicts = screen_relevance(batch, _TOPIC)
-    assert "large language model" in verdicts[0]["reason"]
-
-
-def test_small_batch_defers_not_rejects():
-    """A handful of candidates is too few for IDF to discriminate -- the
-    gate must keep them all and flag cold-start, never blanket-reject."""
-    batch = _GENUINE                     # 3 papers -> below the gate floor
+def test_focused_uniform_batch_is_kept_whole():
+    """A focused search returns an all-relevant batch whose BM25 scores
+    rise smoothly -- no adjacent >=2x jump -- so nothing is rejected."""
+    batch = [
+        {"title": f"Large language model water resources study {i}",
+         "abstract": "A large language model applied to water resources "
+                     f"and hydrological modeling, case {i}."}
+        for i in range(8)
+    ]
     verdicts = screen_relevance(batch, _TOPIC)
     assert all(v["kept"] for v in verdicts)
     assert all(v["tier"] == "cold-start" for v in verdicts)
     assert all("relevance_unverified" in v["reason"] for v in verdicts)
 
 
-def test_uniform_batch_with_no_distinctive_term_defers():
-    """When every candidate carries the topic phrase, nothing is
-    *distinctive* within the batch -- keep all, flag cold-start, never
-    blanket-reject genuine papers."""
+def test_small_batch_defers_not_rejects():
+    """Fewer than 5 candidates is too few to read a score distribution --
+    keep all, flag cold-start, never blanket-reject."""
+    verdicts = screen_relevance(_GENUINE, _TOPIC)      # 3 papers
+    assert all(v["kept"] for v in verdicts)
+    assert all(v["tier"] == "cold-start" for v in verdicts)
+    assert all("relevance_unverified" in v["reason"] for v in verdicts)
+
+
+def test_identical_scores_batch_defers():
+    """Every candidate identical -> no gap is possible -> keep all."""
     batch = [
-        {"title": f"LLM study {i}",
-         "abstract": "A large language model agent for water resources."}
-        for i in range(8)
+        {"title": "Large language model water resources",
+         "abstract": "A large language model for water resources."}
+        for _ in range(6)
     ]
     verdicts = screen_relevance(batch, _TOPIC)
     assert all(v["kept"] for v in verdicts)
     assert all(v["tier"] == "cold-start" for v in verdicts)
-    assert all("no distinctive topic term" in v["reason"] for v in verdicts)
 
 
 def test_empty_definition_defers_all():
-    batch = _GENUINE + _HYDROLOGY
-    verdicts = screen_relevance(batch, "")
+    verdicts = screen_relevance(_GENUINE + _HYDROLOGY, "")
     assert all(v["kept"] for v in verdicts)
     assert all(v["tier"] == "cold-start" for v in verdicts)
 


### PR DESCRIPTION
## Problem (follow-up to #79)

A real focused-search run — `auto "large language model social interaction"`
— quarantined **13/25 papers** with the new BM25 fit-check gate, several
of them squarely on-topic ("LLM-enabled Social Agents" scored 0.83 yet was
rejected). Two flaws in #79's gate:

1. **`_count_term` matched terms exactly.** The singular topic term
   "large language model" never matched the plural "large language
   models" — the form papers actually use ("Large Language Models
   (LLMs)..."). This wrecked the document-frequency counts the gate
   depends on.
2. **The "must match a distinctive term" hard gate is wrong for a focused
   batch.** A focused search returns mostly-relevant results where no
   single term is in *every* paper, so the gate always found some rare
   term and rejected papers that used other vocabulary ("LLM" vs "large
   language model").

## Fix

- **`_count_term`** now tolerates a regular plural — `(?:es|s)?` on the
  term — so "large language model" matches "large language models".
- **`screen_relevance`** is rebuilt as a **bimodal-gap split**: compute
  BM25 scores, sort them, find the largest gap between consecutive scores.
  A split fires **only** when the score just above the gap is ≥ 2×
  (`_GAP_RATIO`) the score just below it — the contamination signature (a
  few on-topic papers far above many off-topic ones). This multiplicative
  test is scale-free, robust to within-cluster spread. A focused,
  uniformly-relevant batch rises smoothly with no such gap → **kept
  whole**. Cold-start (batch < 5, no topic terms, identical scores, or no
  ≥2× gap) → keep all, flag `relevance_unverified`. Recall-biased: never
  rejects a batch it cannot clearly split.

## Verification

- Contaminated batch (3 LLM-water + 7 hydrology) still splits cleanly —
  the 7 hydrology papers rejected, the 3 LLM-water kept.
- A focused all-relevant batch is kept whole (no spurious gap).
- `tests/test_fit_check_relevance.py` reworked for gap-split — 13 tests;
  fit-check suite 62 passed.
- code-review skill: APPROVE (P2 doc-staleness from the rename fixed
  before push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)