### PR TITLE
fix(fit-check): raise gap-split bar to 5x — catch only blatant contamination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **fit-check no-LLM gate tuned to catch only blatant contamination**
+  (`fit_check.py`).  The bimodal-gap split's ratio bar was 2x — still too
+  aggressive: a real `auto` run for "large language model social
+  interaction" kept only 6/25, rejecting 19 genuinely on-topic papers
+  ("Multi-Agent Social Simulation", "LLM-based Chatbots", "AI-Mediated
+  Communication") that simply phrase the concept differently than the
+  topic string.  A no-LLM *lexical* gate cannot tell an on-topic paper
+  with different vocabulary from an off-topic one — both score modestly.
+  The gap bar is now **5x**: it fires only on blatant cross-field
+  contamination (pure-hydrology papers in an LLM cluster score ~1 vs ~8
+  for genuine LLM papers — an ~8x gap), while a focused all-relevant
+  batch (scores spread ~2x) is kept whole.  Fine-grained relevance
+  screening is the LLM-judge tier's job; the no-LLM tier is a
+  recall-biased fallback that only catches blatant contamination.
+
 - **`gap-to-topic` dossier — evidence-strength tags + an upgrade/kill test**
   (`skills/gap-to-topic/`, plugin `0.3.4 → 0.3.5`).  A Codex evaluation of a
   real dossier found two gaps: (1) Gate 1 said a gap was "densely populated"

--- a/src/research_hub/fit_check.py
+++ b/src/research_hub/fit_check.py
@@ -285,11 +285,19 @@ _BM25_K1 = 1.2
 _BM25_B = 0.75
 # At the largest gap between consecutive sorted BM25 scores, the score
 # just ABOVE the gap must be at least this multiple of the score just
-# BELOW it for the batch to count as a real on/off-topic split. This
-# multiplicative test is scale-free -- robust to within-cluster spread,
-# unlike a fraction-of-range test. A focused, uniformly-relevant batch
-# rises smoothly (no adjacent ~2x jump) -> no split -> keep all.
-_GAP_RATIO = 2.0
+# BELOW it for the batch to count as a real on/off-topic split.
+#
+# Set deliberately high (5x): a no-LLM lexical gate cannot tell an
+# on-topic paper that uses different vocabulary ("multi-agent social
+# simulation" for an "LLM social interaction" topic) from an off-topic
+# one -- both score modestly. A 5x bar fires only on BLATANT cross-field
+# contamination (e.g. pure-hydrology papers in an LLM cluster score ~1
+# while genuine LLM papers score ~8 -- an ~8x gap). A focused search
+# returns an all-relevant batch whose scores spread by ~2x at most, well
+# under the bar -> kept whole. Fine-grained relevance is the LLM judge's
+# job; this no-LLM tier only catches blatant contamination and is
+# otherwise recall-biased (keep all).
+_GAP_RATIO = 5.0
 # Below this many candidates the batch is too small to read a score
 # distribution -- treat as cold-start and defer (keep all, flag).
 _MIN_BATCH_FOR_GATE = 5


### PR DESCRIPTION
## Problem

Follow-up to the bimodal-gap fit-check gate. The split ratio bar was 2x —
still too aggressive. A real `auto` run for "large language model social
interaction" kept only **6/25**, rejecting 19 *genuinely on-topic* papers
("Multi-Agent Social Simulation", "LLM-based Chatbots", "AI-Mediated
Communication Can Steer Collective Opinion") that phrase the concept
differently than the literal topic string.

## Root insight

A no-LLM **lexical** gate fundamentally cannot tell an on-topic paper that
uses different vocabulary from an off-topic one — both score modestly
under BM25. Any ratio bar low enough to catch *subtle* contamination also
rejects on-topic papers. Three gate iterations confirmed this (term-overlap
→ distinctive-term → 2x gap-split, each failing one way or the other).

## Fix

Scope the no-LLM tier to what it **can** do reliably: catch **blatant
cross-field contamination**. The gap-split ratio bar is raised to **5x**.

- Pure-hydrology papers in an LLM cluster score ~1 while genuine LLM
  papers score ~8 — an ~8x gap → still caught.
- A focused, all-relevant search spreads only ~2x → kept whole.
- Fine-grained relevance screening is the LLM-judge tier's job; the
  no-LLM tier is an explicitly recall-biased fallback.

## Verification

- The real 19-paper LLM-social batch (all genuinely on-topic) is now
  **kept whole** (cold-start — no 5x gap).
- The contamination test (3 LLM-water + 7 hydrology, 8.3x gap) **still
  splits cleanly** — hydrology rejected.
- 13 fit-check-relevance tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)