### PR TITLE
fix(skill): gap-to-topic dossier — section-by-section rework (v0.3.8)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,28 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **`gap-to-topic` dossier — section-by-section rework for researcher value**
+  (`skills/gap-to-topic/`, plugin `0.3.7 → 0.3.8`).  A section-by-section
+  review with the maintainer, plus a Codex evaluation, reworked
+  `references/dossier-template.md`:
+  - **Decision scorecard** is now a 5-point Likert per gate — each gate is
+    a claim rated 1–5 (strongly agree … strongly disagree); the cell is
+    `N/5 label — description`; a topic is worth pursuing only if every gate
+    rates 3 or higher.
+  - **Gate 2** gains "What it would contribute" (one explicit claim) and a
+    "Minimum validation sketch"; a caution paper is summarised by the kind
+    of risk it raises, not offloaded to the reader.
+  - **Gate 3** gains "Design feasibility", a "Scale outline", and an
+    explicit proposal-vs-dissertation feasibility split — it is no longer
+    only a data-availability test.
+  - **The decision is yours** is framed consistently as a conditional
+    recommendation; the upgrade/kill test is written as concrete artifacts;
+    a failed candidate gets a salvage-path line.
+  - **Appendix A** is recast from a tool log into a method note (search
+    scope, inclusion criteria, automated-vs-judgement).
+  - **What's in this deliverable** gains a file tree.
+  SKILL.md "What it produces" updated.  Mirrored to
+  `src/research_hub/skills_data/gap-to-topic/`.
 - **`gap-to-topic` dossier reworked to read as a plain summary report**
   (`skills/gap-to-topic/`, plugin `0.3.6 → 0.3.7`).  A review found the
   dossier still did not read cleanly in Word: the candidate roster showed

--- a/skills/gap-to-topic/SKILL.md
+++ b/skills/gap-to-topic/SKILL.md
@@ -45,14 +45,14 @@ pursue — as stated" / "Worth pursuing — only if its open conditions hold" /
 
 | Section | What it covers |
 |---|---|
-| Bottom line | the answer up front — one plain-language paragraph per candidate plus a **Decision scorecard** table (candidates × the 3 gates + verdict) |
-| What's in this deliverable | an index of the bundle — every file and what information it carries |
-| The candidates | 1–N candidate topics in a roster table, each given a readable name + a plain "why it could be a gap" phrase |
-| Gate 1 — Is the gap still open? | the literature funnel + classification, closest prior work, recall confidence |
-| Gate 2 — Would it be a real contribution? | dead-end history + new-capability-vs-extension |
-| Gate 3 — Is it feasible? | can the data / resources be obtained in time and budget |
-| The decision is yours | the dossier states explicitly the *"worth it"* verdict is the researcher's + advisor's; upgrade/kill test per conditional candidate |
-| Appendix A | how the dossier was produced (pipeline, recall mechanics) |
+| Bottom line | the answer up front — one plain-language paragraph per candidate plus a **Decision scorecard**: each gate rated 1–5 (Likert), candidates × the 3 gates + verdict |
+| What's in this deliverable | an index of the bundle — every file, what it carries, and a file tree |
+| The candidates | 1–N candidate topics in a roster table, each given a readable name + a plain "why it could be a gap" tag |
+| Gate 1 — Is the gap still open? | the literature funnel + classification, closest prior work and how solid it is, recall confidence |
+| Gate 2 — Would it be a real contribution? | what it would contribute, dead-end history, new-capability-vs-extension, a minimum validation sketch |
+| Gate 3 — Is it feasible? | data / resources, design feasibility, a scale outline, the binding constraint, proposal-vs-dissertation feasibility |
+| The decision is yours | a conditional recommendation pending named checks; an operational upgrade/kill test; a salvage path for a failed candidate |
+| Appendix A | how the dossier was produced — a method note (search scope, inclusion criteria, automated-vs-judgement) |
 
 (SKILL.md §0–§4 below are the agent's internal workflow steps; they map to
 the reader-facing sections above — §0 → The candidates, §1 → Gate 1, etc.)

--- a/skills/gap-to-topic/references/dossier-template.md
+++ b/skills/gap-to-topic/references/dossier-template.md
@@ -4,20 +4,20 @@
 > italic note is that section's contract — what it must contain. The dossier
 > is a thinking tool: surface uncertainty, do not polish it away.
 >
-> **Reader-first rules** — the dossier must read as a plain summary report a
-> researcher understands top-to-bottom in Word, with no decoding:
+> **Reader-first rules** — the dossier is written for a researcher (a
+> graduate student and their advisor) deciding a thesis or proposal topic.
+> It must read as a plain summary report, top-to-bottom, with no decoding:
 > - **No codes in the document.** Candidates are named in plain words; the
->   machine ids (`G1`, `G2`, …) live only in the `.gaps.yml` companion,
->   never in the dossier.
-> - **No decorative symbols.** No `✓ ✗ ~` glyphs, no `·` separators —
->   plain words, plain numbering, commas and "and".
+>   machine ids (`G1`, `G2`, …) live only in the `.gaps.yml` companion.
+> - **No decorative symbols.** No `✓ ✗ ~` glyphs, no `·` separators.
 > - **Plain verdicts.** Never "no-go / go" jargon — say "Do not pursue —
 >   as stated", "Worth pursuing — only if its open conditions hold",
 >   "Worth pursuing".
-> - **Lead with the answer**, state each gate verdict in plain language
->   before the evidence, keep tool / pipeline mechanics in Appendix A.
+> - **Lead with the answer**; keep tool / pipeline mechanics in Appendix A.
 > - Formal enum tokens (`partially-occupied`, `borderline`, …) belong in
 >   `.gaps.yml`, not the prose — gloss them in plain words.
+> - The dossier is **English by default**. A translated mirror is produced
+>   only on request, in a sibling-language folder.
 
 ---
 
@@ -26,26 +26,33 @@
 ## Bottom line
 
 > *One framing sentence (what was evaluated), then one short paragraph per
-> candidate — name it, give its plain-language outcome and the reason in a
-> sentence or two. Then the Decision scorecard, then the single most
-> important caveat. A reader must get the whole answer here.*
+> candidate — name it, give its plain-language outcome, and the reason in a
+> sentence or two. Each paragraph must name at least one concrete piece of
+> evidence. Then the Decision scorecard, then the one key caveat.*
 
 <One sentence: N candidate topics were evaluated for <area>.>
 
-**<Candidate 1 name>** — <plain outcome>. <One or two plain sentences: why
-this outcome.>
+**<Candidate 1 name>** — <plain outcome>. <One or two plain sentences; name
+a concrete piece of evidence.>
 
-**<Candidate 2 name>** — <plain outcome>. <…>
+**<Candidate 2 name>** — <plain outcome>. <…with a concrete piece of
+evidence named.>
 
 ### Decision scorecard
 
-> *Candidates against the 3 gates, plus the verdict. Plain words only — no
-> glyphs. A gate a candidate was not assessed on (it already failed an
-> earlier gate) reads "Not assessed".*
+> *Each gate is stated as a claim and rated 1–5: 5 = strongly agree the
+> claim holds, 3 = mixed or qualified, 1 = strongly disagree. A topic is
+> worth pursuing only if every gate rates 3 or higher. A gate after a gate
+> that already failed reads "Not assessed". No glyphs — the cell is
+> `N/5 label — short description`.*
 
-| Candidate | Gate 1 — Open? | Gate 2 — A contribution? | Gate 3 — Feasible? | Verdict |
+Rating: 5 = strongly agree, 4 = agree, 3 = neutral, 2 = disagree,
+1 = strongly disagree. A topic is worth pursuing only if every gate is 3 or
+higher.
+
+| Candidate | Gate 1 — "the gap is still open" | Gate 2 — "it would be a real contribution" | Gate 3 — "it is feasible within reach" | Verdict |
 |---|---|---|---|---|
-| 1. <name> | <Open / Occupied / Partially occupied + confidence> | <A contribution / Borderline / Not assessed> | <Feasible / Feasible with effort / Blocked / Not assessed> | **<Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing>** |
+| 1. <name> | <N/5 label — short description> | <N/5 label — … or "Not assessed"> | <N/5 label — … or "Not assessed"> | **<Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing>** |
 | 2. <name> | … | … | … | **…** |
 
 | Field | Value |
@@ -61,8 +68,10 @@ this outcome.>
 
 ## What's in this deliverable
 
-> *An index of the bundle — every file and what information it carries, so
-> a reader knows the whole pack from this one document.*
+> *An index of the bundle — every file and what information it carries — so
+> a reader knows the whole pack from this one document, then a file tree of
+> the layout. A default (English-only) dossier lists a flat bundle; a
+> translated deliverable shows the sibling-language folders.*
 
 | File | What it is | What it gives you |
 |---|---|---|
@@ -71,17 +80,27 @@ this outcome.>
 | `literature_matrix.md` | The paper-by-paper comparison table | How each retrieved paper compares — method, claim, evidence type, limitation |
 | `topic_dossier.gaps.yml` | Machine-readable export | Structured data for a downstream tool or a later pass; not needed for reading |
 
+```
+<deliverable-folder>/
+├── topic_dossier.md / .docx
+├── topic_dossier.bib
+├── literature_matrix.md
+└── topic_dossier.gaps.yml
+```
+
 ## The candidates
 
 > *1–N candidates, articulated WITH the researcher (Socratic — never
 > invented). The roster table names each and says, in plain words, why it
-> could be a gap; then a one-sentence statement per candidate. Each
-> candidate also has a machine id (`G1`, `G2`, …) — that id goes ONLY into
-> `.gaps.yml`, never into this document.*
+> could be a gap — each "why" cell leads with one of two plain tags:
+> "No one has tried this" (a capability not yet applied to a domain) or
+> "Current methods fall short" (an existing method has a blocking limit).
+> Then a one-sentence statement per candidate. Each candidate also has a
+> machine id (`G1`, `G2`, …) — that id goes ONLY into `.gaps.yml`.*
 
 | # | Candidate topic | Why it could be a gap |
 |---|---|---|
-| 1 | <readable name> | <plain phrase — e.g. "a capability no one has applied to this domain" or "a limit of existing methods"> |
+| 1 | <readable name> | <"No one has tried this" / "Current methods fall short"> — <plain rationale> |
 | 2 | <readable name> | <…> |
 
 1. **<name>** — <one-sentence statement of the candidate>.
@@ -90,10 +109,7 @@ this outcome.>
 ## Gate 1 — Is the gap still open?
 
 > *The verdict is in the Decision scorecard; this section is the evidence
-> behind it. Show the search funnel and the prior-art classification, the
-> closest prior work (each work tagged by evidence type), an evidence-mix
-> summary, and a one-sentence recall-confidence headline. Tool mechanics go
-> in Appendix A. "Absent from my corpus" is never proof of "open".*
+> behind it, in three blocks.*
 
 **Literature collected.** The Gate 1 search funnel:
 
@@ -111,14 +127,15 @@ Classification of the prior-art corpus (full per-paper detail in
 |---|---|
 | <e.g. 6 primary studies, 2 reviews, 1 survey, 1 perspective, 1 caution paper, 2 close analogues> | <e.g. 9 bear on Candidate 1, 4 on Candidate 2> |
 
-**Closest prior work.** <The papers that bear on whether each gap is filled
-— readable prose, each tagged by evidence type (primary study, review,
-survey, perspective, caution paper, close analogue, conference abstract,
-preprint, data artifact). Full list in the `.bib`.>
+**Closest prior work, and how solid it is.** <One conclusion sentence, then
+a few bullets — the key papers per candidate, each with an inline
+evidence-type tag (primary study, review, survey, perspective, caution
+paper, close analogue, conference abstract, preprint, data artifact), and a
+plain note on how solid the occupancy signal is. Full list in the `.bib`.>
 
-**Evidence mix.** <One or two sentences: how solid the occupancy signal is
-— e.g. an "occupied" verdict resting mostly on conference abstracts is
-weaker than one resting on primary studies.>
+- **Candidate 1:** <key papers, tagged> — <how solid the signal is>.
+- **Candidate 2:** <closest analogues, tagged> — <how thin the direct
+  evidence is>.
 
 **Recall confidence.** <One plain sentence — e.g. "Medium: one search
 backend was unavailable, so a missed paper is possible; re-check before
@@ -126,65 +143,91 @@ relying on an 'open' verdict.">
 
 ## Gate 2 — Would it be a real contribution?
 
-> *The scorecard carries the verdict; here is the reasoning. Per assessed
-> candidate, two plain-language questions. (1) Has the field already tried
-> this and hit a wall? — a gap can be open because the field gave up.
-> (2) Would this be a new capability, or an extension of existing work? —
-> a descriptive lens, NOT a quality judgment; an extension can be well
-> worth doing. A candidate that failed Gate 1 is not assessed here.*
+> *The scorecard carries the verdict; here is the reasoning, per assessed
+> candidate, in four parts. A candidate that failed Gate 1 is not assessed.*
 
-- **<candidate> — has the field hit a wall here?** <plain answer +
-  evidence; cite the paper(s).>
-- **<candidate> — new capability or extension?** <plain answer +
-  one-sentence justification.>
+For each assessed candidate:
+
+- **What it would contribute.** <One explicit claim — what the finished
+  research would add: a modelling method, a validated behavioural
+  representation, a dataset or benchmark, an empirical finding, or a
+  decision-support result. Not "applies X to Y" — the actual addition.>
+- **Has the field tried this and hit a wall?** <Plain answer. If a caution
+  or post-mortem paper exists, summarise the *kind* of risk it raises —
+  construct validity, ethics, representativeness, interpretability — not
+  just "go read it".>
+- **A new capability, or an extension of existing work?** <Plain answer +
+  one-sentence justification. A descriptive lens, not a quality judgment;
+  an extension can be well worth doing.>
+- **Minimum validation sketch.** <What would distinguish a real
+  contribution from a plausible-looking result: the behaviour target, a
+  baseline or comparator, a held-out test, and the main failure mode the
+  study must survive.>
 
 ## Gate 3 — Is it feasible?
 
-> *The scorecard carries the verdict; here is the data/resource detail.
-> Front-loaded: feasibility must be known BEFORE the research framework is
-> built. Per assessed candidate, in plain words: what is needed, is it
-> public, what does it cost, how long to obtain — and the binding
-> constraint. A candidate that failed an earlier gate is not assessed.*
+> *The scorecard carries the verdict; here is the detail, per assessed
+> candidate, in five parts. Front-loaded — feasibility must be known BEFORE
+> the research framework is built. A candidate that failed an earlier gate
+> is not assessed.*
 
-- **<candidate> — what it needs:** <data / resources — public? cost? lead
-  time?>
-- **<candidate> — the binding constraint:** <the one item that decides the
-  timeline.>
+For each assessed candidate:
+
+- **What it needs.** <Data / resources — public? cost? lead time?>
+- **Design feasibility.** <Beyond data availability: can the baselines /
+  comparators actually be run; privacy or consent constraints on the data;
+  reproducibility when outputs depend on an external API model.>
+- **Scale outline.** <A rough size / time / cost band — enough for the
+  reader to picture the project, not a precise estimate.>
+- **The binding constraint.** <The one item that decides the timeline.>
+- **Proposal-feasible vs dissertation-feasible.** <State both: what a
+  proposal needs to clear, and whether a full dissertation or paper can
+  realistically be completed — for a student the effort boundary is the
+  decision.>
 
 ## The decision is yours
 
-> *State explicitly that the dossier stops here. It has assembled the three
-> gate verdicts; whether a gap is WORTH doing is the researcher's and
-> advisor's call. Per candidate, name the outcome in plain words and the
-> conditions the human must resolve before committing. For each candidate
-> that is "worth pursuing only if its conditions hold", give an explicit
-> upgrade / kill test — the finding that would make it a clear go, and the
-> finding that would make it not worth pursuing.*
+> *The dossier stops here. It has assembled the three gate verdicts;
+> whether a gap is WORTH doing is the researcher's and advisor's call.
+> Frame each surviving candidate consistently as a CONDITIONAL
+> RECOMMENDATION pending named checks — do not mix "evidence, not a
+> verdict" with "worth pursuing". For each, give an upgrade / kill test
+> written as concrete artifacts or results, and for a failed candidate one
+> explicit salvage-path line.*
 
-The three gates above are assembled evidence, not a verdict. A topic is
-worth pursuing only if all three pass — open AND a contribution AND
-feasible; if any gate fails, do not pursue it as stated. **Whether
-<Candidate N> is worth pursuing is your and your advisor's decision.**
-<Per-candidate: the plain-language outcome, and the conditions to resolve
-first.>
+The three gates above are assembled evidence. A topic is worth pursuing
+only if all three pass — open AND a contribution AND feasible. **Whether
+<Candidate N> is worth pursuing is your and your advisor's decision**, and
+for any candidate that cleared the gates it is a *conditional
+recommendation* — worth pursuing once the checks below are met.
 
-**Upgrade / kill test — <conditional candidate>.** It becomes clearly
-**worth pursuing** if <the findings that resolve every open condition
-favourably>. It is **not worth pursuing as stated** if <the finding that
-would fail any gate — e.g. the recall re-run surfaces a paper already
-occupying the gap, or the binding resource proves unobtainable>.
+<Per candidate: the plain outcome, then the conditions to resolve.>
+
+**Upgrade / kill test — <conditional candidate>.** It is **worth pursuing**
+once <each open condition expressed as a concrete artifact or result — e.g.
+"a held-out validation result against baseline X", not "credibly answer">.
+It is **not worth pursuing as stated** if <the concrete finding that would
+fail a gate>.
+
+**Salvage path — <failed candidate>.** <One line: the narrower slice worth
+a fresh look, and what specifically to re-search.>
 
 ---
 
 ## Appendix A — How this dossier was produced
 
-> *All tool / pipeline / API mechanics live here, out of the reader's way.*
+> *A method note, not a tool log — enough for a researcher to judge how far
+> to trust the dossier and what must be re-run. Downplay internal command
+> names; state search scope, inclusion criteria, and dates; separate the
+> automated steps from agent / researcher judgement.*
 
 | Item | Detail |
 |---|---|
-| Pipeline | research-hub `search --adversarial --screen --json` → `literature-triage-matrix` → gap-to-topic gates |
-| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence. The `--screen` relevance gate: retrieved / on-topic / screened-out counts.> |
-| Tool / version | <research-hub plugin version, run date, caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall> |
+| Search scope | <what was searched: query phrasings, fields, year range, the backends used and any unavailable> |
+| Inclusion criteria | <how the prior-art corpus was selected from the screened set — what made a paper in or out> |
+| Automated vs judgement | <which steps were automated — search, relevance screening — and which were agent / researcher judgement — corpus selection, evidence tagging, the gate verdicts> |
+| Recall confidence | <the headline confidence and why; what to re-run for a tighter verdict> |
+| Run details | <date; tool version; pipeline as a one-line trace if useful> |
 
 ---
 

--- a/src/research_hub/skills_data/gap-to-topic/SKILL.md
+++ b/src/research_hub/skills_data/gap-to-topic/SKILL.md
@@ -45,14 +45,14 @@ pursue — as stated" / "Worth pursuing — only if its open conditions hold" /
 
 | Section | What it covers |
 |---|---|
-| Bottom line | the answer up front — one plain-language paragraph per candidate plus a **Decision scorecard** table (candidates × the 3 gates + verdict) |
-| What's in this deliverable | an index of the bundle — every file and what information it carries |
-| The candidates | 1–N candidate topics in a roster table, each given a readable name + a plain "why it could be a gap" phrase |
-| Gate 1 — Is the gap still open? | the literature funnel + classification, closest prior work, recall confidence |
-| Gate 2 — Would it be a real contribution? | dead-end history + new-capability-vs-extension |
-| Gate 3 — Is it feasible? | can the data / resources be obtained in time and budget |
-| The decision is yours | the dossier states explicitly the *"worth it"* verdict is the researcher's + advisor's; upgrade/kill test per conditional candidate |
-| Appendix A | how the dossier was produced (pipeline, recall mechanics) |
+| Bottom line | the answer up front — one plain-language paragraph per candidate plus a **Decision scorecard**: each gate rated 1–5 (Likert), candidates × the 3 gates + verdict |
+| What's in this deliverable | an index of the bundle — every file, what it carries, and a file tree |
+| The candidates | 1–N candidate topics in a roster table, each given a readable name + a plain "why it could be a gap" tag |
+| Gate 1 — Is the gap still open? | the literature funnel + classification, closest prior work and how solid it is, recall confidence |
+| Gate 2 — Would it be a real contribution? | what it would contribute, dead-end history, new-capability-vs-extension, a minimum validation sketch |
+| Gate 3 — Is it feasible? | data / resources, design feasibility, a scale outline, the binding constraint, proposal-vs-dissertation feasibility |
+| The decision is yours | a conditional recommendation pending named checks; an operational upgrade/kill test; a salvage path for a failed candidate |
+| Appendix A | how the dossier was produced — a method note (search scope, inclusion criteria, automated-vs-judgement) |
 
 (SKILL.md §0–§4 below are the agent's internal workflow steps; they map to
 the reader-facing sections above — §0 → The candidates, §1 → Gate 1, etc.)

--- a/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
+++ b/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
@@ -4,20 +4,20 @@
 > italic note is that section's contract — what it must contain. The dossier
 > is a thinking tool: surface uncertainty, do not polish it away.
 >
-> **Reader-first rules** — the dossier must read as a plain summary report a
-> researcher understands top-to-bottom in Word, with no decoding:
+> **Reader-first rules** — the dossier is written for a researcher (a
+> graduate student and their advisor) deciding a thesis or proposal topic.
+> It must read as a plain summary report, top-to-bottom, with no decoding:
 > - **No codes in the document.** Candidates are named in plain words; the
->   machine ids (`G1`, `G2`, …) live only in the `.gaps.yml` companion,
->   never in the dossier.
-> - **No decorative symbols.** No `✓ ✗ ~` glyphs, no `·` separators —
->   plain words, plain numbering, commas and "and".
+>   machine ids (`G1`, `G2`, …) live only in the `.gaps.yml` companion.
+> - **No decorative symbols.** No `✓ ✗ ~` glyphs, no `·` separators.
 > - **Plain verdicts.** Never "no-go / go" jargon — say "Do not pursue —
 >   as stated", "Worth pursuing — only if its open conditions hold",
 >   "Worth pursuing".
-> - **Lead with the answer**, state each gate verdict in plain language
->   before the evidence, keep tool / pipeline mechanics in Appendix A.
+> - **Lead with the answer**; keep tool / pipeline mechanics in Appendix A.
 > - Formal enum tokens (`partially-occupied`, `borderline`, …) belong in
 >   `.gaps.yml`, not the prose — gloss them in plain words.
+> - The dossier is **English by default**. A translated mirror is produced
+>   only on request, in a sibling-language folder.
 
 ---
 
@@ -26,26 +26,33 @@
 ## Bottom line
 
 > *One framing sentence (what was evaluated), then one short paragraph per
-> candidate — name it, give its plain-language outcome and the reason in a
-> sentence or two. Then the Decision scorecard, then the single most
-> important caveat. A reader must get the whole answer here.*
+> candidate — name it, give its plain-language outcome, and the reason in a
+> sentence or two. Each paragraph must name at least one concrete piece of
+> evidence. Then the Decision scorecard, then the one key caveat.*
 
 <One sentence: N candidate topics were evaluated for <area>.>
 
-**<Candidate 1 name>** — <plain outcome>. <One or two plain sentences: why
-this outcome.>
+**<Candidate 1 name>** — <plain outcome>. <One or two plain sentences; name
+a concrete piece of evidence.>
 
-**<Candidate 2 name>** — <plain outcome>. <…>
+**<Candidate 2 name>** — <plain outcome>. <…with a concrete piece of
+evidence named.>
 
 ### Decision scorecard
 
-> *Candidates against the 3 gates, plus the verdict. Plain words only — no
-> glyphs. A gate a candidate was not assessed on (it already failed an
-> earlier gate) reads "Not assessed".*
+> *Each gate is stated as a claim and rated 1–5: 5 = strongly agree the
+> claim holds, 3 = mixed or qualified, 1 = strongly disagree. A topic is
+> worth pursuing only if every gate rates 3 or higher. A gate after a gate
+> that already failed reads "Not assessed". No glyphs — the cell is
+> `N/5 label — short description`.*
 
-| Candidate | Gate 1 — Open? | Gate 2 — A contribution? | Gate 3 — Feasible? | Verdict |
+Rating: 5 = strongly agree, 4 = agree, 3 = neutral, 2 = disagree,
+1 = strongly disagree. A topic is worth pursuing only if every gate is 3 or
+higher.
+
+| Candidate | Gate 1 — "the gap is still open" | Gate 2 — "it would be a real contribution" | Gate 3 — "it is feasible within reach" | Verdict |
 |---|---|---|---|---|
-| 1. <name> | <Open / Occupied / Partially occupied + confidence> | <A contribution / Borderline / Not assessed> | <Feasible / Feasible with effort / Blocked / Not assessed> | **<Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing>** |
+| 1. <name> | <N/5 label — short description> | <N/5 label — … or "Not assessed"> | <N/5 label — … or "Not assessed"> | **<Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing>** |
 | 2. <name> | … | … | … | **…** |
 
 | Field | Value |
@@ -61,8 +68,10 @@ this outcome.>
 
 ## What's in this deliverable
 
-> *An index of the bundle — every file and what information it carries, so
-> a reader knows the whole pack from this one document.*
+> *An index of the bundle — every file and what information it carries — so
+> a reader knows the whole pack from this one document, then a file tree of
+> the layout. A default (English-only) dossier lists a flat bundle; a
+> translated deliverable shows the sibling-language folders.*
 
 | File | What it is | What it gives you |
 |---|---|---|
@@ -71,17 +80,27 @@ this outcome.>
 | `literature_matrix.md` | The paper-by-paper comparison table | How each retrieved paper compares — method, claim, evidence type, limitation |
 | `topic_dossier.gaps.yml` | Machine-readable export | Structured data for a downstream tool or a later pass; not needed for reading |
 
+```
+<deliverable-folder>/
+├── topic_dossier.md / .docx
+├── topic_dossier.bib
+├── literature_matrix.md
+└── topic_dossier.gaps.yml
+```
+
 ## The candidates
 
 > *1–N candidates, articulated WITH the researcher (Socratic — never
 > invented). The roster table names each and says, in plain words, why it
-> could be a gap; then a one-sentence statement per candidate. Each
-> candidate also has a machine id (`G1`, `G2`, …) — that id goes ONLY into
-> `.gaps.yml`, never into this document.*
+> could be a gap — each "why" cell leads with one of two plain tags:
+> "No one has tried this" (a capability not yet applied to a domain) or
+> "Current methods fall short" (an existing method has a blocking limit).
+> Then a one-sentence statement per candidate. Each candidate also has a
+> machine id (`G1`, `G2`, …) — that id goes ONLY into `.gaps.yml`.*
 
 | # | Candidate topic | Why it could be a gap |
 |---|---|---|
-| 1 | <readable name> | <plain phrase — e.g. "a capability no one has applied to this domain" or "a limit of existing methods"> |
+| 1 | <readable name> | <"No one has tried this" / "Current methods fall short"> — <plain rationale> |
 | 2 | <readable name> | <…> |
 
 1. **<name>** — <one-sentence statement of the candidate>.
@@ -90,10 +109,7 @@ this outcome.>
 ## Gate 1 — Is the gap still open?
 
 > *The verdict is in the Decision scorecard; this section is the evidence
-> behind it. Show the search funnel and the prior-art classification, the
-> closest prior work (each work tagged by evidence type), an evidence-mix
-> summary, and a one-sentence recall-confidence headline. Tool mechanics go
-> in Appendix A. "Absent from my corpus" is never proof of "open".*
+> behind it, in three blocks.*
 
 **Literature collected.** The Gate 1 search funnel:
 
@@ -111,14 +127,15 @@ Classification of the prior-art corpus (full per-paper detail in
 |---|---|
 | <e.g. 6 primary studies, 2 reviews, 1 survey, 1 perspective, 1 caution paper, 2 close analogues> | <e.g. 9 bear on Candidate 1, 4 on Candidate 2> |
 
-**Closest prior work.** <The papers that bear on whether each gap is filled
-— readable prose, each tagged by evidence type (primary study, review,
-survey, perspective, caution paper, close analogue, conference abstract,
-preprint, data artifact). Full list in the `.bib`.>
+**Closest prior work, and how solid it is.** <One conclusion sentence, then
+a few bullets — the key papers per candidate, each with an inline
+evidence-type tag (primary study, review, survey, perspective, caution
+paper, close analogue, conference abstract, preprint, data artifact), and a
+plain note on how solid the occupancy signal is. Full list in the `.bib`.>
 
-**Evidence mix.** <One or two sentences: how solid the occupancy signal is
-— e.g. an "occupied" verdict resting mostly on conference abstracts is
-weaker than one resting on primary studies.>
+- **Candidate 1:** <key papers, tagged> — <how solid the signal is>.
+- **Candidate 2:** <closest analogues, tagged> — <how thin the direct
+  evidence is>.
 
 **Recall confidence.** <One plain sentence — e.g. "Medium: one search
 backend was unavailable, so a missed paper is possible; re-check before
@@ -126,65 +143,91 @@ relying on an 'open' verdict.">
 
 ## Gate 2 — Would it be a real contribution?
 
-> *The scorecard carries the verdict; here is the reasoning. Per assessed
-> candidate, two plain-language questions. (1) Has the field already tried
-> this and hit a wall? — a gap can be open because the field gave up.
-> (2) Would this be a new capability, or an extension of existing work? —
-> a descriptive lens, NOT a quality judgment; an extension can be well
-> worth doing. A candidate that failed Gate 1 is not assessed here.*
+> *The scorecard carries the verdict; here is the reasoning, per assessed
+> candidate, in four parts. A candidate that failed Gate 1 is not assessed.*
 
-- **<candidate> — has the field hit a wall here?** <plain answer +
-  evidence; cite the paper(s).>
-- **<candidate> — new capability or extension?** <plain answer +
-  one-sentence justification.>
+For each assessed candidate:
+
+- **What it would contribute.** <One explicit claim — what the finished
+  research would add: a modelling method, a validated behavioural
+  representation, a dataset or benchmark, an empirical finding, or a
+  decision-support result. Not "applies X to Y" — the actual addition.>
+- **Has the field tried this and hit a wall?** <Plain answer. If a caution
+  or post-mortem paper exists, summarise the *kind* of risk it raises —
+  construct validity, ethics, representativeness, interpretability — not
+  just "go read it".>
+- **A new capability, or an extension of existing work?** <Plain answer +
+  one-sentence justification. A descriptive lens, not a quality judgment;
+  an extension can be well worth doing.>
+- **Minimum validation sketch.** <What would distinguish a real
+  contribution from a plausible-looking result: the behaviour target, a
+  baseline or comparator, a held-out test, and the main failure mode the
+  study must survive.>
 
 ## Gate 3 — Is it feasible?
 
-> *The scorecard carries the verdict; here is the data/resource detail.
-> Front-loaded: feasibility must be known BEFORE the research framework is
-> built. Per assessed candidate, in plain words: what is needed, is it
-> public, what does it cost, how long to obtain — and the binding
-> constraint. A candidate that failed an earlier gate is not assessed.*
+> *The scorecard carries the verdict; here is the detail, per assessed
+> candidate, in five parts. Front-loaded — feasibility must be known BEFORE
+> the research framework is built. A candidate that failed an earlier gate
+> is not assessed.*
 
-- **<candidate> — what it needs:** <data / resources — public? cost? lead
-  time?>
-- **<candidate> — the binding constraint:** <the one item that decides the
-  timeline.>
+For each assessed candidate:
+
+- **What it needs.** <Data / resources — public? cost? lead time?>
+- **Design feasibility.** <Beyond data availability: can the baselines /
+  comparators actually be run; privacy or consent constraints on the data;
+  reproducibility when outputs depend on an external API model.>
+- **Scale outline.** <A rough size / time / cost band — enough for the
+  reader to picture the project, not a precise estimate.>
+- **The binding constraint.** <The one item that decides the timeline.>
+- **Proposal-feasible vs dissertation-feasible.** <State both: what a
+  proposal needs to clear, and whether a full dissertation or paper can
+  realistically be completed — for a student the effort boundary is the
+  decision.>
 
 ## The decision is yours
 
-> *State explicitly that the dossier stops here. It has assembled the three
-> gate verdicts; whether a gap is WORTH doing is the researcher's and
-> advisor's call. Per candidate, name the outcome in plain words and the
-> conditions the human must resolve before committing. For each candidate
-> that is "worth pursuing only if its conditions hold", give an explicit
-> upgrade / kill test — the finding that would make it a clear go, and the
-> finding that would make it not worth pursuing.*
+> *The dossier stops here. It has assembled the three gate verdicts;
+> whether a gap is WORTH doing is the researcher's and advisor's call.
+> Frame each surviving candidate consistently as a CONDITIONAL
+> RECOMMENDATION pending named checks — do not mix "evidence, not a
+> verdict" with "worth pursuing". For each, give an upgrade / kill test
+> written as concrete artifacts or results, and for a failed candidate one
+> explicit salvage-path line.*
 
-The three gates above are assembled evidence, not a verdict. A topic is
-worth pursuing only if all three pass — open AND a contribution AND
-feasible; if any gate fails, do not pursue it as stated. **Whether
-<Candidate N> is worth pursuing is your and your advisor's decision.**
-<Per-candidate: the plain-language outcome, and the conditions to resolve
-first.>
+The three gates above are assembled evidence. A topic is worth pursuing
+only if all three pass — open AND a contribution AND feasible. **Whether
+<Candidate N> is worth pursuing is your and your advisor's decision**, and
+for any candidate that cleared the gates it is a *conditional
+recommendation* — worth pursuing once the checks below are met.
 
-**Upgrade / kill test — <conditional candidate>.** It becomes clearly
-**worth pursuing** if <the findings that resolve every open condition
-favourably>. It is **not worth pursuing as stated** if <the finding that
-would fail any gate — e.g. the recall re-run surfaces a paper already
-occupying the gap, or the binding resource proves unobtainable>.
+<Per candidate: the plain outcome, then the conditions to resolve.>
+
+**Upgrade / kill test — <conditional candidate>.** It is **worth pursuing**
+once <each open condition expressed as a concrete artifact or result — e.g.
+"a held-out validation result against baseline X", not "credibly answer">.
+It is **not worth pursuing as stated** if <the concrete finding that would
+fail a gate>.
+
+**Salvage path — <failed candidate>.** <One line: the narrower slice worth
+a fresh look, and what specifically to re-search.>
 
 ---
 
 ## Appendix A — How this dossier was produced
 
-> *All tool / pipeline / API mechanics live here, out of the reader's way.*
+> *A method note, not a tool log — enough for a researcher to judge how far
+> to trust the dossier and what must be re-run. Downplay internal command
+> names; state search scope, inclusion criteria, and dates; separate the
+> automated steps from agent / researcher judgement.*
 
 | Item | Detail |
 |---|---|
-| Pipeline | research-hub `search --adversarial --screen --json` → `literature-triage-matrix` → gap-to-topic gates |
-| Recall mechanics | <N query phrasings, M unique papers; which backends ran; any rate-limited / unavailable and the effect on recall confidence. The `--screen` relevance gate: retrieved / on-topic / screened-out counts.> |
-| Tool / version | <research-hub plugin version, run date, caveats — e.g. set `SEMANTIC_SCHOLAR_API_KEY` for tighter recall> |
+| Search scope | <what was searched: query phrasings, fields, year range, the backends used and any unavailable> |
+| Inclusion criteria | <how the prior-art corpus was selected from the screened set — what made a paper in or out> |
+| Automated vs judgement | <which steps were automated — search, relevance screening — and which were agent / researcher judgement — corpus selection, evidence tagging, the gate verdicts> |
+| Recall confidence | <the headline confidence and why; what to re-run for a tighter verdict> |
+| Run details | <date; tool version; pipeline as a one-line trace if useful> |
 
 ---
 


### PR DESCRIPTION
## Summary

A section-by-section design review with the maintainer, plus a Codex evaluation, reworked the `gap-to-topic` dossier template so it serves a researcher making a topic decision. Full spec: agreed section-by-section.

## Changes — `references/dossier-template.md`

- **Decision scorecard** — now a 5-point **Likert** per gate: each gate is a claim rated 1–5 (strongly agree … strongly disagree); cell is `N/5 label — description`; a topic is worth pursuing only if every gate rates ≥ 3.
- **Gate 2** — gains "What it would contribute" (one explicit claim) and a "Minimum validation sketch"; a caution paper is summarised by the *kind* of risk it raises.
- **Gate 3** — gains "Design feasibility", a "Scale outline", and an explicit proposal-vs-dissertation feasibility split — no longer only a data-availability test.
- **The decision is yours** — framed consistently as a conditional recommendation; the upgrade/kill test written as concrete artifacts; a failed candidate gets a salvage-path line.
- **Appendix A** — recast from a tool log into a method note (search scope, inclusion criteria, automated-vs-judgement).
- **What's in this deliverable** — gains a file tree.

`SKILL.md` "What it produces" updated. Doc-only. Mirrored to `src/research_hub/skills_data/gap-to-topic/`. Plugin `0.3.7 → 0.3.8`.

## Verification

- `tests/test_v068_3_version_sync.py` — 3 passed (byte-parity).
- SKILL.md 194 lines (<500 spec limit).
- Independent `code-reviewer` → checked against the spec, all 11 sections implemented; REQUEST CHANGES on one self-referential `·`-separator slip in the scale line — fixed before push, re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)