### PR TITLE
fix(skill): gap-to-topic dossier — evidence tags + upgrade/kill test

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **`gap-to-topic` dossier — evidence-strength tags + an upgrade/kill test**
+  (`skills/gap-to-topic/`, plugin `0.3.4 → 0.3.5`).  A Codex evaluation of a
+  real dossier found two gaps: (1) Gate 1 said a gap was "densely populated"
+  but the reader had to open `literature_matrix.md` to see the occupancy
+  signal was partly conference abstracts / artifacts, not primary studies;
+  (2) a "conditional go" listed open conditions but no threshold — the
+  advisor still had to supply the kill/upgrade logic.  `references/dossier-template.md`
+  now: Gate 1 tags each cited work by evidence type (primary study / review
+  / close analogue / caution paper / conference abstract / preprint / data
+  artifact) and ends with a one-sentence evidence-mix summary; "The decision
+  is yours" carries an explicit **upgrade / kill test** per conditional-go
+  candidate.  Mirrored to `src/research_hub/skills_data/gap-to-topic/`.
 - **`gap-to-topic` dossier — added tables for scannability**
   (`skills/gap-to-topic/`, plugin `0.3.3 → 0.3.4`).  Follow-up to the
   reader-first redesign: the verdicts were still spread across prose bullets

--- a/skills/gap-to-topic/references/dossier-template.md
+++ b/skills/gap-to-topic/references/dossier-template.md
@@ -76,10 +76,22 @@ published caution. Whether to pursue it is your and your advisor's call.">
 > full list in the `.bib`), and a one-sentence recall-confidence headline
 > (how much to trust "open"). How the search was run belongs in Appendix A.
 > "Absent from my corpus" is never proof of "open".*
+>
+> *Tag each cited work by evidence type — primary study / review / close
+> analogue / caution paper / conference abstract / preprint / data
+> artifact — and end with a one-sentence evidence-mix summary. The reader
+> must see how solid the occupancy signal is without opening
+> `literature_matrix.md`: an "occupied" verdict resting mostly on
+> conference abstracts is weaker than one resting on primary studies.*
 
 **Closest prior work:** <the papers that bear on whether each gap is filled
-— readable prose; full list in the `.bib`, structured comparison in
-`literature_matrix.md`.>
+— readable prose, each tagged by evidence type, e.g. "Smith 2024 (primary
+study)", "Jones 2026 (conference abstract)". Full list in the `.bib`,
+structured comparison in `literature_matrix.md`.>
+
+**Evidence mix:** <one sentence — e.g. "Of the 9 papers on Candidate 1:
+4 primary studies, 1 review, 3 conference abstracts, 1 data artifact — the
+occupancy signal is clear but partly early-stage.">
 
 **Recall confidence:** <one plain sentence — e.g. "Medium: one search
 backend was unavailable, so a missed paper is possible; re-check before
@@ -117,13 +129,22 @@ relying on an 'open' verdict.">
 > *State explicitly that the dossier stops here. It has assembled the three
 > gate verdicts; whether a gap is WORTH doing is the researcher's and
 > advisor's call. Per candidate, name the outcome and the conditions the
-> human must resolve before committing.*
+> human must resolve before committing. For each conditional-go candidate,
+> give an explicit **upgrade / kill test** — the finding that would make it
+> a clear go, and the finding that would make it a no-go — so the threshold
+> logic lives in the dossier, not left for the advisor to supply.*
 
 The three gates above are assembled evidence, not a verdict. A go requires
 all three to pass (open AND a contribution AND feasible); any gate failing
 is a no-go. **Whether <Candidate N> is worth pursuing is your and your
 advisor's decision.** <Per-candidate: the outcome, and the conditions to
 resolve first.>
+
+**Upgrade / kill test — <conditional-go candidate>.** It becomes a clear
+**go** if <the findings that would resolve every open condition favourably>.
+It becomes a **no-go** if <the finding that would fail any gate — e.g. the
+recall re-run surfaces a paper already occupying the gap, or the binding
+resource proves unobtainable within scope>.
 
 ---
 

--- a/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
+++ b/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
@@ -76,10 +76,22 @@ published caution. Whether to pursue it is your and your advisor's call.">
 > full list in the `.bib`), and a one-sentence recall-confidence headline
 > (how much to trust "open"). How the search was run belongs in Appendix A.
 > "Absent from my corpus" is never proof of "open".*
+>
+> *Tag each cited work by evidence type — primary study / review / close
+> analogue / caution paper / conference abstract / preprint / data
+> artifact — and end with a one-sentence evidence-mix summary. The reader
+> must see how solid the occupancy signal is without opening
+> `literature_matrix.md`: an "occupied" verdict resting mostly on
+> conference abstracts is weaker than one resting on primary studies.*
 
 **Closest prior work:** <the papers that bear on whether each gap is filled
-— readable prose; full list in the `.bib`, structured comparison in
-`literature_matrix.md`.>
+— readable prose, each tagged by evidence type, e.g. "Smith 2024 (primary
+study)", "Jones 2026 (conference abstract)". Full list in the `.bib`,
+structured comparison in `literature_matrix.md`.>
+
+**Evidence mix:** <one sentence — e.g. "Of the 9 papers on Candidate 1:
+4 primary studies, 1 review, 3 conference abstracts, 1 data artifact — the
+occupancy signal is clear but partly early-stage.">
 
 **Recall confidence:** <one plain sentence — e.g. "Medium: one search
 backend was unavailable, so a missed paper is possible; re-check before
@@ -117,13 +129,22 @@ relying on an 'open' verdict.">
 > *State explicitly that the dossier stops here. It has assembled the three
 > gate verdicts; whether a gap is WORTH doing is the researcher's and
 > advisor's call. Per candidate, name the outcome and the conditions the
-> human must resolve before committing.*
+> human must resolve before committing. For each conditional-go candidate,
+> give an explicit **upgrade / kill test** — the finding that would make it
+> a clear go, and the finding that would make it a no-go — so the threshold
+> logic lives in the dossier, not left for the advisor to supply.*
 
 The three gates above are assembled evidence, not a verdict. A go requires
 all three to pass (open AND a contribution AND feasible); any gate failing
 is a no-go. **Whether <Candidate N> is worth pursuing is your and your
 advisor's decision.** <Per-candidate: the outcome, and the conditions to
 resolve first.>
+
+**Upgrade / kill test — <conditional-go candidate>.** It becomes a clear
+**go** if <the findings that would resolve every open condition favourably>.
+It becomes a **no-go** if <the finding that would fail any gate — e.g. the
+recall re-run surfaces a paper already occupying the gap, or the binding
+resource proves unobtainable within scope>.
 
 ---
 


### PR DESCRIPTION
## Summary

A Codex evaluation of a real `gap-to-topic` dossier found two gaps:

1. **Evidence strength was invisible.** Gate 1 said a gap was "densely populated" / occupied, but the reader had to open `literature_matrix.md` to see the occupancy signal was partly conference abstracts and data artifacts, not primary studies.
2. **A "conditional go" had no threshold.** It listed the open conditions but stated no kill/upgrade logic — the advisor still had to supply it.

## Changes — `references/dossier-template.md`

- **Gate 1** now tags each cited work by evidence type (primary study / review / close analogue / caution paper / conference abstract / preprint / data artifact) and ends with a one-sentence **evidence-mix summary** — so a reader sees how solid an "occupied" verdict is without opening the matrix.
- **The decision is yours** now carries an explicit **upgrade / kill test** per conditional-go candidate — the finding that makes it a clear go, and the finding that makes it a no-go.

Doc-only; no code path changed. Mirrored to `src/research_hub/skills_data/gap-to-topic/`. Plugin `0.3.4 → 0.3.5`.

## Verification

- `tests/test_v068_3_version_sync.py` — 3 passed (byte-parity).
- Independent `code-reviewer` → **APPROVE** — both edits well-formed and style-consistent, section order intact, no tool mechanics in body, version consistent, no stale `0.3.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)