### PR TITLE
fix(skill): gap-to-topic §1 applies the fit-check relevance gate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **`gap-to-topic` §1 now applies the fit-check relevance gate**
+  (`skills/gap-to-topic/`, plugin `0.3.5 → 0.3.6`).  `search --screen`
+  (PR #84) wired the BM25 relevance gate into the `search` command; §1 now
+  uses it.  SKILL.md §1: step 1 runs `search --adversarial --screen --json`
+  and reads the new `{screening_summary, results}` shape (each paper
+  carries a `relevance` field); steps 2-3 build the matrix and `.bib` from
+  the **on-topic** results only (`kept: true`), excluding screened-out
+  off-topic noise; step 4 reports the retrieved-vs-on-topic counts in the
+  recall headline.  `references/dossier-template.md` Appendix A pipeline +
+  recall-mechanics rows updated.  Mirrored to
+  `src/research_hub/skills_data/gap-to-topic/`.
 - **ingest dedup re-scoped to research-hub's own literature** (`pipeline.py`).
   `auto` for a new topic produced a near-empty cluster — a search returned
   25 papers, fit-check kept all 25, yet only ~1 Obsidian note was created.

--- a/skills/gap-to-topic/SKILL.md
+++ b/skills/gap-to-topic/SKILL.md
@@ -73,9 +73,10 @@ In priority order:
 4. The user's free-text answers during the §0 and §3 conversational steps.
 
 This skill orchestrates other research-hub capabilities as tools:
-`search --adversarial --json` (§1 step 1 — recall + the metadata the
-`.bib` is built from) and `literature-triage-matrix` (§1 step 2 — turns
-the search results into the prior-art comparison matrix). `paper gaps`
+`search --adversarial --screen --json` (§1 step 1 — recall, the fit-check
+BM25 relevance gate, and the metadata the `.bib` is built from) and
+`literature-triage-matrix` (§1 step 2 — turns the on-topic search results
+into the prior-art comparison matrix). `paper gaps`
 is used only when a relevant ingested cluster already exists — at
 topic-selection time it usually does not, so the
 `search` → `literature-triage-matrix` path is the default. Note:
@@ -110,31 +111,42 @@ gate runs per gap.
 Incomplete recall is the dominant failure mode: a missed paper makes a gap
 look open when it is not. So this gate is **adversarial**:
 
-1. Run `research-hub search --adversarial --json` on the gap — it searches
-   several query phrasings, reports a recall-confidence verdict, and emits
-   full per-paper metadata (title, DOI / arXiv ID, year, authors, venue).
-   If `--adversarial` is unavailable (older CLI), run several query
-   phrasings by hand and record the reduced recall confidence in the dossier.
-2. Feed the retrieved papers to `literature-triage-matrix` (as its
-   input #0 — a Markdown list of titles + DOIs / arXiv IDs) to produce
+1. Run `research-hub search --adversarial --screen --json` on the gap. It
+   searches several query phrasings, reports a recall-confidence verdict,
+   and applies the fit-check BM25 relevance gate. With `--screen --json` the
+   output is an object `{screening_summary, results}`: `results` is the
+   per-paper list (title, DOI / arXiv ID, year, authors, venue, plus a
+   `relevance` field — `score` / `kept` / `tier` / `reason`), and
+   `screening_summary`
+   gives the retrieved / kept / screened-out counts. `--screen` never drops
+   a paper — it tags relevance, so recall stays auditable. If `--adversarial`
+   or `--screen` is unavailable (older CLI), run several query phrasings by
+   hand and record the reduced recall confidence in the dossier.
+2. From `results`, take the **on-topic** papers — those the relevance gate
+   tagged `kept: true` — and feed them to `literature-triage-matrix` (as
+   its input #0, a Markdown list of titles + DOIs / arXiv IDs) to produce
    `.research/literature_matrix.md`: the structured prior-art comparison
    (per paper — method, main claim, evidence, limitation, relevance).
-   This matrix is a **real workflow output** — it is what the openness
-   judgement in step 4 and the §2 gates read, not an assumed
-   pre-existing input. If a `literature_matrix.md` from an earlier run
-   exists, `literature-triage-matrix` appends to it; if the skill is
-   unavailable, reason directly over the `search --json` results and
-   record the reduced structure in the dossier.
+   Papers tagged `kept: false` are off-topic noise — keep them out of the
+   matrix, the `.bib` and the openness reasoning. This matrix is a **real
+   workflow output** — it is what the openness judgement in step 4 and the
+   §2 gates read, not an assumed pre-existing input. If a
+   `literature_matrix.md` from an earlier run exists, `literature-triage-matrix`
+   appends to it; if either skill is unavailable, reason directly over the
+   `results` and record the reduced structure in the dossier.
 3. Build the **complete reference list** (real DOIs / arXiv IDs) as the
-   `.bib` companion **from the `search --json` metadata** — this is the
-   trust artifact; the researcher must be able to verify "open" themselves.
-   Do **not** use `cite --format bibtex` here: `cite` resolves identifiers
-   only against an already-ingested Zotero library, and at topic-selection
-   time the candidate papers are not ingested. Every entry must carry a
-   resolvable DOI or arXiv ID; drop any paper whose identifier did not
-   resolve (an unverifiable reference is not a trust artifact).
+   `.bib` companion **from the on-topic `results` metadata** (the same
+   `kept: true` set as step 2) — this is the trust artifact; the researcher
+   must be able to verify "open" themselves. Do **not** use
+   `cite --format bibtex` here: `cite` resolves identifiers only against an
+   already-ingested Zotero library, and at topic-selection time the
+   candidate papers are not ingested. Every entry must carry a resolvable
+   DOI or arXiv ID; drop any paper whose identifier did not resolve (an
+   unverifiable reference is not a trust artifact).
 4. Record the recall-confidence verdict as a **headline**, not a footnote,
-   and reason the per-gap openness over the step-2 matrix.
+   and report the `screening_summary` counts (retrieved vs on-topic) so the
+   reader sees how much of the corpus was off-topic noise. Reason the
+   per-gap openness over the step-2 matrix.
 
 A gap is never declared "open" on the basis of "absent from my corpus" —
 absence in a corpus is not absence in the literature.

--- a/skills/gap-to-topic/references/dossier-template.md
+++ b/skills/gap-to-topic/references/dossier-template.md
@@ -154,15 +154,15 @@ resource proves unobtainable within scope>.
 
 | Item | Detail |
 |---|---|
-| Pipeline | research-hub `search --adversarial --json` → `literature-triage-matrix` → gap-to-topic gates |
-| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence> |
+| Pipeline | research-hub `search --adversarial --screen --json` → `literature-triage-matrix` → gap-to-topic gates |
+| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence. The `--screen` BM25 relevance gate: retrieved / on-topic / screened-out counts.> |
 | Tool / version | <research-hub plugin version, run date, caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall> |
 
 ## Appendix B — Companion files
 
 | File | What it is |
 |---|---|
-| `<dossier>.bib` | The Gate 1 reference list as BibTeX — the trust artifact that lets the researcher verify "open" independently. Built from the `search --adversarial --json` metadata (NOT from `cite --format bibtex`, which resolves only already-ingested Zotero items — see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID. |
+| `<dossier>.bib` | The Gate 1 reference list as BibTeX — the trust artifact that lets the researcher verify "open" independently. Built from the on-topic `search --adversarial --screen --json` results (NOT from `cite --format bibtex`, which resolves only already-ingested Zotero items — see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID. |
 | `<dossier>.gaps.yml` | Structured export of the candidates + gate verdicts + open questions, so a later pass (or a downstream skill) can list every candidate and its standing. Keeps the machine ids and the formal enum tokens. Schema below. |
 | `literature_matrix.md` | The structured prior-art comparison (`literature-triage-matrix` output): one row per paper — method, claim, evidence, limitation, relevance. |
 

--- a/src/research_hub/skills_data/gap-to-topic/SKILL.md
+++ b/src/research_hub/skills_data/gap-to-topic/SKILL.md
@@ -73,9 +73,10 @@ In priority order:
 4. The user's free-text answers during the §0 and §3 conversational steps.
 
 This skill orchestrates other research-hub capabilities as tools:
-`search --adversarial --json` (§1 step 1 — recall + the metadata the
-`.bib` is built from) and `literature-triage-matrix` (§1 step 2 — turns
-the search results into the prior-art comparison matrix). `paper gaps`
+`search --adversarial --screen --json` (§1 step 1 — recall, the fit-check
+BM25 relevance gate, and the metadata the `.bib` is built from) and
+`literature-triage-matrix` (§1 step 2 — turns the on-topic search results
+into the prior-art comparison matrix). `paper gaps`
 is used only when a relevant ingested cluster already exists — at
 topic-selection time it usually does not, so the
 `search` → `literature-triage-matrix` path is the default. Note:
@@ -110,31 +111,42 @@ gate runs per gap.
 Incomplete recall is the dominant failure mode: a missed paper makes a gap
 look open when it is not. So this gate is **adversarial**:
 
-1. Run `research-hub search --adversarial --json` on the gap — it searches
-   several query phrasings, reports a recall-confidence verdict, and emits
-   full per-paper metadata (title, DOI / arXiv ID, year, authors, venue).
-   If `--adversarial` is unavailable (older CLI), run several query
-   phrasings by hand and record the reduced recall confidence in the dossier.
-2. Feed the retrieved papers to `literature-triage-matrix` (as its
-   input #0 — a Markdown list of titles + DOIs / arXiv IDs) to produce
+1. Run `research-hub search --adversarial --screen --json` on the gap. It
+   searches several query phrasings, reports a recall-confidence verdict,
+   and applies the fit-check BM25 relevance gate. With `--screen --json` the
+   output is an object `{screening_summary, results}`: `results` is the
+   per-paper list (title, DOI / arXiv ID, year, authors, venue, plus a
+   `relevance` field — `score` / `kept` / `tier` / `reason`), and
+   `screening_summary`
+   gives the retrieved / kept / screened-out counts. `--screen` never drops
+   a paper — it tags relevance, so recall stays auditable. If `--adversarial`
+   or `--screen` is unavailable (older CLI), run several query phrasings by
+   hand and record the reduced recall confidence in the dossier.
+2. From `results`, take the **on-topic** papers — those the relevance gate
+   tagged `kept: true` — and feed them to `literature-triage-matrix` (as
+   its input #0, a Markdown list of titles + DOIs / arXiv IDs) to produce
    `.research/literature_matrix.md`: the structured prior-art comparison
    (per paper — method, main claim, evidence, limitation, relevance).
-   This matrix is a **real workflow output** — it is what the openness
-   judgement in step 4 and the §2 gates read, not an assumed
-   pre-existing input. If a `literature_matrix.md` from an earlier run
-   exists, `literature-triage-matrix` appends to it; if the skill is
-   unavailable, reason directly over the `search --json` results and
-   record the reduced structure in the dossier.
+   Papers tagged `kept: false` are off-topic noise — keep them out of the
+   matrix, the `.bib` and the openness reasoning. This matrix is a **real
+   workflow output** — it is what the openness judgement in step 4 and the
+   §2 gates read, not an assumed pre-existing input. If a
+   `literature_matrix.md` from an earlier run exists, `literature-triage-matrix`
+   appends to it; if either skill is unavailable, reason directly over the
+   `results` and record the reduced structure in the dossier.
 3. Build the **complete reference list** (real DOIs / arXiv IDs) as the
-   `.bib` companion **from the `search --json` metadata** — this is the
-   trust artifact; the researcher must be able to verify "open" themselves.
-   Do **not** use `cite --format bibtex` here: `cite` resolves identifiers
-   only against an already-ingested Zotero library, and at topic-selection
-   time the candidate papers are not ingested. Every entry must carry a
-   resolvable DOI or arXiv ID; drop any paper whose identifier did not
-   resolve (an unverifiable reference is not a trust artifact).
+   `.bib` companion **from the on-topic `results` metadata** (the same
+   `kept: true` set as step 2) — this is the trust artifact; the researcher
+   must be able to verify "open" themselves. Do **not** use
+   `cite --format bibtex` here: `cite` resolves identifiers only against an
+   already-ingested Zotero library, and at topic-selection time the
+   candidate papers are not ingested. Every entry must carry a resolvable
+   DOI or arXiv ID; drop any paper whose identifier did not resolve (an
+   unverifiable reference is not a trust artifact).
 4. Record the recall-confidence verdict as a **headline**, not a footnote,
-   and reason the per-gap openness over the step-2 matrix.
+   and report the `screening_summary` counts (retrieved vs on-topic) so the
+   reader sees how much of the corpus was off-topic noise. Reason the
+   per-gap openness over the step-2 matrix.
 
 A gap is never declared "open" on the basis of "absent from my corpus" —
 absence in a corpus is not absence in the literature.

--- a/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
+++ b/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
@@ -154,15 +154,15 @@ resource proves unobtainable within scope>.
 
 | Item | Detail |
 |---|---|
-| Pipeline | research-hub `search --adversarial --json` → `literature-triage-matrix` → gap-to-topic gates |
-| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence> |
+| Pipeline | research-hub `search --adversarial --screen --json` → `literature-triage-matrix` → gap-to-topic gates |
+| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence. The `--screen` BM25 relevance gate: retrieved / on-topic / screened-out counts.> |
 | Tool / version | <research-hub plugin version, run date, caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall> |
 
 ## Appendix B — Companion files
 
 | File | What it is |
 |---|---|
-| `<dossier>.bib` | The Gate 1 reference list as BibTeX — the trust artifact that lets the researcher verify "open" independently. Built from the `search --adversarial --json` metadata (NOT from `cite --format bibtex`, which resolves only already-ingested Zotero items — see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID. |
+| `<dossier>.bib` | The Gate 1 reference list as BibTeX — the trust artifact that lets the researcher verify "open" independently. Built from the on-topic `search --adversarial --screen --json` results (NOT from `cite --format bibtex`, which resolves only already-ingested Zotero items — see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID. |
 | `<dossier>.gaps.yml` | Structured export of the candidates + gate verdicts + open questions, so a later pass (or a downstream skill) can list every candidate and its standing. Keeps the machine ids and the formal enum tokens. Schema below. |
 | `literature_matrix.md` | The structured prior-art comparison (`literature-triage-matrix` output): one row per paper — method, claim, evidence, limitation, relevance. |
 


### PR DESCRIPTION
## Summary

research-hub [#84](https://github.com/WenyuChiou/research-hub/pull/84) added a `--screen` flag to the `search` command (it applies the fit-check BM25 relevance gate). gap-to-topic §1 now uses it — previously §1's `search --adversarial --json` returned an unscreened, noisy corpus (the same off-topic-contamination problem the BM25 gate fixed for `auto`).

## Changes — `skills/gap-to-topic/SKILL.md` §1

- **step 1** runs `search --adversarial --screen --json` and reads the new `{screening_summary, results}` shape — each paper carries a `relevance` field (`score` / `kept` / `tier` / `reason`).
- **steps 2–3** build the `literature_matrix` and the `.bib` from the **on-topic** results only (`kept: true`); papers tagged `kept: false` are off-topic noise and are excluded from the matrix, the `.bib` and the openness reasoning.
- **step 4** reports the `screening_summary` counts (retrieved vs on-topic) in the recall headline.
- the "orchestrates" paragraph updated to match.

`references/dossier-template.md`: Appendix A pipeline + recall-mechanics rows updated; the `.bib` companion note updated.

Doc-only; no code path changed. Mirrored to `src/research_hub/skills_data/gap-to-topic/`. Plugin `0.3.5 → 0.3.6`.

## Verification

- `tests/test_v068_3_version_sync.py` — 3 passed (byte-parity).
- SKILL.md 190 lines (<500 spec limit).
- Independent `code-reviewer` → REQUEST CHANGES on one factual omission (the `relevance` object's `reason` key was missing from the SKILL.md field list); fixed (`score/kept/tier` → `score/kept/tier/reason`), re-mirrored, re-verified. All other checks PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)