### PR TITLE
fix(pipeline): dedup skips only research-hub's own notes, not the Zotero library

### DIFF
--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -968,6 +968,11 @@ def run_pipeline(
         errors: list[dict] = []
         papers_for_notes: list[dict] = []
         pending_zotero_papers: list[dict] = []
+        # Papers whose Zotero item already exists (dedup zotero_hit): the item
+        # is reused (no duplicate created) but the paper is STILL ingested into
+        # research-hub. Collected separately because write_papers_to_zotero
+        # reassigns papers_for_notes below, which would discard direct appends.
+        reused_zotero_papers: list[dict] = []
         target_collection_key = cluster_coll or collection_key
 
         from research_hub.authenticity import verify_authenticity
@@ -1027,7 +1032,15 @@ def run_pipeline(
                 if is_duplicate:
                     obsidian_hit = next((hit for hit in dedup_hits if hit.source == "obsidian"), None)
                     zotero_hit = next((hit for hit in dedup_hits if hit.source == "zotero"), None)
-                    if obsidian_hit and obsidian_hit.obsidian_path:
+                    # Only treat an obsidian_hit as a true duplicate (skip)
+                    # when the note file ACTUALLY EXISTS. A stale dedup-index
+                    # entry pointing at a deleted note must NOT cause a skip;
+                    # fall through so the paper is ingested fresh.
+                    if (
+                        obsidian_hit
+                        and obsidian_hit.obsidian_path
+                        and Path(obsidian_hit.obsidian_path).exists()
+                    ):
                         append_cluster_query_to_existing(
                             Path(obsidian_hit.obsidian_path),
                             query_text,
@@ -1059,6 +1072,17 @@ def run_pipeline(
                                 "key": obsidian_hit.zotero_key or "",
                             }
                         )
+                        continue
+                    if zotero_hit and no_zotero:
+                        # no_zotero mode: zot is None, so the Zotero-item
+                        # reuse ops below would fail. Still ingest the
+                        # note; treat it like any other no_zotero paper.
+                        pp["zotero_key"] = ""
+                        zr.append(
+                            {"title": pp["title"],
+                             "status": "SKIPPED_NO_ZOTERO", "key": ""}
+                        )
+                        papers_for_notes.append(pp)
                         continue
                     if zotero_hit:
                         cluster = clusters.get(cluster_slug) if cluster_slug else None
@@ -1098,25 +1122,26 @@ def run_pipeline(
                                     add_note(zot, zotero_hit.zotero_key, _build_note_html(pp))
                             except Exception as exc:
                                 p(f"  WARN dedup note-add failed: {exc}")
+                        # The Zotero item already exists — its useful work is
+                        # done above (moved into the cluster collection, hub
+                        # tags + note added; NO duplicate Zotero item created).
+                        # The paper is NOT skipped: it must still be ingested
+                        # into research-hub. Reuse the existing Zotero key and
+                        # defer to Obsidian-note creation downstream.
+                        pp["zotero_key"] = zotero_hit.zotero_key or ""
                         manifest.append(
                             new_entry(
                                 cluster=cluster_slug or "",
                                 query=query_text,
-                                action="dup-zotero",
+                                action="ingest-reuse-zotero",
                                 doi=pp["doi"],
                                 title=pp["title"],
                                 zotero_key=zotero_hit.zotero_key or "",
                                 batch_label=resolved_batch_label,
                             )
                         )
-                        p("  SKIPPED dup in Zotero")
-                        zr.append(
-                            {
-                                "title": pp["title"],
-                                "status": "SKIPPED_DUPLICATE",
-                                "key": zotero_hit.zotero_key or "",
-                            }
-                        )
+                        p("  REUSING existing Zotero item; ingesting into cluster")
+                        reused_zotero_papers.append(pp)
                         continue
                 if no_zotero:
                     dup = False
@@ -1157,6 +1182,11 @@ def run_pipeline(
                 log=p,
             )
             errors.extend(zotero_errors)
+
+        # write_papers_to_zotero reassigns papers_for_notes, so add the
+        # reused-Zotero papers AFTER it: they reuse an existing Zotero item but
+        # still need an Obsidian note + cluster binding created downstream.
+        papers_for_notes.extend(reused_zotero_papers)
 
         p("\n=== DOI VALIDATION ===")
         verify_cache = VerifyCache(cfg.research_hub_dir / "verify_cache.json") if verify else None

--- a/tests/test_manifest_integrity.py
+++ b/tests/test_manifest_integrity.py
@@ -47,6 +47,7 @@ def test_manifest_action_vocabulary_respected():
         "duplicate",
         "dup-obsidian",
         "dup-zotero",
+        "ingest-reuse-zotero",
         "error",
         "updated",
         "archived",

--- a/tests/test_v1_ingest_dedup_scope.py
+++ b/tests/test_v1_ingest_dedup_scope.py
@@ -1,0 +1,287 @@
+"""Ingest dedup must be scoped to research-hub's OWN literature.
+
+Bug (confirmed in the field): `research-hub auto` for a new topic produced
+a near-empty Obsidian cluster — a search returned 25 papers, the fit-check
+kept all 25, yet only ~1 Obsidian note was created.
+
+Root cause: the dedup index (`<vault>/.research_hub/dedup_index.json`) was
+dominated by `source:"zotero"` entries mirroring the user's ENTIRE Zotero
+library (most of it never managed by research-hub) plus stale
+`source:"obsidian"` entries pointing at deleted note files. The ingest
+dedup block then:
+
+  * treated any paper merely present in the Zotero library as a duplicate
+    and `continue`-d past Obsidian-note creation — dropping it from the
+    new cluster entirely; and
+  * treated a stale obsidian entry (note file already deleted) as a live
+    duplicate and skipped the paper.
+
+Required behaviour: dedup may skip a paper ONLY when it duplicates
+research-hub's own literature — i.e. a CURRENT Obsidian cluster note that
+still exists on disk. A paper that is merely in the Zotero library must
+still be ingested into the cluster (its Obsidian note created), while
+reusing the existing Zotero item so no duplicate Zotero item is created.
+
+These tests pin all three branches of the dedup block in
+`research_hub.pipeline.run_pipeline`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from research_hub import pipeline
+from research_hub.clusters import ClusterRegistry
+from research_hub.dedup import DedupHit, DedupIndex
+from research_hub.pipeline import run_pipeline
+
+
+# --- fixtures -------------------------------------------------------------
+
+
+def _cfg(tmp_path: Path, *, default_collection: str | None = "DEFAULT") -> SimpleNamespace:
+    root = tmp_path / "vault"
+    raw = root / "raw"
+    logs = root / "logs"
+    hub = root / ".research_hub"
+    raw.mkdir(parents=True)
+    logs.mkdir(parents=True)
+    hub.mkdir(parents=True)
+    return SimpleNamespace(
+        root=root,
+        raw=raw,
+        logs=logs,
+        research_hub_dir=hub,
+        clusters_file=hub / "clusters.yaml",
+        zotero_default_collection=default_collection,
+        zotero_collections={},
+        zotero_library_id="123",
+    )
+
+
+def _paper(idx: int = 1) -> dict:
+    return {
+        "title": f"Already-In-Zotero Paper {idx}",
+        "doi": f"10.1000/in-library-{idx}",
+        "authors": [{"creatorType": "author", "lastName": "Doe", "firstName": "Jane"}],
+        "year": 2026,
+        "abstract": "Abstract",
+        "journal": "Journal",
+        "summary": "Summary",
+        "key_findings": ["Finding"],
+        "methodology": "Method",
+        "relevance": "Relevant",
+        "slug": f"doe2026-already-in-zotero-paper-{idx}",
+        "sub_category": "agents",
+        "citation_count": 1,
+    }
+
+
+class _DedupZotero:
+    """Zotero stub that records writes so tests can assert no DUPLICATE
+    item is created, while still serving the reads the zotero_hit reuse
+    branch performs (`item` / `children` / `update_item`)."""
+
+    def __init__(self) -> None:
+        self.created: list[list[dict]] = []
+        self.updated: list[dict] = []
+
+    def item_template(self, item_type: str) -> dict:
+        return {"itemType": item_type}
+
+    def create_items(self, items):  # type: ignore[no-untyped-def]
+        self.created.append(items)
+        return {
+            "successful": {
+                str(idx): {"key": f"NEW{idx}"} for idx, _item in enumerate(items)
+            }
+        }
+
+    def item(self, key: str) -> dict:
+        return {"data": {"key": key, "itemType": "journalArticle", "tags": []}}
+
+    def children(self, key: str) -> list:
+        return []
+
+    def update_item(self, data) -> bool:  # type: ignore[no-untyped-def]
+        self.updated.append(data)
+        return True
+
+
+def _mock(monkeypatch: pytest.MonkeyPatch, cfg, dedup: DedupIndex) -> _DedupZotero:
+    z = _DedupZotero()
+    monkeypatch.setattr("research_hub.pipeline.get_config", lambda: cfg)
+    monkeypatch.setattr(pipeline, "get_client", lambda: z)
+    monkeypatch.setattr(
+        pipeline, "check_duplicate", lambda zot, title, doi="", **kwargs: False
+    )
+    monkeypatch.setattr(pipeline, "add_note", lambda zot, key, content: True)
+    monkeypatch.setattr(pipeline, "_load_or_build_dedup", lambda *a, **k: dedup)
+    monkeypatch.setattr("research_hub.pipeline.time.sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        "research_hub.pipeline.update_cluster_links", lambda *a, **k: None
+    )
+    return z
+
+
+def _write_input(cfg, paper: dict) -> None:
+    (cfg.root / "papers_input.json").write_text(
+        json.dumps({"papers": [paper]}), encoding="utf-8"
+    )
+
+
+def _manifest_actions(cfg) -> list[str]:
+    path = cfg.research_hub_dir / "manifest.jsonl"
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)["action"]
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# --- branch 2: zotero_hit -> reuse Zotero item, STILL ingest into cluster --
+
+
+def test_paper_already_in_zotero_library_is_still_ingested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A paper whose DOI matches a `source:"zotero"` dedup entry (it lives
+    somewhere in the user's broader Zotero library) must STILL get an
+    Obsidian note in the new cluster. The existing Zotero item is reused
+    (key carried onto the paper) and NO duplicate Zotero item is created."""
+    cfg = _cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(
+        query="agents", name="Agents", slug="agents", zotero_collection_key="DEFAULT"
+    )
+    paper = _paper()
+    _write_input(cfg, paper)
+
+    dedup = DedupIndex()
+    dedup.add(
+        DedupHit(
+            source="zotero",
+            doi=paper["doi"],
+            title=paper["title"],
+            zotero_key="EXISTINGKEY",
+        )
+    )
+    z = _mock(monkeypatch, cfg, dedup)
+
+    rc = run_pipeline(dry_run=False, cluster_slug="agents", verify=False)
+
+    assert rc == 0
+    # The Obsidian note WAS created (the bug dropped it entirely).
+    notes = list(cfg.raw.rglob("*.md"))
+    assert len(notes) == 1, f"expected one ingested note, found {notes}"
+    note_text = notes[0].read_text(encoding="utf-8")
+    # The note reuses the existing Zotero key rather than minting a new one.
+    assert "EXISTINGKEY" in note_text
+    # No DUPLICATE Zotero item was created for the already-present paper.
+    assert z.created == [], "reused Zotero paper must not create a new item"
+    # Manifest records the reuse decision (not a skip) at the dedup stage,
+    # plus a "new" entry when the Obsidian note is created downstream.
+    actions = _manifest_actions(cfg)
+    assert "ingest-reuse-zotero" in actions
+    assert "dup-zotero" not in actions
+    assert "new" in actions  # the Obsidian note was created for the reused paper
+
+
+# --- branch 1a: stale obsidian_hit -> note file deleted -> ingest fresh ----
+
+
+def test_stale_obsidian_entry_does_not_skip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A `source:"obsidian"` dedup entry whose note file no longer exists
+    is stale. It must NOT cause a skip — the paper is ingested fresh."""
+    cfg = _cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(
+        query="agents", name="Agents", slug="agents", zotero_collection_key="DEFAULT"
+    )
+    paper = _paper()
+    _write_input(cfg, paper)
+
+    dedup = DedupIndex()
+    dedup.add(
+        DedupHit(
+            source="obsidian",
+            doi=paper["doi"],
+            title=paper["title"],
+            zotero_key="OLDKEY",
+            obsidian_path=str(tmp_path / "deleted" / "gone.md"),  # does NOT exist
+        )
+    )
+    z = _mock(monkeypatch, cfg, dedup)
+
+    rc = run_pipeline(dry_run=False, cluster_slug="agents", verify=False)
+
+    assert rc == 0
+    notes = list(cfg.raw.rglob("*.md"))
+    assert len(notes) == 1, f"stale obsidian entry must not block ingest: {notes}"
+    # Fresh ingest: a new Zotero item IS created (no real item to reuse).
+    assert z.created, "stale-obsidian paper should be written to Zotero fresh"
+    actions = _manifest_actions(cfg)
+    assert "new" in actions
+    assert "dup-obsidian" not in actions
+
+
+# --- branch 1b: live obsidian_hit -> note file exists -> genuine skip ------
+
+
+def test_live_obsidian_note_still_skips(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A paper that IS a current research-hub Obsidian note (file exists on
+    disk) is a genuine duplicate and must still be skipped."""
+    cfg = _cfg(tmp_path)
+    ClusterRegistry(cfg.clusters_file).create(
+        query="agents", name="Agents", slug="agents", zotero_collection_key="DEFAULT"
+    )
+    paper = _paper()
+    _write_input(cfg, paper)
+
+    existing_dir = cfg.raw / "agents"
+    existing_dir.mkdir(parents=True, exist_ok=True)
+    existing_note = existing_dir / f"{paper['slug']}.md"
+    existing_note.write_text(
+        "---\n"
+        f'title: "{paper["title"]}"\n'
+        f'doi: "{paper["doi"]}"\n'
+        'zotero-key: "LIVEKEY"\n'
+        'cluster_queries: ["old query"]\n'
+        'topic_cluster: "agents"\n'
+        'tags: ["agents"]\n'
+        "---\n",
+        encoding="utf-8",
+    )
+
+    dedup = DedupIndex()
+    dedup.add(
+        DedupHit(
+            source="obsidian",
+            doi=paper["doi"],
+            title=paper["title"],
+            zotero_key="LIVEKEY",
+            obsidian_path=str(existing_note),
+        )
+    )
+    z = _mock(monkeypatch, cfg, dedup)
+
+    rc = run_pipeline(dry_run=False, cluster_slug="agents", verify=False)
+
+    assert rc == 0
+    # No NEW note file appeared — only the pre-existing one.
+    notes = list(cfg.raw.rglob("*.md"))
+    assert notes == [existing_note], f"live obsidian dup must skip: {notes}"
+    # No Zotero item created for the skipped duplicate.
+    assert z.created == []
+    actions = _manifest_actions(cfg)
+    assert "dup-obsidian" in actions
+    assert "new" not in actions
+    assert "ingest-reuse-zotero" not in actions


### PR DESCRIPTION
## Problem

`auto` for a new topic produced a near-empty Obsidian cluster — a search
returned 25 papers, fit-check kept all 25, yet only **~1 note** was
created. Cause: the dedup index is dominated by `source:"zotero"` entries
mirroring the user's **entire Zotero library** (mostly never managed by
research-hub), plus stale `source:"obsidian"` entries pointing at deleted
note files. The dedup block treated **any** paper merely present in the
Zotero library as a duplicate and skipped it.

## Fix

A paper is a true duplicate only if it is already **research-hub's own
literature** — a live Obsidian cluster note:

- the `obsidian_hit` skip now also requires the note file to **actually
  exist** — a stale dedup-index entry pointing at a deleted note no
  longer causes a skip;
- the `zotero_hit` branch **no longer skips**. It keeps its useful work
  (reuse the existing Zotero item — move into the cluster collection, add
  hub tags + note; **no duplicate Zotero item created**), but the paper
  is still ingested into research-hub: its Obsidian note is created,
  reusing the existing Zotero key. Manifest action `dup-zotero` →
  `ingest-reuse-zotero`;
- reused-Zotero papers flow through a new `reused_zotero_papers` list
  merged into `papers_for_notes` **after** `write_papers_to_zotero`
  reassigns it (a direct append would otherwise be discarded);
- `no_zotero` mode + a `zotero_hit` is handled explicitly (`zot` is
  `None` there) instead of a swallowed `AttributeError`.

## Verification

- `tests/test_v1_ingest_dedup_scope.py` (new) — a Zotero-library paper is
  still ingested; a stale obsidian entry does not skip; a live obsidian
  note still skips.
- `test_manifest_integrity.py` vocabulary updated for `ingest-reuse-zotero`.
- **269 passed** across the pipeline / ingest / dedup / manifest suites.
- code-reviewer subagent: **APPROVE** (no P0/P1). W2 — the `no_zotero` +
  `zotero_hit` edge case — was fixed before push. W1 (the run summary
  doesn't surface a "Zotero reused" count) is a non-blocking observability
  follow-up.

The CHANGELOG entry for this fix is already on master (it landed early
via #84) — no CHANGELOG change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)