### PR TITLE
fix(skill): gap-to-topic dossier — read it as a plain summary report

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **`gap-to-topic` dossier reworked to read as a plain summary report**
+  (`skills/gap-to-topic/`, plugin `0.3.6 → 0.3.7`).  A review found the
+  dossier still did not read cleanly in Word: the candidate roster showed
+  an `id` column of `G1`/`G2` codes; the Decision scorecard used
+  `✓ ✗ ~` glyphs and the jargon verdicts "No-go / Conditional go / Go";
+  there was no index of the bundle's files.  `references/dossier-template.md`
+  now: drops the `id` column (the `G1`/`G2` ids stay only in `.gaps.yml`)
+  and states "why it could be a gap" in plain words; drops the scorecard
+  glyphs for plain words; replaces the verdict jargon with plain phrasing
+  ("Do not pursue — as stated" / "Worth pursuing — only if its open
+  conditions hold" / "Worth pursuing"); adds a "What's in this deliverable"
+  index section; gives the Bottom line one plain paragraph per candidate.
+  The `.gaps.yml` schema moved to a trailing "not emitted" reference block.
+  SKILL.md "What it produces" updated.  Mirrored to
+  `src/research_hub/skills_data/gap-to-topic/`.
 - **`gap-to-topic` §1 now applies the fit-check relevance gate**
   (`skills/gap-to-topic/`, plugin `0.3.5 → 0.3.6`).  `search --screen`
   (PR #84) wired the BM25 relevance gate into the `search` command; §1 now

--- a/skills/gap-to-topic/SKILL.md
+++ b/skills/gap-to-topic/SKILL.md
@@ -37,19 +37,22 @@ Not for:
 
 ## What it produces
 
-`.research/topic_dossier.md` — a **reader-first** document: it opens with a
-plain-language verdict, runs each candidate through the 3-gate test, and
-keeps all tool / pipeline mechanics in two appendices at the end.
+`.research/topic_dossier.md` — a **reader-first summary report**: it must
+read top-to-bottom in Word with no decoding — no codes (`G1`/`G2` stay only
+in `.gaps.yml`), no decorative glyphs, plain-language verdicts ("Do not
+pursue — as stated" / "Worth pursuing — only if its open conditions hold" /
+"Worth pursuing"), tool mechanics kept in Appendix A.
 
 | Section | What it covers |
 |---|---|
-| Bottom line | the answer up front — a plain-language summary plus a **Decision scorecard** table (candidates × the 3 gates + verdict) |
-| The candidates | 1–N candidate topics in a roster table, each given a readable name; opening type stated in plain words (method-limitation vs unoccupied-application) |
-| Gate 1 — Is the gap still open? | is the gap genuinely unoccupied — backed by a complete, verifiable reference list |
+| Bottom line | the answer up front — one plain-language paragraph per candidate plus a **Decision scorecard** table (candidates × the 3 gates + verdict) |
+| What's in this deliverable | an index of the bundle — every file and what information it carries |
+| The candidates | 1–N candidate topics in a roster table, each given a readable name + a plain "why it could be a gap" phrase |
+| Gate 1 — Is the gap still open? | the literature funnel + classification, closest prior work, recall confidence |
 | Gate 2 — Would it be a real contribution? | dead-end history + new-capability-vs-extension |
 | Gate 3 — Is it feasible? | can the data / resources be obtained in time and budget |
-| The decision is yours | the dossier states explicitly the *"worth it"* verdict is the researcher's + advisor's |
-| Appendix A / B | how the dossier was produced (pipeline, recall mechanics) + the companion files |
+| The decision is yours | the dossier states explicitly the *"worth it"* verdict is the researcher's + advisor's; upgrade/kill test per conditional candidate |
+| Appendix A | how the dossier was produced (pipeline, recall mechanics) |
 
 (SKILL.md §0–§4 below are the agent's internal workflow steps; they map to
 the reader-facing sections above — §0 → The candidates, §1 → Gate 1, etc.)

--- a/skills/gap-to-topic/references/dossier-template.md
+++ b/skills/gap-to-topic/references/dossier-template.md
@@ -4,13 +4,20 @@
 > italic note is that section's contract — what it must contain. The dossier
 > is a thinking tool: surface uncertainty, do not polish it away.
 >
-> **Reader-first rules** (the dossier is for a researcher, not for the
-> pipeline): lead with the answer; name every candidate in plain words; put
-> the gate verdicts in the **Decision scorecard** table so the whole 3-gate
-> test is scannable at a glance; keep all tool / API / pipeline mechanics out
-> of the body — they live in Appendix A. Formal enum tokens
-> (`partially-occupied`, `borderline`, …) belong in the `.gaps.yml`
-> companion, not the prose — gloss them in the body.
+> **Reader-first rules** — the dossier must read as a plain summary report a
+> researcher understands top-to-bottom in Word, with no decoding:
+> - **No codes in the document.** Candidates are named in plain words; the
+>   machine ids (`G1`, `G2`, …) live only in the `.gaps.yml` companion,
+>   never in the dossier.
+> - **No decorative symbols.** No `✓ ✗ ~` glyphs, no `·` separators —
+>   plain words, plain numbering, commas and "and".
+> - **Plain verdicts.** Never "no-go / go" jargon — say "Do not pursue —
+>   as stated", "Worth pursuing — only if its open conditions hold",
+>   "Worth pursuing".
+> - **Lead with the answer**, state each gate verdict in plain language
+>   before the evidence, keep tool / pipeline mechanics in Appendix A.
+> - Formal enum tokens (`partially-occupied`, `borderline`, …) belong in
+>   `.gaps.yml`, not the prose — gloss them in plain words.
 
 ---
 
@@ -18,26 +25,28 @@
 
 ## Bottom line
 
-> *2–4 sentences of plain-language prose — what was evaluated and the
-> verdict for each named candidate — followed by the Decision scorecard
-> table. A reader must get the whole answer here without reading on.*
+> *One framing sentence (what was evaluated), then one short paragraph per
+> candidate — name it, give its plain-language outcome and the reason in a
+> sentence or two. Then the Decision scorecard, then the single most
+> important caveat. A reader must get the whole answer here.*
 
-<e.g. "Two candidate topics were evaluated. **<Candidate 1 name>** is a
-no-go — the gap is already taken. **<Candidate 2 name>** is a conditional
-go — open and feasible, but it rests on a medium-confidence search and one
-published caution. Whether to pursue it is your and your advisor's call.">
+<One sentence: N candidate topics were evaluated for <area>.>
+
+**<Candidate 1 name>** — <plain outcome>. <One or two plain sentences: why
+this outcome.>
+
+**<Candidate 2 name>** — <plain outcome>. <…>
 
 ### Decision scorecard
 
-> *Candidates × the 3 gates + the verdict. Cell convention: `✓` = passes,
-> `✗` = fails, `~` = borderline / qualified, `—` = not assessed (a
-> candidate that already failed an earlier gate). Each cell pairs the glyph
-> with one plain word. The Verdict column: No-go / Conditional go / Go.*
+> *Candidates against the 3 gates, plus the verdict. Plain words only — no
+> glyphs. A gate a candidate was not assessed on (it already failed an
+> earlier gate) reads "Not assessed".*
 
-| Candidate | Gate 1 · Open? | Gate 2 · A contribution? | Gate 3 · Feasible? | Verdict |
+| Candidate | Gate 1 — Open? | Gate 2 — A contribution? | Gate 3 — Feasible? | Verdict |
 |---|---|---|---|---|
-| 1 · <name> | <✓/✗/~ + word> | <✓/~/— + word> | <✓/~/✗/— + word> | **<No-go / Conditional go / Go>** |
-| 2 · <name> | … | … | … | **…** |
+| 1. <name> | <Open / Occupied / Partially occupied + confidence> | <A contribution / Borderline / Not assessed> | <Feasible / Feasible with effort / Blocked / Not assessed> | **<Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing>** |
+| 2. <name> | … | … | … | **…** |
 
 | Field | Value |
 |---|---|
@@ -47,53 +56,71 @@ published caution. Whether to pursue it is your and your advisor's call.">
 
 > *This dossier is a thinking tool, not a polished report. It runs each
 > candidate through a 3-gate test — open AND a contribution AND feasible. A
-> candidate that fails any gate is a no-go. The "is it worth doing" call is
-> handed back to the researcher and advisor.*
+> candidate that fails any gate should not be pursued as stated. The "is it
+> worth doing" call is handed back to the researcher and advisor.*
+
+## What's in this deliverable
+
+> *An index of the bundle — every file and what information it carries, so
+> a reader knows the whole pack from this one document.*
+
+| File | What it is | What it gives you |
+|---|---|---|
+| `topic_dossier.md` / `.docx` | This document — the topic-decision summary | The verdict on each candidate and the evidence behind it |
+| `topic_dossier.bib` | The reference list, as BibTeX | Every cited paper with a resolvable DOI / arXiv ID — lets you verify "open" yourself |
+| `literature_matrix.md` | The paper-by-paper comparison table | How each retrieved paper compares — method, claim, evidence type, limitation |
+| `topic_dossier.gaps.yml` | Machine-readable export | Structured data for a downstream tool or a later pass; not needed for reading |
 
 ## The candidates
 
 > *1–N candidates, articulated WITH the researcher (Socratic — never
-> invented). List them in the roster table, then give a one-sentence
-> statement per candidate. Each candidate has a short readable name; the
-> machine id (`G1`, `G2`, …) is a tag for the `.gaps.yml` companion, not
-> the reader's label. Opening type: a method-limitation opening (an
-> existing method cannot do X) or an unoccupied-application opening (no one
-> has applied a capability to a domain).*
+> invented). The roster table names each and says, in plain words, why it
+> could be a gap; then a one-sentence statement per candidate. Each
+> candidate also has a machine id (`G1`, `G2`, …) — that id goes ONLY into
+> `.gaps.yml`, never into this document.*
 
-| # | Candidate | Opening type | id |
-|---|---|---|---|
-| 1 | <readable name> | <unoccupied-application / method-limitation> opening | `G1` |
-| 2 | <readable name> | … | `G2` |
+| # | Candidate topic | Why it could be a gap |
+|---|---|---|
+| 1 | <readable name> | <plain phrase — e.g. "a capability no one has applied to this domain" or "a limit of existing methods"> |
+| 2 | <readable name> | <…> |
 
-**1 · <name>** — <one-sentence statement of the candidate>.
-
-**2 · <name>** — <…>
+1. **<name>** — <one-sentence statement of the candidate>.
+2. **<name>** — <…>
 
 ## Gate 1 — Is the gap still open?
 
-> *The verdict is in the Decision scorecard; this section is the EVIDENCE
-> behind it. Give the closest prior work (readable prose, real citations —
-> full list in the `.bib`), and a one-sentence recall-confidence headline
-> (how much to trust "open"). How the search was run belongs in Appendix A.
-> "Absent from my corpus" is never proof of "open".*
->
-> *Tag each cited work by evidence type — primary study / review / close
-> analogue / caution paper / conference abstract / preprint / data
-> artifact — and end with a one-sentence evidence-mix summary. The reader
-> must see how solid the occupancy signal is without opening
-> `literature_matrix.md`: an "occupied" verdict resting mostly on
-> conference abstracts is weaker than one resting on primary studies.*
+> *The verdict is in the Decision scorecard; this section is the evidence
+> behind it. Show the search funnel and the prior-art classification, the
+> closest prior work (each work tagged by evidence type), an evidence-mix
+> summary, and a one-sentence recall-confidence headline. Tool mechanics go
+> in Appendix A. "Absent from my corpus" is never proof of "open".*
 
-**Closest prior work:** <the papers that bear on whether each gap is filled
-— readable prose, each tagged by evidence type, e.g. "Smith 2024 (primary
-study)", "Jones 2026 (conference abstract)". Full list in the `.bib`,
-structured comparison in `literature_matrix.md`.>
+**Literature collected.** The Gate 1 search funnel:
 
-**Evidence mix:** <one sentence — e.g. "Of the 9 papers on Candidate 1:
-4 primary studies, 1 review, 3 conference abstracts, 1 data artifact — the
-occupancy signal is clear but partly early-stage.">
+| Stage | Count |
+|---|---|
+| Retrieved (adversarial query phrasings) | <N unique papers> |
+| Returned for relevance screening | <M> |
+| Kept on-topic by the relevance gate | <K> |
+| Selected into the prior-art corpus | <P> |
 
-**Recall confidence:** <one plain sentence — e.g. "Medium: one search
+Classification of the prior-art corpus (full per-paper detail in
+`literature_matrix.md`):
+
+| By evidence type | By candidate |
+|---|---|
+| <e.g. 6 primary studies, 2 reviews, 1 survey, 1 perspective, 1 caution paper, 2 close analogues> | <e.g. 9 bear on Candidate 1, 4 on Candidate 2> |
+
+**Closest prior work.** <The papers that bear on whether each gap is filled
+— readable prose, each tagged by evidence type (primary study, review,
+survey, perspective, caution paper, close analogue, conference abstract,
+preprint, data artifact). Full list in the `.bib`.>
+
+**Evidence mix.** <One or two sentences: how solid the occupancy signal is
+— e.g. an "occupied" verdict resting mostly on conference abstracts is
+weaker than one resting on primary studies.>
+
+**Recall confidence.** <One plain sentence — e.g. "Medium: one search
 backend was unavailable, so a missed paper is possible; re-check before
 relying on an 'open' verdict.">
 
@@ -103,8 +130,8 @@ relying on an 'open' verdict.">
 > candidate, two plain-language questions. (1) Has the field already tried
 > this and hit a wall? — a gap can be open because the field gave up.
 > (2) Would this be a new capability, or an extension of existing work? —
-> a descriptive lens, NOT a quality judgment; an extension can be well worth
-> doing. A candidate that failed Gate 1 is not assessed here.*
+> a descriptive lens, NOT a quality judgment; an extension can be well
+> worth doing. A candidate that failed Gate 1 is not assessed here.*
 
 - **<candidate> — has the field hit a wall here?** <plain answer +
   evidence; cite the paper(s).>
@@ -128,23 +155,24 @@ relying on an 'open' verdict.">
 
 > *State explicitly that the dossier stops here. It has assembled the three
 > gate verdicts; whether a gap is WORTH doing is the researcher's and
-> advisor's call. Per candidate, name the outcome and the conditions the
-> human must resolve before committing. For each conditional-go candidate,
-> give an explicit **upgrade / kill test** — the finding that would make it
-> a clear go, and the finding that would make it a no-go — so the threshold
-> logic lives in the dossier, not left for the advisor to supply.*
+> advisor's call. Per candidate, name the outcome in plain words and the
+> conditions the human must resolve before committing. For each candidate
+> that is "worth pursuing only if its conditions hold", give an explicit
+> upgrade / kill test — the finding that would make it a clear go, and the
+> finding that would make it not worth pursuing.*
 
-The three gates above are assembled evidence, not a verdict. A go requires
-all three to pass (open AND a contribution AND feasible); any gate failing
-is a no-go. **Whether <Candidate N> is worth pursuing is your and your
-advisor's decision.** <Per-candidate: the outcome, and the conditions to
-resolve first.>
+The three gates above are assembled evidence, not a verdict. A topic is
+worth pursuing only if all three pass — open AND a contribution AND
+feasible; if any gate fails, do not pursue it as stated. **Whether
+<Candidate N> is worth pursuing is your and your advisor's decision.**
+<Per-candidate: the plain-language outcome, and the conditions to resolve
+first.>
 
-**Upgrade / kill test — <conditional-go candidate>.** It becomes a clear
-**go** if <the findings that would resolve every open condition favourably>.
-It becomes a **no-go** if <the finding that would fail any gate — e.g. the
-recall re-run surfaces a paper already occupying the gap, or the binding
-resource proves unobtainable within scope>.
+**Upgrade / kill test — <conditional candidate>.** It becomes clearly
+**worth pursuing** if <the findings that resolve every open condition
+favourably>. It is **not worth pursuing as stated** if <the finding that
+would fail any gate — e.g. the recall re-run surfaces a paper already
+occupying the gap, or the binding resource proves unobtainable>.
 
 ---
 
@@ -155,19 +183,18 @@ resource proves unobtainable within scope>.
 | Item | Detail |
 |---|---|
 | Pipeline | research-hub `search --adversarial --screen --json` → `literature-triage-matrix` → gap-to-topic gates |
-| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence. The `--screen` BM25 relevance gate: retrieved / on-topic / screened-out counts.> |
+| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence. The `--screen` relevance gate: retrieved / on-topic / screened-out counts.> |
 | Tool / version | <research-hub plugin version, run date, caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall> |
 
-## Appendix B — Companion files
+---
 
-| File | What it is |
-|---|---|
-| `<dossier>.bib` | The Gate 1 reference list as BibTeX — the trust artifact that lets the researcher verify "open" independently. Built from the on-topic `search --adversarial --screen --json` results (NOT from `cite --format bibtex`, which resolves only already-ingested Zotero items — see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID. |
-| `<dossier>.gaps.yml` | Structured export of the candidates + gate verdicts + open questions, so a later pass (or a downstream skill) can list every candidate and its standing. Keeps the machine ids and the formal enum tokens. Schema below. |
-| `literature_matrix.md` | The structured prior-art comparison (`literature-triage-matrix` output): one row per paper — method, claim, evidence, limitation, relevance. |
+## Schema reference — `topic_dossier.gaps.yml` (NOT emitted in the dossier)
+
+> The `.gaps.yml` companion is machine-readable and is **not** part of the
+> human dossier above. It keeps the machine ids (`G1`, `G2`) and the formal
+> enum tokens. Its shape:
 
 ```yaml
-# <dossier>.gaps.yml
 dossier: <topic area>
 generated: "YYYY-MM-DD"
 gaps:
@@ -184,3 +211,8 @@ open_questions:
   - id: Q1
     text: "<question the evidence could not settle>"
 ```
+
+The `.bib` companion is the Gate 1 reference list as BibTeX — built from the
+on-topic `search --adversarial --screen --json` results (NOT from
+`cite --format bibtex`, which resolves only already-ingested Zotero items —
+see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID.

--- a/src/research_hub/skills_data/gap-to-topic/SKILL.md
+++ b/src/research_hub/skills_data/gap-to-topic/SKILL.md
@@ -37,19 +37,22 @@ Not for:
 
 ## What it produces
 
-`.research/topic_dossier.md` — a **reader-first** document: it opens with a
-plain-language verdict, runs each candidate through the 3-gate test, and
-keeps all tool / pipeline mechanics in two appendices at the end.
+`.research/topic_dossier.md` — a **reader-first summary report**: it must
+read top-to-bottom in Word with no decoding — no codes (`G1`/`G2` stay only
+in `.gaps.yml`), no decorative glyphs, plain-language verdicts ("Do not
+pursue — as stated" / "Worth pursuing — only if its open conditions hold" /
+"Worth pursuing"), tool mechanics kept in Appendix A.
 
 | Section | What it covers |
 |---|---|
-| Bottom line | the answer up front — a plain-language summary plus a **Decision scorecard** table (candidates × the 3 gates + verdict) |
-| The candidates | 1–N candidate topics in a roster table, each given a readable name; opening type stated in plain words (method-limitation vs unoccupied-application) |
-| Gate 1 — Is the gap still open? | is the gap genuinely unoccupied — backed by a complete, verifiable reference list |
+| Bottom line | the answer up front — one plain-language paragraph per candidate plus a **Decision scorecard** table (candidates × the 3 gates + verdict) |
+| What's in this deliverable | an index of the bundle — every file and what information it carries |
+| The candidates | 1–N candidate topics in a roster table, each given a readable name + a plain "why it could be a gap" phrase |
+| Gate 1 — Is the gap still open? | the literature funnel + classification, closest prior work, recall confidence |
 | Gate 2 — Would it be a real contribution? | dead-end history + new-capability-vs-extension |
 | Gate 3 — Is it feasible? | can the data / resources be obtained in time and budget |
-| The decision is yours | the dossier states explicitly the *"worth it"* verdict is the researcher's + advisor's |
-| Appendix A / B | how the dossier was produced (pipeline, recall mechanics) + the companion files |
+| The decision is yours | the dossier states explicitly the *"worth it"* verdict is the researcher's + advisor's; upgrade/kill test per conditional candidate |
+| Appendix A | how the dossier was produced (pipeline, recall mechanics) |
 
 (SKILL.md §0–§4 below are the agent's internal workflow steps; they map to
 the reader-facing sections above — §0 → The candidates, §1 → Gate 1, etc.)

--- a/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
+++ b/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
@@ -4,13 +4,20 @@
 > italic note is that section's contract — what it must contain. The dossier
 > is a thinking tool: surface uncertainty, do not polish it away.
 >
-> **Reader-first rules** (the dossier is for a researcher, not for the
-> pipeline): lead with the answer; name every candidate in plain words; put
-> the gate verdicts in the **Decision scorecard** table so the whole 3-gate
-> test is scannable at a glance; keep all tool / API / pipeline mechanics out
-> of the body — they live in Appendix A. Formal enum tokens
-> (`partially-occupied`, `borderline`, …) belong in the `.gaps.yml`
-> companion, not the prose — gloss them in the body.
+> **Reader-first rules** — the dossier must read as a plain summary report a
+> researcher understands top-to-bottom in Word, with no decoding:
+> - **No codes in the document.** Candidates are named in plain words; the
+>   machine ids (`G1`, `G2`, …) live only in the `.gaps.yml` companion,
+>   never in the dossier.
+> - **No decorative symbols.** No `✓ ✗ ~` glyphs, no `·` separators —
+>   plain words, plain numbering, commas and "and".
+> - **Plain verdicts.** Never "no-go / go" jargon — say "Do not pursue —
+>   as stated", "Worth pursuing — only if its open conditions hold",
+>   "Worth pursuing".
+> - **Lead with the answer**, state each gate verdict in plain language
+>   before the evidence, keep tool / pipeline mechanics in Appendix A.
+> - Formal enum tokens (`partially-occupied`, `borderline`, …) belong in
+>   `.gaps.yml`, not the prose — gloss them in plain words.
 
 ---
 
@@ -18,26 +25,28 @@
 
 ## Bottom line
 
-> *2–4 sentences of plain-language prose — what was evaluated and the
-> verdict for each named candidate — followed by the Decision scorecard
-> table. A reader must get the whole answer here without reading on.*
+> *One framing sentence (what was evaluated), then one short paragraph per
+> candidate — name it, give its plain-language outcome and the reason in a
+> sentence or two. Then the Decision scorecard, then the single most
+> important caveat. A reader must get the whole answer here.*
 
-<e.g. "Two candidate topics were evaluated. **<Candidate 1 name>** is a
-no-go — the gap is already taken. **<Candidate 2 name>** is a conditional
-go — open and feasible, but it rests on a medium-confidence search and one
-published caution. Whether to pursue it is your and your advisor's call.">
+<One sentence: N candidate topics were evaluated for <area>.>
+
+**<Candidate 1 name>** — <plain outcome>. <One or two plain sentences: why
+this outcome.>
+
+**<Candidate 2 name>** — <plain outcome>. <…>
 
 ### Decision scorecard
 
-> *Candidates × the 3 gates + the verdict. Cell convention: `✓` = passes,
-> `✗` = fails, `~` = borderline / qualified, `—` = not assessed (a
-> candidate that already failed an earlier gate). Each cell pairs the glyph
-> with one plain word. The Verdict column: No-go / Conditional go / Go.*
+> *Candidates against the 3 gates, plus the verdict. Plain words only — no
+> glyphs. A gate a candidate was not assessed on (it already failed an
+> earlier gate) reads "Not assessed".*
 
-| Candidate | Gate 1 · Open? | Gate 2 · A contribution? | Gate 3 · Feasible? | Verdict |
+| Candidate | Gate 1 — Open? | Gate 2 — A contribution? | Gate 3 — Feasible? | Verdict |
 |---|---|---|---|---|
-| 1 · <name> | <✓/✗/~ + word> | <✓/~/— + word> | <✓/~/✗/— + word> | **<No-go / Conditional go / Go>** |
-| 2 · <name> | … | … | … | **…** |
+| 1. <name> | <Open / Occupied / Partially occupied + confidence> | <A contribution / Borderline / Not assessed> | <Feasible / Feasible with effort / Blocked / Not assessed> | **<Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing>** |
+| 2. <name> | … | … | … | **…** |
 
 | Field | Value |
 |---|---|
@@ -47,53 +56,71 @@ published caution. Whether to pursue it is your and your advisor's call.">
 
 > *This dossier is a thinking tool, not a polished report. It runs each
 > candidate through a 3-gate test — open AND a contribution AND feasible. A
-> candidate that fails any gate is a no-go. The "is it worth doing" call is
-> handed back to the researcher and advisor.*
+> candidate that fails any gate should not be pursued as stated. The "is it
+> worth doing" call is handed back to the researcher and advisor.*
+
+## What's in this deliverable
+
+> *An index of the bundle — every file and what information it carries, so
+> a reader knows the whole pack from this one document.*
+
+| File | What it is | What it gives you |
+|---|---|---|
+| `topic_dossier.md` / `.docx` | This document — the topic-decision summary | The verdict on each candidate and the evidence behind it |
+| `topic_dossier.bib` | The reference list, as BibTeX | Every cited paper with a resolvable DOI / arXiv ID — lets you verify "open" yourself |
+| `literature_matrix.md` | The paper-by-paper comparison table | How each retrieved paper compares — method, claim, evidence type, limitation |
+| `topic_dossier.gaps.yml` | Machine-readable export | Structured data for a downstream tool or a later pass; not needed for reading |
 
 ## The candidates
 
 > *1–N candidates, articulated WITH the researcher (Socratic — never
-> invented). List them in the roster table, then give a one-sentence
-> statement per candidate. Each candidate has a short readable name; the
-> machine id (`G1`, `G2`, …) is a tag for the `.gaps.yml` companion, not
-> the reader's label. Opening type: a method-limitation opening (an
-> existing method cannot do X) or an unoccupied-application opening (no one
-> has applied a capability to a domain).*
+> invented). The roster table names each and says, in plain words, why it
+> could be a gap; then a one-sentence statement per candidate. Each
+> candidate also has a machine id (`G1`, `G2`, …) — that id goes ONLY into
+> `.gaps.yml`, never into this document.*
 
-| # | Candidate | Opening type | id |
-|---|---|---|---|
-| 1 | <readable name> | <unoccupied-application / method-limitation> opening | `G1` |
-| 2 | <readable name> | … | `G2` |
+| # | Candidate topic | Why it could be a gap |
+|---|---|---|
+| 1 | <readable name> | <plain phrase — e.g. "a capability no one has applied to this domain" or "a limit of existing methods"> |
+| 2 | <readable name> | <…> |
 
-**1 · <name>** — <one-sentence statement of the candidate>.
-
-**2 · <name>** — <…>
+1. **<name>** — <one-sentence statement of the candidate>.
+2. **<name>** — <…>
 
 ## Gate 1 — Is the gap still open?
 
-> *The verdict is in the Decision scorecard; this section is the EVIDENCE
-> behind it. Give the closest prior work (readable prose, real citations —
-> full list in the `.bib`), and a one-sentence recall-confidence headline
-> (how much to trust "open"). How the search was run belongs in Appendix A.
-> "Absent from my corpus" is never proof of "open".*
->
-> *Tag each cited work by evidence type — primary study / review / close
-> analogue / caution paper / conference abstract / preprint / data
-> artifact — and end with a one-sentence evidence-mix summary. The reader
-> must see how solid the occupancy signal is without opening
-> `literature_matrix.md`: an "occupied" verdict resting mostly on
-> conference abstracts is weaker than one resting on primary studies.*
+> *The verdict is in the Decision scorecard; this section is the evidence
+> behind it. Show the search funnel and the prior-art classification, the
+> closest prior work (each work tagged by evidence type), an evidence-mix
+> summary, and a one-sentence recall-confidence headline. Tool mechanics go
+> in Appendix A. "Absent from my corpus" is never proof of "open".*
 
-**Closest prior work:** <the papers that bear on whether each gap is filled
-— readable prose, each tagged by evidence type, e.g. "Smith 2024 (primary
-study)", "Jones 2026 (conference abstract)". Full list in the `.bib`,
-structured comparison in `literature_matrix.md`.>
+**Literature collected.** The Gate 1 search funnel:
 
-**Evidence mix:** <one sentence — e.g. "Of the 9 papers on Candidate 1:
-4 primary studies, 1 review, 3 conference abstracts, 1 data artifact — the
-occupancy signal is clear but partly early-stage.">
+| Stage | Count |
+|---|---|
+| Retrieved (adversarial query phrasings) | <N unique papers> |
+| Returned for relevance screening | <M> |
+| Kept on-topic by the relevance gate | <K> |
+| Selected into the prior-art corpus | <P> |
 
-**Recall confidence:** <one plain sentence — e.g. "Medium: one search
+Classification of the prior-art corpus (full per-paper detail in
+`literature_matrix.md`):
+
+| By evidence type | By candidate |
+|---|---|
+| <e.g. 6 primary studies, 2 reviews, 1 survey, 1 perspective, 1 caution paper, 2 close analogues> | <e.g. 9 bear on Candidate 1, 4 on Candidate 2> |
+
+**Closest prior work.** <The papers that bear on whether each gap is filled
+— readable prose, each tagged by evidence type (primary study, review,
+survey, perspective, caution paper, close analogue, conference abstract,
+preprint, data artifact). Full list in the `.bib`.>
+
+**Evidence mix.** <One or two sentences: how solid the occupancy signal is
+— e.g. an "occupied" verdict resting mostly on conference abstracts is
+weaker than one resting on primary studies.>
+
+**Recall confidence.** <One plain sentence — e.g. "Medium: one search
 backend was unavailable, so a missed paper is possible; re-check before
 relying on an 'open' verdict.">
 
@@ -103,8 +130,8 @@ relying on an 'open' verdict.">
 > candidate, two plain-language questions. (1) Has the field already tried
 > this and hit a wall? — a gap can be open because the field gave up.
 > (2) Would this be a new capability, or an extension of existing work? —
-> a descriptive lens, NOT a quality judgment; an extension can be well worth
-> doing. A candidate that failed Gate 1 is not assessed here.*
+> a descriptive lens, NOT a quality judgment; an extension can be well
+> worth doing. A candidate that failed Gate 1 is not assessed here.*
 
 - **<candidate> — has the field hit a wall here?** <plain answer +
   evidence; cite the paper(s).>
@@ -128,23 +155,24 @@ relying on an 'open' verdict.">
 
 > *State explicitly that the dossier stops here. It has assembled the three
 > gate verdicts; whether a gap is WORTH doing is the researcher's and
-> advisor's call. Per candidate, name the outcome and the conditions the
-> human must resolve before committing. For each conditional-go candidate,
-> give an explicit **upgrade / kill test** — the finding that would make it
-> a clear go, and the finding that would make it a no-go — so the threshold
-> logic lives in the dossier, not left for the advisor to supply.*
+> advisor's call. Per candidate, name the outcome in plain words and the
+> conditions the human must resolve before committing. For each candidate
+> that is "worth pursuing only if its conditions hold", give an explicit
+> upgrade / kill test — the finding that would make it a clear go, and the
+> finding that would make it not worth pursuing.*
 
-The three gates above are assembled evidence, not a verdict. A go requires
-all three to pass (open AND a contribution AND feasible); any gate failing
-is a no-go. **Whether <Candidate N> is worth pursuing is your and your
-advisor's decision.** <Per-candidate: the outcome, and the conditions to
-resolve first.>
+The three gates above are assembled evidence, not a verdict. A topic is
+worth pursuing only if all three pass — open AND a contribution AND
+feasible; if any gate fails, do not pursue it as stated. **Whether
+<Candidate N> is worth pursuing is your and your advisor's decision.**
+<Per-candidate: the plain-language outcome, and the conditions to resolve
+first.>
 
-**Upgrade / kill test — <conditional-go candidate>.** It becomes a clear
-**go** if <the findings that would resolve every open condition favourably>.
-It becomes a **no-go** if <the finding that would fail any gate — e.g. the
-recall re-run surfaces a paper already occupying the gap, or the binding
-resource proves unobtainable within scope>.
+**Upgrade / kill test — <conditional candidate>.** It becomes clearly
+**worth pursuing** if <the findings that resolve every open condition
+favourably>. It is **not worth pursuing as stated** if <the finding that
+would fail any gate — e.g. the recall re-run surfaces a paper already
+occupying the gap, or the binding resource proves unobtainable>.
 
 ---
 
@@ -155,19 +183,18 @@ resource proves unobtainable within scope>.
 | Item | Detail |
 |---|---|
 | Pipeline | research-hub `search --adversarial --screen --json` → `literature-triage-matrix` → gap-to-topic gates |
-| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence. The `--screen` BM25 relevance gate: retrieved / on-topic / screened-out counts.> |
+| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence. The `--screen` relevance gate: retrieved / on-topic / screened-out counts.> |
 | Tool / version | <research-hub plugin version, run date, caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall> |
 
-## Appendix B — Companion files
+---
 
-| File | What it is |
-|---|---|
-| `<dossier>.bib` | The Gate 1 reference list as BibTeX — the trust artifact that lets the researcher verify "open" independently. Built from the on-topic `search --adversarial --screen --json` results (NOT from `cite --format bibtex`, which resolves only already-ingested Zotero items — see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID. |
-| `<dossier>.gaps.yml` | Structured export of the candidates + gate verdicts + open questions, so a later pass (or a downstream skill) can list every candidate and its standing. Keeps the machine ids and the formal enum tokens. Schema below. |
-| `literature_matrix.md` | The structured prior-art comparison (`literature-triage-matrix` output): one row per paper — method, claim, evidence, limitation, relevance. |
+## Schema reference — `topic_dossier.gaps.yml` (NOT emitted in the dossier)
+
+> The `.gaps.yml` companion is machine-readable and is **not** part of the
+> human dossier above. It keeps the machine ids (`G1`, `G2`) and the formal
+> enum tokens. Its shape:
 
 ```yaml
-# <dossier>.gaps.yml
 dossier: <topic area>
 generated: "YYYY-MM-DD"
 gaps:
@@ -184,3 +211,8 @@ open_questions:
   - id: Q1
     text: "<question the evidence could not settle>"
 ```
+
+The `.bib` companion is the Gate 1 reference list as BibTeX — built from the
+on-topic `search --adversarial --screen --json` results (NOT from
+`cite --format bibtex`, which resolves only already-ingested Zotero items —
+see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID.


### PR DESCRIPTION
## Problem

A Word review found the `gap-to-topic` dossier still did not read as a self-contained summary report:

- the candidate roster carried an `id` column of `G1`/`G2` codes a reader cannot decode;
- the Decision scorecard used `✓ ✗ ~` glyphs and the jargon verdicts "No-go / Conditional go / Go";
- nothing indexed the bundle — a reader had no guide to what each file is.

## Changes — `references/dossier-template.md`

- **Roster drops the `id` column.** `G1`/`G2` now live only in `.gaps.yml`; the roster says "why it could be a gap" in plain words (not "unoccupied-application opening").
- **Scorecard drops the `✓ ✗ ~` glyphs** — plain words only.
- **Plain verdicts everywhere** — "Do not pursue — as stated" / "Worth pursuing — only if its open conditions hold" / "Worth pursuing" (no "no-go/go" jargon in emitted prose).
- **New "What's in this deliverable" index section** — every bundle file and what information it carries (replaces "Appendix B — Companion files").
- **Bottom line** — one plain paragraph per candidate (skimmable), not one dense paragraph.
- The `.gaps.yml` YAML schema moved to a trailing **"NOT emitted in the dossier"** reference block.

`SKILL.md` "What it produces" table updated. Doc-only. Mirrored to `src/research_hub/skills_data/gap-to-topic/`. Plugin `0.3.6 → 0.3.7`.

## Verification

- `tests/test_v068_3_version_sync.py` — 3 passed (byte-parity).
- SKILL.md 194 lines (<500 spec limit).
- Independent `code-reviewer` → **APPROVE** — no glyphs in emitted prose, no `id` column, plain verdicts, all tables well-formed, cross-references resolve. One scorecard verdict-phrasing nit found and fixed before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)