### PR TITLE
feat(search): --screen flag applies the fit-check BM25 relevance gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **ingest dedup re-scoped to research-hub's own literature** (`pipeline.py`).
+  `auto` for a new topic produced a near-empty cluster — a search returned
+  25 papers, fit-check kept all 25, yet only ~1 Obsidian note was created.
+  Cause: the dedup index was dominated by `source:"zotero"` entries
+  mirroring the user's ENTIRE Zotero library (mostly never managed by
+  research-hub) plus stale `source:"obsidian"` entries pointing at deleted
+  note files. The dedup block treated **any** paper merely present in the
+  Zotero library as a duplicate and `continue`-d past Obsidian-note
+  creation, dropping it from the new cluster. Dedup now skips a paper only
+  when it duplicates research-hub's OWN literature: (1) the `obsidian_hit`
+  branch requires the note file to actually exist on disk — a stale index
+  entry no longer blocks ingest; (2) the `zotero_hit` branch no longer
+  skips — it still reuses the existing Zotero item (moves it into the
+  cluster collection, adds hub tags + note, creates **no** duplicate item)
+  but the paper is now ingested into research-hub with its Obsidian note
+  created and bound to the cluster. New manifest action
+  `ingest-reuse-zotero` records the reuse decision.
 - **fit-check no-LLM relevance gate rewritten** (`fit_check.py`, `auto.py`).
   The old `no_llm_fit_check` gate split the topic into independent unigrams
   and kept any paper matching `>= 0.1` of them — i.e. **1 of 5** words. A
@@ -147,6 +164,22 @@ graph rebuild (link out to the real tools instead)._
   (`paper summarize --pending --cluster <slug>`).
 
 ### Added
+- **`search --screen` — fit-check BM25 relevance gate on the search
+  command** (`cli.py`).  The BM25 relevance gate (`screen_relevance` /
+  `bm25_scores`, from PRs #79/#81/#83) was only applied by the `auto`
+  ingest pipeline; the standalone `search` command returned unscreened,
+  potentially off-topic results.  `search --screen` now runs that same
+  gate over the retrieved papers: each result is tagged with a relevance
+  score + a keep / screened-out verdict, and a screening summary
+  (`N retrieved → M kept, K screened out`) is printed to stderr.  It is
+  **recall-preserving** — no paper is dropped from the output, so a caller
+  can still audit the full retrieved count.  `--json` switches to a
+  `{"screening_summary": {...}, "results": [...]}` object (each result
+  carrying a `relevance` block) when `--screen` is set; without `--screen`
+  the output is byte-identical to before (bare array).  Composable with
+  `--adversarial` / `--max-variants` / `--rank-by` (orthogonal to ranking
+  — `--screen` only annotates).  Reuses the existing gate; no new scorer.
+
 - **`gap-to-topic` skill — a topic-decision dossier.** New 11th packaged
   skill. Choosing a thesis/proposal topic is a go/no-go decision, not a
   literature review; `gap-to-topic` produces a `.research/topic_dossier.md`

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -2987,6 +2987,7 @@ def _search(
     cluster_slug: str | None = None,
     adversarial: bool = False,
     max_variants: int = 5,
+    screen: bool = False,
 ) -> int:
     cfg = get_config()
     index = DedupIndex.load(cfg.research_hub_dir / "dedup_index.json")
@@ -3036,13 +3037,55 @@ def _search(
     ingested = {normalize_doi(doi) for doi in index.doi_to_hits.keys() if doi}
     results = [r for r in results if normalize_doi(r.doi) not in ingested]
 
+    # --screen: fit-check BM25 relevance gate. Tags each result, never
+    # drops one (recall-preserving — gap-to-topic Gate 1 audits on the
+    # full retrieved count). Orthogonal to --rank-by (ordering is left
+    # untouched; screening only annotates).
+    verdicts: list[dict] | None = None
+    screening_summary: dict | None = None
+    if screen:
+        from research_hub.fit_check import screen_relevance
+
+        verdicts = screen_relevance([asdict(r) for r in results], query)
+        kept_n = sum(1 for v in verdicts if v["kept"])
+        screening_summary = {
+            "retrieved": len(results),
+            "kept": kept_n,
+            "screened_out": len(results) - kept_n,
+            "tier": (verdicts[0]["tier"] if verdicts else ""),
+        }
+        print(
+            f"[screen] {screening_summary['retrieved']} retrieved -> "
+            f"{screening_summary['kept']} kept, "
+            f"{screening_summary['screened_out']} screened out "
+            f"(gate tier: {screening_summary['tier'] or 'n/a'})",
+            file=sys.stderr,
+        )
+
     if to_papers_input:
         _emit_papers_input_json(results, cluster_slug)
         return 0
     if emit_json:
-        print(json.dumps([asdict(r) for r in results], indent=2, ensure_ascii=False))
+        if screen and verdicts is not None:
+            screened_results = []
+            for result, verdict in zip(results, verdicts):
+                row = asdict(result)
+                row["relevance"] = {
+                    "score": verdict["score"],
+                    "kept": verdict["kept"],
+                    "tier": verdict["tier"],
+                    "reason": verdict["reason"],
+                }
+                screened_results.append(row)
+            print(json.dumps(
+                {"screening_summary": screening_summary, "results": screened_results},
+                indent=2,
+                ensure_ascii=False,
+            ))
+        else:
+            print(json.dumps([asdict(r) for r in results], indent=2, ensure_ascii=False))
         return 0
-    for result in results:
+    for i, result in enumerate(results):
         line = (
             f"{result.title}\t{result.doi or result.arxiv_id}\t"
             f"{result.year or '????'}\t{result.citation_count}\t{result.source}"
@@ -3050,6 +3093,12 @@ def _search(
         if verify:
             verified = bool(result.doi) and verify_doi(result.doi).ok
             line += "\tVERIFIED" if verified else "\tUNVERIFIED"
+        if screen and verdicts is not None:
+            verdict = verdicts[i]
+            line += (
+                f"\t{'KEEP' if verdict['kept'] else 'SCREENED-OUT'}"
+                f"({verdict['score']})"
+            )
         print(line)
     return 0
 
@@ -5950,6 +5999,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=5,
         help="With --adversarial: max alternative query phrasings to search (default 5).",
     )
+    search_parser.add_argument(
+        "--screen",
+        action="store_true",
+        help="Apply the fit-check BM25 relevance gate to the results. Tags "
+        "each paper with a relevance score + keep/screened-out verdict and "
+        "prints a screening summary; does NOT drop papers (recall-preserving). "
+        "Composable with --adversarial / --rank-by / --json. With "
+        "--to-papers-input the summary still prints to stderr but the emitted "
+        "JSON carries no relevance annotations.",
+    )
     search_parser.add_argument("--json", action="store_true", help="Emit JSON array")
     search_parser.add_argument(
         "--to-papers-input",
@@ -7895,6 +7954,7 @@ def _main_dispatch(args, parser) -> int:
             cluster_slug=args.cluster,
             adversarial=args.adversarial,
             max_variants=args.max_variants,
+            screen=args.screen,
         )
     if args.command == "websearch":
         return _websearch(

--- a/tests/test_search_screen.py
+++ b/tests/test_search_screen.py
@@ -1,0 +1,204 @@
+"""`search --screen` — wires the fit-check BM25 relevance gate onto the
+standalone `search` command.
+
+`--screen` runs the existing `screen_relevance` gate over the retrieved
+results, tags each with a relevance score + keep/screened-out verdict,
+and prints a screening summary. It is recall-preserving: it never drops a
+paper from the output, so a downstream caller (gap-to-topic Gate 1) can
+still audit the full retrieved count.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import research_hub.cli as cli_mod
+from research_hub.cli import _search
+from research_hub.dedup import DedupIndex
+from research_hub.search.base import SearchResult
+
+
+class _EmptyIndex:
+    """A dedup index that filters nothing."""
+    doi_to_hits: dict = {}
+
+
+def _result(title: str, abstract: str, doi: str) -> SearchResult:
+    return SearchResult(title=title, abstract=abstract, doi=doi, year=2025, source="test")
+
+
+# A contaminated batch: 3 genuine LLM x water-resources papers far
+# out-scoring 8 generic hydrology papers -> a blatant BM25 gap the gate
+# splits on.
+_GENUINE = [
+    _result(
+        "Large Language Models as Calibration Agents in Hydrological Modeling",
+        "We employ a large language model to calibrate a hydrological model "
+        "for streamflow in water resources.",
+        "10.0/g1",
+    ),
+    _result(
+        "Retrieval-augmented large language models for water resources decisions",
+        "A large language model with retrieval augmentation supports water "
+        "resources management decisions.",
+        "10.0/g2",
+    ),
+    _result(
+        "Evaluating large language model agents for streamflow forecasting",
+        "Large language model agents are evaluated for streamflow forecasting "
+        "against a hydrological model baseline.",
+        "10.0/g3",
+    ),
+]
+_HYDRO = [
+    _result(f"Hydrology study {i}: streamflow and irrigation",
+            "A hydrological model for streamflow and irrigation in water "
+            "resources management with no language component.",
+            f"10.0/h{i}")
+    for i in range(8)
+]
+_BATCH = _GENUINE + _HYDRO
+_TOPIC = "large language model water resources"
+
+
+@pytest.fixture
+def wired(monkeypatch, tmp_path):
+    """Run `_search` fully offline: stub config, dedup index, and the
+    search backends."""
+    cfg = type("Cfg", (), {"research_hub_dir": tmp_path})()
+    monkeypatch.setattr(cli_mod, "get_config", lambda: cfg)
+    monkeypatch.setattr(DedupIndex, "load", classmethod(lambda cls, _p: _EmptyIndex()))
+    import research_hub.search as search_mod
+    monkeypatch.setattr(search_mod, "search_papers", lambda *a, **k: list(_BATCH))
+    return monkeypatch
+
+
+def _capture_json(capsys) -> object:
+    return json.loads(capsys.readouterr().out)
+
+
+# ---------------------------------------------------------------------------
+# --screen present
+# ---------------------------------------------------------------------------
+
+def test_screen_json_has_summary_and_per_paper_relevance(wired, capsys):
+    rc = _search(_TOPIC, 20, emit_json=True, screen=True)
+    assert rc == 0
+    payload = _capture_json(capsys)
+
+    # object shape: {screening_summary, results}
+    assert set(payload) == {"screening_summary", "results"}
+    summary = payload["screening_summary"]
+    assert summary["retrieved"] == len(_BATCH)
+    assert summary["kept"] + summary["screened_out"] == len(_BATCH)
+    # every result carries a relevance verdict
+    for row in payload["results"]:
+        assert set(row["relevance"]) == {"score", "kept", "tier", "reason"}
+
+
+def test_screen_is_recall_preserving(wired, capsys):
+    """--screen tags but never drops: every retrieved paper is still in the
+    output, even the screened-out ones."""
+    _search(_TOPIC, 20, emit_json=True, screen=True)
+    payload = _capture_json(capsys)
+    assert len(payload["results"]) == len(_BATCH)
+
+
+def test_screen_splits_the_contaminated_batch(wired, capsys):
+    """On this contaminated batch the gate fires: the hydrology papers are
+    marked screened-out, the genuine LLM papers kept."""
+    _search(_TOPIC, 20, emit_json=True, screen=True)
+    payload = _capture_json(capsys)
+    by_doi = {r["doi"]: r["relevance"]["kept"] for r in payload["results"]}
+    assert by_doi["10.0/g1"] is True
+    assert by_doi["10.0/h0"] is False
+    assert payload["screening_summary"]["screened_out"] >= 8
+
+
+def test_screen_summary_printed_to_stderr(wired, capsys):
+    _search(_TOPIC, 20, emit_json=True, screen=True)
+    err = capsys.readouterr().err
+    assert "[screen]" in err
+    assert "retrieved" in err
+
+
+def test_screen_composes_with_adversarial(monkeypatch, wired, capsys):
+    """--screen works on top of --adversarial (which returns a different
+    retrieval tuple)."""
+    import research_hub.search as search_mod
+
+    class _Recall:
+        queries_run = 3
+        total_unique = len(_BATCH)
+        confidence = "high"
+        saturated = False
+
+    monkeypatch.setattr(
+        search_mod, "adversarial_search",
+        lambda *a, **k: (list(_BATCH), _Recall()),
+    )
+    rc = _search(_TOPIC, 20, emit_json=True, screen=True, adversarial=True)
+    assert rc == 0
+    payload = _capture_json(capsys)
+    assert "screening_summary" in payload
+    assert len(payload["results"]) == len(_BATCH)
+
+
+# ---------------------------------------------------------------------------
+# --screen absent — regression: behaviour unchanged
+# ---------------------------------------------------------------------------
+
+def test_no_screen_json_is_a_bare_array(wired, capsys):
+    """Without --screen the JSON output is the original bare array — no
+    object wrapper, no relevance key."""
+    rc = _search(_TOPIC, 20, emit_json=True, screen=False)
+    assert rc == 0
+    payload = _capture_json(capsys)
+    assert isinstance(payload, list)
+    assert len(payload) == len(_BATCH)
+    assert "relevance" not in payload[0]
+
+
+def test_no_screen_prints_no_screening_summary(wired, capsys):
+    _search(_TOPIC, 20, emit_json=True, screen=False)
+    assert "[screen]" not in capsys.readouterr().err
+
+
+def test_no_screen_text_output_unchanged(wired, capsys):
+    """Text mode without --screen: lines carry no KEEP/SCREENED-OUT tag."""
+    _search(_TOPIC, 20, emit_json=False, screen=False)
+    out = capsys.readouterr().out
+    assert "KEEP" not in out
+    assert "SCREENED-OUT" not in out
+
+
+# ---------------------------------------------------------------------------
+# edge cases
+# ---------------------------------------------------------------------------
+
+def test_screen_with_to_papers_input_emits_unscreened_json(wired, monkeypatch, capsys):
+    """--screen + --to-papers-input: the papers_input branch returns early
+    with the unscreened results, but the screening summary still reaches
+    stderr (documented asymmetry)."""
+    received = {}
+    monkeypatch.setattr(
+        cli_mod, "_emit_papers_input_json",
+        lambda results, slug: received.update(n=len(results)),
+    )
+    rc = _search(_TOPIC, 20, screen=True, to_papers_input=True, cluster_slug=None)
+    assert rc == 0
+    assert received["n"] == len(_BATCH)          # unscreened: all results passed through
+    assert "[screen]" in capsys.readouterr().err  # summary still printed
+
+
+def test_screen_small_batch_defers_to_cold_start(monkeypatch, wired, capsys):
+    """Fewer than the gate's minimum batch size -> cold-start: all kept,
+    nothing screened out."""
+    import research_hub.search as search_mod
+    monkeypatch.setattr(search_mod, "search_papers", lambda *a, **k: list(_GENUINE))
+    _search(_TOPIC, 20, emit_json=True, screen=True)
+    payload = _capture_json(capsys)
+    assert payload["screening_summary"]["screened_out"] == 0
+    assert all(r["relevance"]["tier"] == "cold-start" for r in payload["results"])


### PR DESCRIPTION
## Problem

The BM25 relevance gate (`screen_relevance` / `bm25_scores`, from PRs
#79/#81/#83) was only applied by the `auto` ingest pipeline. The
standalone `search` command returned **unscreened** results. Downstream,
the `gap-to-topic` skill's Gate 1 runs `search --adversarial --json` for
prior-art retrieval — and got a noisy, off-topic corpus, the same failure
the BM25 rewrite fixed for `auto`.

## What this adds

A `--screen` flag on the `search` subcommand that runs the **existing**
gate over the retrieved papers (reuse — no new scorer):

- Each result is tagged with a relevance score + a **keep / screened-out**
  verdict; a screening summary (`N retrieved → M kept, K screened out`)
  prints to stderr.
- **Recall-preserving** — no paper is dropped from the output, so a caller
  can still audit the full retrieved count (gap-to-topic Gate 1's
  recall-confidence reasoning depends on this).
- `--json`: when `--screen` is set the output is
  `{"screening_summary": {...}, "results": [...]}` — each result carries a
  `relevance` block (`score` / `kept` / `tier` / `reason`). Without
  `--screen` the output is **byte-identical** to before (bare array).
- Composable with `--adversarial` / `--max-variants` / `--rank-by`.
  Orthogonal to `--rank-by` — screening only annotates, ordering is left
  untouched.
- `--to-papers-input` + `--screen`: the summary still prints to stderr but
  the papers_input JSON is emitted unscreened (documented in the help text).

## Verification

- `tests/test_search_screen.py` — 10 tests: JSON object shape +
  per-paper `relevance`, recall-preserving (no drops), contaminated-batch
  split, `--adversarial` composition, small-batch cold-start,
  `--to-papers-input` asymmetry, and the **no-`--screen` regression**
  (bare array + unchanged text output).
- 381 passed across the search / fit-check / cli-json suites.
- code-reviewer subagent: **APPROVE** (no P0/P1; the two recommended
  edge-case tests + help-text note were added before push).

## Downstream

Once on master, `gap-to-topic` SKILL.md §1 can switch its retrieval call
to `search --adversarial --screen` — a one-line change, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)