### PR TITLE
fix(skill): gap-to-topic dossier — 7-section decision-memo format (v0.3.9)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Fixed
+- **`gap-to-topic` dossier reflowed as a 7-section research-grade decision
+  memo** (`skills/gap-to-topic/`, plugin `0.3.8 → 0.3.9`). The v0.3.8
+  dossier rendered as "Markdown converted to Word" — wide scorecard with
+  one-letter-wide columns, no decision-level visual cue, too many tables
+  in the body. `references/dossier-template.md` is reorganised: §1
+  Executive Decision Summary (metadata + verdict cards + key uncertainty)
+  → §2 Candidate Definitions (prose, no roster table) → §3 Decision
+  Scorecards (per-candidate small tables, replacing the wide combined
+  one) → §4 Evidence Base → §5 Gate-by-Gate Assessment (each gate uses a
+  fixed Score / Evidence / Interpretation / Risk / Action-needed
+  skeleton) → §6 Risks and Upgrade/Kill Tests (named risks; operational
+  kill-test artifacts; salvage path) → §7 Recommended Next Steps (formal
+  research-memo prose) → Appendix A Search and Screening Protocol
+  (reproducibility log) → Appendix B Deliverable File List. SKILL.md
+  "What it produces" updated to match. Mirrored to
+  `src/research_hub/skills_data/gap-to-topic/`.
 - **`gap-to-topic` dossier — section-by-section rework for researcher value**
   (`skills/gap-to-topic/`, plugin `0.3.7 → 0.3.8`).  A section-by-section
   review with the maintainer, plus a Codex evaluation, reworked

--- a/skills/gap-to-topic/SKILL.md
+++ b/skills/gap-to-topic/SKILL.md
@@ -37,25 +37,28 @@ Not for:
 
 ## What it produces
 
-`.research/topic_dossier.md` — a **reader-first summary report**: it must
-read top-to-bottom in Word with no decoding — no codes (`G1`/`G2` stay only
-in `.gaps.yml`), no decorative glyphs, plain-language verdicts ("Do not
-pursue — as stated" / "Worth pursuing — only if its open conditions hold" /
-"Worth pursuing"), tool mechanics kept in Appendix A.
+`.research/topic_dossier.md` — a **research-grade decision memo**: first
+page enables a decision; the body supports verification; the appendices
+support a re-run. Reads top-to-bottom in Word with no decoding — no codes
+(`G1`/`G2` stay only in `.gaps.yml`), no decorative glyphs, plain-language
+verdicts, decision-relevant tables in the body and reference / log tables
+in the appendices.
 
 | Section | What it covers |
 |---|---|
-| Bottom line | the answer up front — one plain-language paragraph per candidate plus a **Decision scorecard**: each gate rated 1–5 (Likert), candidates × the 3 gates + verdict |
-| What's in this deliverable | an index of the bundle — every file, what it carries, and a file tree |
-| The candidates | 1–N candidate topics in a roster table, each given a readable name + a plain "why it could be a gap" tag |
-| Gate 1 — Is the gap still open? | the literature funnel + classification, closest prior work and how solid it is, recall confidence |
-| Gate 2 — Would it be a real contribution? | what it would contribute, dead-end history, new-capability-vs-extension, a minimum validation sketch |
-| Gate 3 — Is it feasible? | data / resources, design feasibility, a scale outline, the binding constraint, proposal-vs-dissertation feasibility |
-| The decision is yours | a conditional recommendation pending named checks; an operational upgrade/kill test; a salvage path for a failed candidate |
-| Appendix A | how the dossier was produced — a method note (search scope, inclusion criteria, automated-vs-judgement) |
+| 1. Executive Decision Summary | metadata box; one framing sentence; **per-candidate verdict cards** (small 2-column tables, generator colour-codes the verdict cell); a one-line key uncertainty |
+| 2. Candidate Definitions | per candidate, name + one-sentence statement + a plain "why it could be a gap" tag ("No one has tried this" / "Current methods fall short") |
+| 3. Decision Scorecards | per candidate, a small 3-column table (Gate / Score / Rationale) with the three gates rated 1–5 (Likert) plus a Verdict row; cells colour-coded by the generator |
+| 4. Evidence Base | the search funnel, the prior-art classification, and the closest prior work per candidate with inline evidence-type tags |
+| 5. Gate-by-Gate Assessment | each gate uses a fixed five-field skeleton: Score / Evidence / Interpretation / Risk / Action needed |
+| 6. Risks and Upgrade / Kill Tests | named risks (construct validity, dataset, novelty, reproducibility); operational upgrade / kill test per conditional candidate; salvage path per failed candidate |
+| 7. Recommended Next Steps | formal research-memo prose — the do-not-pursue topic and the conditional topic, with named actions |
+| Appendix A. Search and Screening Protocol | a reproducibility log — search date, databases, query families, retrieved, dedup, inclusion / exclusion, screening, known limitations, recall confidence |
+| Appendix B. Deliverable File List | the file index and the file tree |
 
 (SKILL.md §0–§4 below are the agent's internal workflow steps; they map to
-the reader-facing sections above — §0 → The candidates, §1 → Gate 1, etc.)
+the reader-facing sections above — §0 → §2 Candidate Definitions, §1 → §3
+Decision Scorecards + §4 Evidence Base + §5 Gate 1, etc.)
 
 Plus two machine-readable companions: `<dossier>.bib` (the Gate 1 reference
 list as BibTeX) and `<dossier>.gaps.yml` (structured candidates + verdicts +

--- a/skills/gap-to-topic/references/dossier-template.md
+++ b/skills/gap-to-topic/references/dossier-template.md
@@ -1,117 +1,106 @@
 # Reference — the topic-decision dossier (blank template)
 
 > The shape `gap-to-topic` emits to `.research/topic_dossier.md`. Each `>`
-> italic note is that section's contract — what it must contain. The dossier
-> is a thinking tool: surface uncertainty, do not polish it away.
+> italic note is that section's contract — what it must contain. The
+> dossier is a **research-grade decision memo**: first page enables a
+> decision; the body supports verification; the appendices support a re-run.
 >
-> **Reader-first rules** — the dossier is written for a researcher (a
-> graduate student and their advisor) deciding a thesis or proposal topic.
-> It must read as a plain summary report, top-to-bottom, with no decoding:
-> - **No codes in the document.** Candidates are named in plain words; the
->   machine ids (`G1`, `G2`, …) live only in the `.gaps.yml` companion.
+> **Reader-first rules** — the dossier is for a graduate student and their
+> advisor. It must read top-to-bottom in Word with no decoding:
+> - **No machine codes in the document.** `G1` / `G2` ids live only in
+>   `.gaps.yml`.
 > - **No decorative symbols.** No `✓ ✗ ~` glyphs, no `·` separators.
-> - **Plain verdicts.** Never "no-go / go" jargon — say "Do not pursue —
->   as stated", "Worth pursuing — only if its open conditions hold",
->   "Worth pursuing".
-> - **Lead with the answer**; keep tool / pipeline mechanics in Appendix A.
-> - Formal enum tokens (`partially-occupied`, `borderline`, …) belong in
->   `.gaps.yml`, not the prose — gloss them in plain words.
-> - The dossier is **English by default**. A translated mirror is produced
->   only on request, in a sibling-language folder.
+> - **Plain verdicts.** "Do not pursue — as stated" / "Worth pursuing —
+>   only if its open conditions hold" / "Worth pursuing".
+> - **Decision-first.** Page 1 is the executive summary; the body holds the
+>   small set of decision-relevant tables; everything else (file list,
+>   search details, automated-vs-judgement) belongs in an appendix.
+> - English by default; a translated mirror goes in a sibling-language folder.
 
 ---
 
 # Topic Decision Dossier — <topic area>
 
-## Bottom line
-
-> *One framing sentence (what was evaluated), then one short paragraph per
-> candidate — name it, give its plain-language outcome, and the reason in a
-> sentence or two. Each paragraph must name at least one concrete piece of
-> evidence. Then the Decision scorecard, then the one key caveat.*
-
-<One sentence: N candidate topics were evaluated for <area>.>
-
-**<Candidate 1 name>** — <plain outcome>. <One or two plain sentences; name
-a concrete piece of evidence.>
-
-**<Candidate 2 name>** — <plain outcome>. <…with a concrete piece of
-evidence named.>
-
-### Decision scorecard
-
-> *Each gate is stated as a claim and rated 1–5: 5 = strongly agree the
-> claim holds, 3 = mixed or qualified, 1 = strongly disagree. A topic is
-> worth pursuing only if every gate rates 3 or higher. A gate after a gate
-> that already failed reads "Not assessed". No glyphs — the cell is
-> `N/5 label — short description`.*
-
-Rating: 5 = strongly agree, 4 = agree, 3 = neutral, 2 = disagree,
-1 = strongly disagree. A topic is worth pursuing only if every gate is 3 or
-higher.
-
-| Candidate | Gate 1 — "the gap is still open" | Gate 2 — "it would be a real contribution" | Gate 3 — "it is feasible within reach" | Verdict |
-|---|---|---|---|---|
-| 1. <name> | <N/5 label — short description> | <N/5 label — … or "Not assessed"> | <N/5 label — … or "Not assessed"> | **<Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing>** |
-| 2. <name> | … | … | … | **…** |
+## 1. Executive Decision Summary
 
 | Field | Value |
 |---|---|
 | Area | <the research area> |
 | Compiled | <YYYY-MM-DD> |
 | Verdict grade | Screening-grade — assembles evidence; does NOT decide worth |
+| Search confidence | <high / medium / low — one phrase why> |
 
-> *This dossier is a thinking tool, not a polished report. It runs each
-> candidate through a 3-gate test — open AND a contribution AND feasible. A
-> candidate that fails any gate should not be pursued as stated. The "is it
-> worth doing" call is handed back to the researcher and advisor.*
+<One framing sentence: "N candidate topics were evaluated for <area>.">
 
-## What's in this deliverable
+> *Verdict cards — one small 2-column table per candidate. Header row
+> reads `Candidate N | <readable name>` (rendered as the card title);
+> data rows are `Verdict | <plain phrase>` (the generator colour-codes
+> this cell) and `Reason | <one or two sentences>`.*
 
-> *An index of the bundle — every file and what information it carries — so
-> a reader knows the whole pack from this one document, then a file tree of
-> the layout. A default (English-only) dossier lists a flat bundle; a
-> translated deliverable shows the sibling-language folders.*
+| Candidate 1 | <readable name> |
+|---|---|
+| **Verdict** | <Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing> |
+| **Reason** | <one or two plain sentences naming a concrete piece of evidence> |
 
-| File | What it is | What it gives you |
+| Candidate 2 | <readable name> |
+|---|---|
+| **Verdict** | <…> |
+| **Reason** | <…> |
+
+**Key uncertainty.** <One line — the dominant caveat the reader must keep
+in mind: recall confidence, a caution paper, or a dataset constraint.>
+
+## 2. Candidate Definitions
+
+> *Plain prose, no roster table. Per candidate: name + a one-sentence
+> statement, then a plain "why it could be a gap" line that leads with one
+> of two tags — "No one has tried this" (a capability not yet applied to a
+> domain) or "Current methods fall short" (an existing method has a
+> blocking limit).*
+
+**Candidate 1 — <readable name>.** <One-sentence statement of the
+candidate.> *Why it could be a gap:* <"No one has tried this" /
+"Current methods fall short"> — <one-sentence rationale>.
+
+**Candidate 2 — <readable name>.** <…>
+
+## 3. Decision Scorecards
+
+> *Per candidate, one small 3-column table — Gate / Score / Rationale —
+> with the three gates plus a Verdict row. The Likert scale: 5 = strongly
+> agree, 4 = agree, 3 = neutral, 2 = disagree, 1 = strongly disagree. A
+> topic is worth pursuing only if every gate is 3 or higher. The Verdict
+> row's Score cell and any "Not assessed" cells are colour-coded by the
+> generator.*
+
+**Candidate 1 — <readable name>**
+
+| Gate | Score | Rationale |
 |---|---|---|
-| `topic_dossier.md` / `.docx` | This document — the topic-decision summary | The verdict on each candidate and the evidence behind it |
-| `topic_dossier.bib` | The reference list, as BibTeX | Every cited paper with a resolvable DOI / arXiv ID — lets you verify "open" yourself |
-| `literature_matrix.md` | The paper-by-paper comparison table | How each retrieved paper compares — method, claim, evidence type, limitation |
-| `topic_dossier.gaps.yml` | Machine-readable export | Structured data for a downstream tool or a later pass; not needed for reading |
+| Gate 1 — Gap still open | <N/5 label> | <brief why> |
+| Gate 2 — Real contribution | <N/5 label or "Not assessed"> | <brief why or "failed Gate 1"> |
+| Gate 3 — Feasible | <N/5 label or "Not assessed"> | <brief why or "failed Gate 1"> |
+| **Verdict** | **<plain verdict phrase>** | <overall one-liner> |
 
-```
-<deliverable-folder>/
-├── topic_dossier.md / .docx
-├── topic_dossier.bib
-├── literature_matrix.md
-└── topic_dossier.gaps.yml
-```
+**Candidate 2 — <readable name>**
 
-## The candidates
-
-> *1–N candidates, articulated WITH the researcher (Socratic — never
-> invented). The roster table names each and says, in plain words, why it
-> could be a gap — each "why" cell leads with one of two plain tags:
-> "No one has tried this" (a capability not yet applied to a domain) or
-> "Current methods fall short" (an existing method has a blocking limit).
-> Then a one-sentence statement per candidate. Each candidate also has a
-> machine id (`G1`, `G2`, …) — that id goes ONLY into `.gaps.yml`.*
-
-| # | Candidate topic | Why it could be a gap |
+| Gate | Score | Rationale |
 |---|---|---|
-| 1 | <readable name> | <"No one has tried this" / "Current methods fall short"> — <plain rationale> |
-| 2 | <readable name> | <…> |
+| Gate 1 — Gap still open | <…> | <…> |
+| Gate 2 — Real contribution | <…> | <…> |
+| Gate 3 — Feasible | <…> | <…> |
+| **Verdict** | **<…>** | <…> |
 
-1. **<name>** — <one-sentence statement of the candidate>.
-2. **<name>** — <…>
+## 4. Evidence Base
 
-## Gate 1 — Is the gap still open?
+> *Three sub-blocks: the search funnel, the prior-art classification, and
+> the closest prior work per candidate. The closest-prior-work bullets
+> carry inline evidence-type tags (primary study, review, survey,
+> perspective, caution paper, close analogue, conference abstract,
+> preprint, data artifact). Full per-paper detail is in
+> `literature_matrix.md`; do not duplicate it here.*
 
-> *The verdict is in the Decision scorecard; this section is the evidence
-> behind it, in three blocks.*
-
-**Literature collected.** The Gate 1 search funnel:
+**Search funnel.**
 
 | Stage | Count |
 |---|---|
@@ -120,114 +109,151 @@ higher.
 | Kept on-topic by the relevance gate | <K> |
 | Selected into the prior-art corpus | <P> |
 
-Classification of the prior-art corpus (full per-paper detail in
-`literature_matrix.md`):
+**Prior-art classification of the <P>-paper corpus.**
 
 | By evidence type | By candidate |
 |---|---|
 | <e.g. 6 primary studies, 2 reviews, 1 survey, 1 perspective, 1 caution paper, 2 close analogues> | <e.g. 9 bear on Candidate 1, 4 on Candidate 2> |
 
-**Closest prior work, and how solid it is.** <One conclusion sentence, then
-a few bullets — the key papers per candidate, each with an inline
-evidence-type tag (primary study, review, survey, perspective, caution
-paper, close analogue, conference abstract, preprint, data artifact), and a
-plain note on how solid the occupancy signal is. Full list in the `.bib`.>
+**Closest prior work.**
 
-- **Candidate 1:** <key papers, tagged> — <how solid the signal is>.
-- **Candidate 2:** <closest analogues, tagged> — <how thin the direct
+- **Candidate 1:** <key papers, each tagged inline by evidence type> —
+  <how solid the occupancy signal is>.
+- **Candidate 2:** <closest analogues, each tagged> — <how thin the direct
   evidence is>.
 
-**Recall confidence.** <One plain sentence — e.g. "Medium: one search
-backend was unavailable, so a missed paper is possible; re-check before
-relying on an 'open' verdict.">
+## 5. Gate-by-Gate Assessment
 
-## Gate 2 — Would it be a real contribution?
+> *Each gate uses the same five-field skeleton. The Score line is the
+> Likert from the scorecard. Evidence summarises the corpus reading (the
+> corpus itself lives in §4). Interpretation says what the score means;
+> Risk names the dominant uncertainty; Action needed says what to do next.*
 
-> *The scorecard carries the verdict; here is the reasoning, per assessed
-> candidate, in four parts. A candidate that failed Gate 1 is not assessed.*
+### Gate 1 — Gap still open
 
-For each assessed candidate:
+- **Score:** <N/5 label, per candidate>.
+- **Evidence:** <one paragraph summarising §4's closest-prior-work read
+  per candidate>.
+- **Interpretation:** <what the score means — "occupied", "open", "lean
+  open", etc., glossed in plain words>.
+- **Risk:** <the dominant openness uncertainty — typically recall
+  confidence and which backend was missing>.
+- **Action needed:** <re-run the search with the missing backend; specific
+  query refinements if any>.
 
-- **What it would contribute.** <One explicit claim — what the finished
-  research would add: a modelling method, a validated behavioural
-  representation, a dataset or benchmark, an empirical finding, or a
-  decision-support result. Not "applies X to Y" — the actual addition.>
-- **Has the field tried this and hit a wall?** <Plain answer. If a caution
-  or post-mortem paper exists, summarise the *kind* of risk it raises —
-  construct validity, ethics, representativeness, interpretability — not
-  just "go read it".>
-- **A new capability, or an extension of existing work?** <Plain answer +
-  one-sentence justification. A descriptive lens, not a quality judgment;
-  an extension can be well worth doing.>
-- **Minimum validation sketch.** <What would distinguish a real
-  contribution from a plausible-looking result: the behaviour target, a
-  baseline or comparator, a held-out test, and the main failure mode the
-  study must survive.>
+### Gate 2 — Real contribution
 
-## Gate 3 — Is it feasible?
+- **Score:** <N/5 label or "Not assessed", per candidate>.
+- **Evidence:** <what the field has already tried; any caution paper —
+  named, with its content summarised>.
+- **Interpretation:** <what the candidate would contribute, in one
+  explicit claim — a method, a validated representation, a dataset, an
+  empirical finding, or a decision-support result; also the
+  new-capability-vs-extension call>.
+- **Risk:** <the kind of risk a caution paper raises: construct validity /
+  ethics / representativeness / interpretability>.
+- **Action needed:** <the minimum validation sketch — behaviour target,
+  baseline or comparator, held-out test, the main failure mode the study
+  must survive>.
 
-> *The scorecard carries the verdict; here is the detail, per assessed
-> candidate, in five parts. Front-loaded — feasibility must be known BEFORE
-> the research framework is built. A candidate that failed an earlier gate
-> is not assessed.*
+### Gate 3 — Feasible
 
-For each assessed candidate:
+- **Score:** <N/5 label or "Not assessed", per candidate>.
+- **Evidence:** <what data / resources are needed; the design-feasibility
+  picture — can the baselines run, privacy / consent constraints,
+  reproducibility when outputs depend on an API model; a scale outline
+  with a rough size / time / cost band>.
+- **Interpretation:** <the binding constraint — the one item that decides
+  the timeline; the proposal-vs-dissertation split>.
+- **Risk:** <privacy / consent or API-model reproducibility, whichever
+  binds harder>.
+- **Action needed:** <identify a reusable dataset, or plan a
+  primary-collection schedule>.
 
-- **What it needs.** <Data / resources — public? cost? lead time?>
-- **Design feasibility.** <Beyond data availability: can the baselines /
-  comparators actually be run; privacy or consent constraints on the data;
-  reproducibility when outputs depend on an external API model.>
-- **Scale outline.** <A rough size / time / cost band — enough for the
-  reader to picture the project, not a precise estimate.>
-- **The binding constraint.** <The one item that decides the timeline.>
-- **Proposal-feasible vs dissertation-feasible.** <State both: what a
-  proposal needs to clear, and whether a full dissertation or paper can
-  realistically be completed — for a student the effort boundary is the
-  decision.>
+## 6. Risks and Upgrade / Kill Tests
 
-## The decision is yours
+> *First a per-candidate list of the named risks; then, per conditional
+> candidate, an operational upgrade / kill test (every condition written
+> as a concrete artifact or result, not "credibly answer" prose); then,
+> per failed candidate, a one-line salvage path.*
 
-> *The dossier stops here. It has assembled the three gate verdicts;
-> whether a gap is WORTH doing is the researcher's and advisor's call.
-> Frame each surviving candidate consistently as a CONDITIONAL
-> RECOMMENDATION pending named checks — do not mix "evidence, not a
-> verdict" with "worth pursuing". For each, give an upgrade / kill test
-> written as concrete artifacts or results, and for a failed candidate one
-> explicit salvage-path line.*
+**Named risks.**
 
-The three gates above are assembled evidence. A topic is worth pursuing
-only if all three pass — open AND a contribution AND feasible. **Whether
-<Candidate N> is worth pursuing is your and your advisor's decision**, and
-for any candidate that cleared the gates it is a *conditional
-recommendation* — worth pursuing once the checks below are met.
+- **Construct-validity risk** — <how it manifests in this dossier — e.g.
+  a caution paper raising whether LLM-generated behaviour faithfully
+  represents real human decisions or only looks plausible>.
+- **Dataset-constraint risk** — <the binding behavioural / domain dataset
+  question for the conditional candidate>.
+- **Novelty risk** — <borderline novelty if a weaker realised form
+  already exists>.
+- **Reproducibility risk** — <e.g. LLM outputs depend on an external API
+  model that can change; the design must pin model versions and archive
+  prompts and outputs>.
 
-<Per candidate: the plain outcome, then the conditions to resolve.>
+**Upgrade / kill test — <conditional candidate>.** Worth pursuing once
+**all** of these hold:
+1. <a concrete search result — e.g. "a full-recall re-run with backend X
+   enabled returns no paper that already builds the candidate">;
+2. <a concrete pilot artifact — e.g. "a held-out validation result in
+   which the candidate's method predicts the target at least as well as
+   baseline X">;
+3. <a concrete data check — e.g. "a reusable dataset is identified or a
+   primary-collection schedule that fits the project timeline is in
+   hand">.
+Not worth pursuing if any one of the above fails on its specific finding.
 
-**Upgrade / kill test — <conditional candidate>.** It is **worth pursuing**
-once <each open condition expressed as a concrete artifact or result — e.g.
-"a held-out validation result against baseline X", not "credibly answer">.
-It is **not worth pursuing as stated** if <the concrete finding that would
-fail a gate>.
+**Salvage path — <failed candidate>.** <One line — the narrower slice
+worth a fresh look, and what specifically to re-search.>
 
-**Salvage path — <failed candidate>.** <One line: the narrower slice worth
-a fresh look, and what specifically to re-search.>
+## 7. Recommended Next Steps
+
+> *Formal research-memo language — two short paragraphs. First, the
+> broad topic that should not be pursued in its current form. Second, the
+> narrower topic that is conditionally promising, with the specific
+> actions required before commitment.*
+
+<Paragraph 1 — the do-not-pursue candidate.>
+
+<Paragraph 2 — the conditional candidate, naming the actions from §6.>
 
 ---
 
-## Appendix A — How this dossier was produced
+## Appendix A. Search and Screening Protocol
 
-> *A method note, not a tool log — enough for a researcher to judge how far
-> to trust the dossier and what must be re-run. Downplay internal command
-> names; state search scope, inclusion criteria, and dates; separate the
-> automated steps from agent / researcher judgement.*
+> *A reproducibility log — enough for a researcher to judge how far to
+> trust the dossier and to re-run the search.*
 
-| Item | Detail |
+| Field | Value |
 |---|---|
-| Search scope | <what was searched: query phrasings, fields, year range, the backends used and any unavailable> |
-| Inclusion criteria | <how the prior-art corpus was selected from the screened set — what made a paper in or out> |
-| Automated vs judgement | <which steps were automated — search, relevance screening — and which were agent / researcher judgement — corpus selection, evidence tagging, the gate verdicts> |
-| Recall confidence | <the headline confidence and why; what to re-run for a tighter verdict> |
-| Run details | <date; tool version; pipeline as a one-line trace if useful> |
+| Search date | <YYYY-MM-DD> |
+| Databases searched | <crossref, OpenAlex, arXiv, Semantic Scholar — note any rate-limited / unavailable> |
+| Query families | <the adversarial query phrasings and how they were generated> |
+| Number retrieved | <N unique> |
+| Deduplication rule | <how duplicates were handled> |
+| Inclusion criteria | <what made a paper enter the prior-art corpus> |
+| Exclusion criteria | <what made a paper exclude — tangential, off-domain, etc.> |
+| Screening process | <automated relevance gate and manual judgement steps, distinguished> |
+| Known limitations | <recall caveats, e.g. a backend unavailable> |
+| Recall confidence | <headline confidence and what to re-run for a tighter verdict> |
+
+## Appendix B. Deliverable File List
+
+| File | What it is | What it gives you |
+|---|---|---|
+| `topic_dossier.md` / `.docx` | This document — the topic-decision summary | The verdict on each candidate and the evidence behind it |
+| `topic_dossier.bib` | The reference list, as BibTeX | Every cited paper with a resolvable DOI — lets you verify "open" yourself |
+| `literature_matrix.md` | The paper-by-paper comparison table | How each retrieved paper compares — method, claim, evidence type, limitation |
+| `topic_dossier.gaps.yml` | Machine-readable export | Structured data for a downstream tool or a later pass; not needed for reading |
+
+```
+en/
+├── topic_dossier.md / .docx
+├── topic_dossier.bib
+├── literature_matrix.md
+└── topic_dossier.gaps.yml
+```
+
+(A translated mirror, if produced, lives in a sibling-language folder.)
 
 ---
 
@@ -235,7 +261,7 @@ a fresh look, and what specifically to re-search.>
 
 > The `.gaps.yml` companion is machine-readable and is **not** part of the
 > human dossier above. It keeps the machine ids (`G1`, `G2`) and the formal
-> enum tokens. Its shape:
+> enum tokens.
 
 ```yaml
 dossier: <topic area>
@@ -255,7 +281,8 @@ open_questions:
     text: "<question the evidence could not settle>"
 ```
 
-The `.bib` companion is the Gate 1 reference list as BibTeX — built from the
-on-topic `search --adversarial --screen --json` results (NOT from
-`cite --format bibtex`, which resolves only already-ingested Zotero items —
-see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID.
+The `.bib` companion is the Gate 1 reference list as BibTeX — built from
+the on-topic `search --adversarial --screen --json` results (NOT from
+`cite --format bibtex`, which resolves only already-ingested Zotero items
+— see SKILL.md §1 step 3). Every entry must have a resolvable DOI or
+arXiv ID.

--- a/src/research_hub/skills_data/gap-to-topic/SKILL.md
+++ b/src/research_hub/skills_data/gap-to-topic/SKILL.md
@@ -37,25 +37,28 @@ Not for:
 
 ## What it produces
 
-`.research/topic_dossier.md` — a **reader-first summary report**: it must
-read top-to-bottom in Word with no decoding — no codes (`G1`/`G2` stay only
-in `.gaps.yml`), no decorative glyphs, plain-language verdicts ("Do not
-pursue — as stated" / "Worth pursuing — only if its open conditions hold" /
-"Worth pursuing"), tool mechanics kept in Appendix A.
+`.research/topic_dossier.md` — a **research-grade decision memo**: first
+page enables a decision; the body supports verification; the appendices
+support a re-run. Reads top-to-bottom in Word with no decoding — no codes
+(`G1`/`G2` stay only in `.gaps.yml`), no decorative glyphs, plain-language
+verdicts, decision-relevant tables in the body and reference / log tables
+in the appendices.
 
 | Section | What it covers |
 |---|---|
-| Bottom line | the answer up front — one plain-language paragraph per candidate plus a **Decision scorecard**: each gate rated 1–5 (Likert), candidates × the 3 gates + verdict |
-| What's in this deliverable | an index of the bundle — every file, what it carries, and a file tree |
-| The candidates | 1–N candidate topics in a roster table, each given a readable name + a plain "why it could be a gap" tag |
-| Gate 1 — Is the gap still open? | the literature funnel + classification, closest prior work and how solid it is, recall confidence |
-| Gate 2 — Would it be a real contribution? | what it would contribute, dead-end history, new-capability-vs-extension, a minimum validation sketch |
-| Gate 3 — Is it feasible? | data / resources, design feasibility, a scale outline, the binding constraint, proposal-vs-dissertation feasibility |
-| The decision is yours | a conditional recommendation pending named checks; an operational upgrade/kill test; a salvage path for a failed candidate |
-| Appendix A | how the dossier was produced — a method note (search scope, inclusion criteria, automated-vs-judgement) |
+| 1. Executive Decision Summary | metadata box; one framing sentence; **per-candidate verdict cards** (small 2-column tables, generator colour-codes the verdict cell); a one-line key uncertainty |
+| 2. Candidate Definitions | per candidate, name + one-sentence statement + a plain "why it could be a gap" tag ("No one has tried this" / "Current methods fall short") |
+| 3. Decision Scorecards | per candidate, a small 3-column table (Gate / Score / Rationale) with the three gates rated 1–5 (Likert) plus a Verdict row; cells colour-coded by the generator |
+| 4. Evidence Base | the search funnel, the prior-art classification, and the closest prior work per candidate with inline evidence-type tags |
+| 5. Gate-by-Gate Assessment | each gate uses a fixed five-field skeleton: Score / Evidence / Interpretation / Risk / Action needed |
+| 6. Risks and Upgrade / Kill Tests | named risks (construct validity, dataset, novelty, reproducibility); operational upgrade / kill test per conditional candidate; salvage path per failed candidate |
+| 7. Recommended Next Steps | formal research-memo prose — the do-not-pursue topic and the conditional topic, with named actions |
+| Appendix A. Search and Screening Protocol | a reproducibility log — search date, databases, query families, retrieved, dedup, inclusion / exclusion, screening, known limitations, recall confidence |
+| Appendix B. Deliverable File List | the file index and the file tree |
 
 (SKILL.md §0–§4 below are the agent's internal workflow steps; they map to
-the reader-facing sections above — §0 → The candidates, §1 → Gate 1, etc.)
+the reader-facing sections above — §0 → §2 Candidate Definitions, §1 → §3
+Decision Scorecards + §4 Evidence Base + §5 Gate 1, etc.)
 
 Plus two machine-readable companions: `<dossier>.bib` (the Gate 1 reference
 list as BibTeX) and `<dossier>.gaps.yml` (structured candidates + verdicts +

--- a/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
+++ b/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
@@ -1,117 +1,106 @@
 # Reference — the topic-decision dossier (blank template)
 
 > The shape `gap-to-topic` emits to `.research/topic_dossier.md`. Each `>`
-> italic note is that section's contract — what it must contain. The dossier
-> is a thinking tool: surface uncertainty, do not polish it away.
+> italic note is that section's contract — what it must contain. The
+> dossier is a **research-grade decision memo**: first page enables a
+> decision; the body supports verification; the appendices support a re-run.
 >
-> **Reader-first rules** — the dossier is written for a researcher (a
-> graduate student and their advisor) deciding a thesis or proposal topic.
-> It must read as a plain summary report, top-to-bottom, with no decoding:
-> - **No codes in the document.** Candidates are named in plain words; the
->   machine ids (`G1`, `G2`, …) live only in the `.gaps.yml` companion.
+> **Reader-first rules** — the dossier is for a graduate student and their
+> advisor. It must read top-to-bottom in Word with no decoding:
+> - **No machine codes in the document.** `G1` / `G2` ids live only in
+>   `.gaps.yml`.
 > - **No decorative symbols.** No `✓ ✗ ~` glyphs, no `·` separators.
-> - **Plain verdicts.** Never "no-go / go" jargon — say "Do not pursue —
->   as stated", "Worth pursuing — only if its open conditions hold",
->   "Worth pursuing".
-> - **Lead with the answer**; keep tool / pipeline mechanics in Appendix A.
-> - Formal enum tokens (`partially-occupied`, `borderline`, …) belong in
->   `.gaps.yml`, not the prose — gloss them in plain words.
-> - The dossier is **English by default**. A translated mirror is produced
->   only on request, in a sibling-language folder.
+> - **Plain verdicts.** "Do not pursue — as stated" / "Worth pursuing —
+>   only if its open conditions hold" / "Worth pursuing".
+> - **Decision-first.** Page 1 is the executive summary; the body holds the
+>   small set of decision-relevant tables; everything else (file list,
+>   search details, automated-vs-judgement) belongs in an appendix.
+> - English by default; a translated mirror goes in a sibling-language folder.
 
 ---
 
 # Topic Decision Dossier — <topic area>
 
-## Bottom line
-
-> *One framing sentence (what was evaluated), then one short paragraph per
-> candidate — name it, give its plain-language outcome, and the reason in a
-> sentence or two. Each paragraph must name at least one concrete piece of
-> evidence. Then the Decision scorecard, then the one key caveat.*
-
-<One sentence: N candidate topics were evaluated for <area>.>
-
-**<Candidate 1 name>** — <plain outcome>. <One or two plain sentences; name
-a concrete piece of evidence.>
-
-**<Candidate 2 name>** — <plain outcome>. <…with a concrete piece of
-evidence named.>
-
-### Decision scorecard
-
-> *Each gate is stated as a claim and rated 1–5: 5 = strongly agree the
-> claim holds, 3 = mixed or qualified, 1 = strongly disagree. A topic is
-> worth pursuing only if every gate rates 3 or higher. A gate after a gate
-> that already failed reads "Not assessed". No glyphs — the cell is
-> `N/5 label — short description`.*
-
-Rating: 5 = strongly agree, 4 = agree, 3 = neutral, 2 = disagree,
-1 = strongly disagree. A topic is worth pursuing only if every gate is 3 or
-higher.
-
-| Candidate | Gate 1 — "the gap is still open" | Gate 2 — "it would be a real contribution" | Gate 3 — "it is feasible within reach" | Verdict |
-|---|---|---|---|---|
-| 1. <name> | <N/5 label — short description> | <N/5 label — … or "Not assessed"> | <N/5 label — … or "Not assessed"> | **<Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing>** |
-| 2. <name> | … | … | … | **…** |
+## 1. Executive Decision Summary
 
 | Field | Value |
 |---|---|
 | Area | <the research area> |
 | Compiled | <YYYY-MM-DD> |
 | Verdict grade | Screening-grade — assembles evidence; does NOT decide worth |
+| Search confidence | <high / medium / low — one phrase why> |
 
-> *This dossier is a thinking tool, not a polished report. It runs each
-> candidate through a 3-gate test — open AND a contribution AND feasible. A
-> candidate that fails any gate should not be pursued as stated. The "is it
-> worth doing" call is handed back to the researcher and advisor.*
+<One framing sentence: "N candidate topics were evaluated for <area>.">
 
-## What's in this deliverable
+> *Verdict cards — one small 2-column table per candidate. Header row
+> reads `Candidate N | <readable name>` (rendered as the card title);
+> data rows are `Verdict | <plain phrase>` (the generator colour-codes
+> this cell) and `Reason | <one or two sentences>`.*
 
-> *An index of the bundle — every file and what information it carries — so
-> a reader knows the whole pack from this one document, then a file tree of
-> the layout. A default (English-only) dossier lists a flat bundle; a
-> translated deliverable shows the sibling-language folders.*
+| Candidate 1 | <readable name> |
+|---|---|
+| **Verdict** | <Do not pursue — as stated / Worth pursuing — only if its open conditions hold / Worth pursuing> |
+| **Reason** | <one or two plain sentences naming a concrete piece of evidence> |
 
-| File | What it is | What it gives you |
+| Candidate 2 | <readable name> |
+|---|---|
+| **Verdict** | <…> |
+| **Reason** | <…> |
+
+**Key uncertainty.** <One line — the dominant caveat the reader must keep
+in mind: recall confidence, a caution paper, or a dataset constraint.>
+
+## 2. Candidate Definitions
+
+> *Plain prose, no roster table. Per candidate: name + a one-sentence
+> statement, then a plain "why it could be a gap" line that leads with one
+> of two tags — "No one has tried this" (a capability not yet applied to a
+> domain) or "Current methods fall short" (an existing method has a
+> blocking limit).*
+
+**Candidate 1 — <readable name>.** <One-sentence statement of the
+candidate.> *Why it could be a gap:* <"No one has tried this" /
+"Current methods fall short"> — <one-sentence rationale>.
+
+**Candidate 2 — <readable name>.** <…>
+
+## 3. Decision Scorecards
+
+> *Per candidate, one small 3-column table — Gate / Score / Rationale —
+> with the three gates plus a Verdict row. The Likert scale: 5 = strongly
+> agree, 4 = agree, 3 = neutral, 2 = disagree, 1 = strongly disagree. A
+> topic is worth pursuing only if every gate is 3 or higher. The Verdict
+> row's Score cell and any "Not assessed" cells are colour-coded by the
+> generator.*
+
+**Candidate 1 — <readable name>**
+
+| Gate | Score | Rationale |
 |---|---|---|
-| `topic_dossier.md` / `.docx` | This document — the topic-decision summary | The verdict on each candidate and the evidence behind it |
-| `topic_dossier.bib` | The reference list, as BibTeX | Every cited paper with a resolvable DOI / arXiv ID — lets you verify "open" yourself |
-| `literature_matrix.md` | The paper-by-paper comparison table | How each retrieved paper compares — method, claim, evidence type, limitation |
-| `topic_dossier.gaps.yml` | Machine-readable export | Structured data for a downstream tool or a later pass; not needed for reading |
+| Gate 1 — Gap still open | <N/5 label> | <brief why> |
+| Gate 2 — Real contribution | <N/5 label or "Not assessed"> | <brief why or "failed Gate 1"> |
+| Gate 3 — Feasible | <N/5 label or "Not assessed"> | <brief why or "failed Gate 1"> |
+| **Verdict** | **<plain verdict phrase>** | <overall one-liner> |
 
-```
-<deliverable-folder>/
-├── topic_dossier.md / .docx
-├── topic_dossier.bib
-├── literature_matrix.md
-└── topic_dossier.gaps.yml
-```
+**Candidate 2 — <readable name>**
 
-## The candidates
-
-> *1–N candidates, articulated WITH the researcher (Socratic — never
-> invented). The roster table names each and says, in plain words, why it
-> could be a gap — each "why" cell leads with one of two plain tags:
-> "No one has tried this" (a capability not yet applied to a domain) or
-> "Current methods fall short" (an existing method has a blocking limit).
-> Then a one-sentence statement per candidate. Each candidate also has a
-> machine id (`G1`, `G2`, …) — that id goes ONLY into `.gaps.yml`.*
-
-| # | Candidate topic | Why it could be a gap |
+| Gate | Score | Rationale |
 |---|---|---|
-| 1 | <readable name> | <"No one has tried this" / "Current methods fall short"> — <plain rationale> |
-| 2 | <readable name> | <…> |
+| Gate 1 — Gap still open | <…> | <…> |
+| Gate 2 — Real contribution | <…> | <…> |
+| Gate 3 — Feasible | <…> | <…> |
+| **Verdict** | **<…>** | <…> |
 
-1. **<name>** — <one-sentence statement of the candidate>.
-2. **<name>** — <…>
+## 4. Evidence Base
 
-## Gate 1 — Is the gap still open?
+> *Three sub-blocks: the search funnel, the prior-art classification, and
+> the closest prior work per candidate. The closest-prior-work bullets
+> carry inline evidence-type tags (primary study, review, survey,
+> perspective, caution paper, close analogue, conference abstract,
+> preprint, data artifact). Full per-paper detail is in
+> `literature_matrix.md`; do not duplicate it here.*
 
-> *The verdict is in the Decision scorecard; this section is the evidence
-> behind it, in three blocks.*
-
-**Literature collected.** The Gate 1 search funnel:
+**Search funnel.**
 
 | Stage | Count |
 |---|---|
@@ -120,114 +109,151 @@ higher.
 | Kept on-topic by the relevance gate | <K> |
 | Selected into the prior-art corpus | <P> |
 
-Classification of the prior-art corpus (full per-paper detail in
-`literature_matrix.md`):
+**Prior-art classification of the <P>-paper corpus.**
 
 | By evidence type | By candidate |
 |---|---|
 | <e.g. 6 primary studies, 2 reviews, 1 survey, 1 perspective, 1 caution paper, 2 close analogues> | <e.g. 9 bear on Candidate 1, 4 on Candidate 2> |
 
-**Closest prior work, and how solid it is.** <One conclusion sentence, then
-a few bullets — the key papers per candidate, each with an inline
-evidence-type tag (primary study, review, survey, perspective, caution
-paper, close analogue, conference abstract, preprint, data artifact), and a
-plain note on how solid the occupancy signal is. Full list in the `.bib`.>
+**Closest prior work.**
 
-- **Candidate 1:** <key papers, tagged> — <how solid the signal is>.
-- **Candidate 2:** <closest analogues, tagged> — <how thin the direct
+- **Candidate 1:** <key papers, each tagged inline by evidence type> —
+  <how solid the occupancy signal is>.
+- **Candidate 2:** <closest analogues, each tagged> — <how thin the direct
   evidence is>.
 
-**Recall confidence.** <One plain sentence — e.g. "Medium: one search
-backend was unavailable, so a missed paper is possible; re-check before
-relying on an 'open' verdict.">
+## 5. Gate-by-Gate Assessment
 
-## Gate 2 — Would it be a real contribution?
+> *Each gate uses the same five-field skeleton. The Score line is the
+> Likert from the scorecard. Evidence summarises the corpus reading (the
+> corpus itself lives in §4). Interpretation says what the score means;
+> Risk names the dominant uncertainty; Action needed says what to do next.*
 
-> *The scorecard carries the verdict; here is the reasoning, per assessed
-> candidate, in four parts. A candidate that failed Gate 1 is not assessed.*
+### Gate 1 — Gap still open
 
-For each assessed candidate:
+- **Score:** <N/5 label, per candidate>.
+- **Evidence:** <one paragraph summarising §4's closest-prior-work read
+  per candidate>.
+- **Interpretation:** <what the score means — "occupied", "open", "lean
+  open", etc., glossed in plain words>.
+- **Risk:** <the dominant openness uncertainty — typically recall
+  confidence and which backend was missing>.
+- **Action needed:** <re-run the search with the missing backend; specific
+  query refinements if any>.
 
-- **What it would contribute.** <One explicit claim — what the finished
-  research would add: a modelling method, a validated behavioural
-  representation, a dataset or benchmark, an empirical finding, or a
-  decision-support result. Not "applies X to Y" — the actual addition.>
-- **Has the field tried this and hit a wall?** <Plain answer. If a caution
-  or post-mortem paper exists, summarise the *kind* of risk it raises —
-  construct validity, ethics, representativeness, interpretability — not
-  just "go read it".>
-- **A new capability, or an extension of existing work?** <Plain answer +
-  one-sentence justification. A descriptive lens, not a quality judgment;
-  an extension can be well worth doing.>
-- **Minimum validation sketch.** <What would distinguish a real
-  contribution from a plausible-looking result: the behaviour target, a
-  baseline or comparator, a held-out test, and the main failure mode the
-  study must survive.>
+### Gate 2 — Real contribution
 
-## Gate 3 — Is it feasible?
+- **Score:** <N/5 label or "Not assessed", per candidate>.
+- **Evidence:** <what the field has already tried; any caution paper —
+  named, with its content summarised>.
+- **Interpretation:** <what the candidate would contribute, in one
+  explicit claim — a method, a validated representation, a dataset, an
+  empirical finding, or a decision-support result; also the
+  new-capability-vs-extension call>.
+- **Risk:** <the kind of risk a caution paper raises: construct validity /
+  ethics / representativeness / interpretability>.
+- **Action needed:** <the minimum validation sketch — behaviour target,
+  baseline or comparator, held-out test, the main failure mode the study
+  must survive>.
 
-> *The scorecard carries the verdict; here is the detail, per assessed
-> candidate, in five parts. Front-loaded — feasibility must be known BEFORE
-> the research framework is built. A candidate that failed an earlier gate
-> is not assessed.*
+### Gate 3 — Feasible
 
-For each assessed candidate:
+- **Score:** <N/5 label or "Not assessed", per candidate>.
+- **Evidence:** <what data / resources are needed; the design-feasibility
+  picture — can the baselines run, privacy / consent constraints,
+  reproducibility when outputs depend on an API model; a scale outline
+  with a rough size / time / cost band>.
+- **Interpretation:** <the binding constraint — the one item that decides
+  the timeline; the proposal-vs-dissertation split>.
+- **Risk:** <privacy / consent or API-model reproducibility, whichever
+  binds harder>.
+- **Action needed:** <identify a reusable dataset, or plan a
+  primary-collection schedule>.
 
-- **What it needs.** <Data / resources — public? cost? lead time?>
-- **Design feasibility.** <Beyond data availability: can the baselines /
-  comparators actually be run; privacy or consent constraints on the data;
-  reproducibility when outputs depend on an external API model.>
-- **Scale outline.** <A rough size / time / cost band — enough for the
-  reader to picture the project, not a precise estimate.>
-- **The binding constraint.** <The one item that decides the timeline.>
-- **Proposal-feasible vs dissertation-feasible.** <State both: what a
-  proposal needs to clear, and whether a full dissertation or paper can
-  realistically be completed — for a student the effort boundary is the
-  decision.>
+## 6. Risks and Upgrade / Kill Tests
 
-## The decision is yours
+> *First a per-candidate list of the named risks; then, per conditional
+> candidate, an operational upgrade / kill test (every condition written
+> as a concrete artifact or result, not "credibly answer" prose); then,
+> per failed candidate, a one-line salvage path.*
 
-> *The dossier stops here. It has assembled the three gate verdicts;
-> whether a gap is WORTH doing is the researcher's and advisor's call.
-> Frame each surviving candidate consistently as a CONDITIONAL
-> RECOMMENDATION pending named checks — do not mix "evidence, not a
-> verdict" with "worth pursuing". For each, give an upgrade / kill test
-> written as concrete artifacts or results, and for a failed candidate one
-> explicit salvage-path line.*
+**Named risks.**
 
-The three gates above are assembled evidence. A topic is worth pursuing
-only if all three pass — open AND a contribution AND feasible. **Whether
-<Candidate N> is worth pursuing is your and your advisor's decision**, and
-for any candidate that cleared the gates it is a *conditional
-recommendation* — worth pursuing once the checks below are met.
+- **Construct-validity risk** — <how it manifests in this dossier — e.g.
+  a caution paper raising whether LLM-generated behaviour faithfully
+  represents real human decisions or only looks plausible>.
+- **Dataset-constraint risk** — <the binding behavioural / domain dataset
+  question for the conditional candidate>.
+- **Novelty risk** — <borderline novelty if a weaker realised form
+  already exists>.
+- **Reproducibility risk** — <e.g. LLM outputs depend on an external API
+  model that can change; the design must pin model versions and archive
+  prompts and outputs>.
 
-<Per candidate: the plain outcome, then the conditions to resolve.>
+**Upgrade / kill test — <conditional candidate>.** Worth pursuing once
+**all** of these hold:
+1. <a concrete search result — e.g. "a full-recall re-run with backend X
+   enabled returns no paper that already builds the candidate">;
+2. <a concrete pilot artifact — e.g. "a held-out validation result in
+   which the candidate's method predicts the target at least as well as
+   baseline X">;
+3. <a concrete data check — e.g. "a reusable dataset is identified or a
+   primary-collection schedule that fits the project timeline is in
+   hand">.
+Not worth pursuing if any one of the above fails on its specific finding.
 
-**Upgrade / kill test — <conditional candidate>.** It is **worth pursuing**
-once <each open condition expressed as a concrete artifact or result — e.g.
-"a held-out validation result against baseline X", not "credibly answer">.
-It is **not worth pursuing as stated** if <the concrete finding that would
-fail a gate>.
+**Salvage path — <failed candidate>.** <One line — the narrower slice
+worth a fresh look, and what specifically to re-search.>
 
-**Salvage path — <failed candidate>.** <One line: the narrower slice worth
-a fresh look, and what specifically to re-search.>
+## 7. Recommended Next Steps
+
+> *Formal research-memo language — two short paragraphs. First, the
+> broad topic that should not be pursued in its current form. Second, the
+> narrower topic that is conditionally promising, with the specific
+> actions required before commitment.*
+
+<Paragraph 1 — the do-not-pursue candidate.>
+
+<Paragraph 2 — the conditional candidate, naming the actions from §6.>
 
 ---
 
-## Appendix A — How this dossier was produced
+## Appendix A. Search and Screening Protocol
 
-> *A method note, not a tool log — enough for a researcher to judge how far
-> to trust the dossier and what must be re-run. Downplay internal command
-> names; state search scope, inclusion criteria, and dates; separate the
-> automated steps from agent / researcher judgement.*
+> *A reproducibility log — enough for a researcher to judge how far to
+> trust the dossier and to re-run the search.*
 
-| Item | Detail |
+| Field | Value |
 |---|---|
-| Search scope | <what was searched: query phrasings, fields, year range, the backends used and any unavailable> |
-| Inclusion criteria | <how the prior-art corpus was selected from the screened set — what made a paper in or out> |
-| Automated vs judgement | <which steps were automated — search, relevance screening — and which were agent / researcher judgement — corpus selection, evidence tagging, the gate verdicts> |
-| Recall confidence | <the headline confidence and why; what to re-run for a tighter verdict> |
-| Run details | <date; tool version; pipeline as a one-line trace if useful> |
+| Search date | <YYYY-MM-DD> |
+| Databases searched | <crossref, OpenAlex, arXiv, Semantic Scholar — note any rate-limited / unavailable> |
+| Query families | <the adversarial query phrasings and how they were generated> |
+| Number retrieved | <N unique> |
+| Deduplication rule | <how duplicates were handled> |
+| Inclusion criteria | <what made a paper enter the prior-art corpus> |
+| Exclusion criteria | <what made a paper exclude — tangential, off-domain, etc.> |
+| Screening process | <automated relevance gate and manual judgement steps, distinguished> |
+| Known limitations | <recall caveats, e.g. a backend unavailable> |
+| Recall confidence | <headline confidence and what to re-run for a tighter verdict> |
+
+## Appendix B. Deliverable File List
+
+| File | What it is | What it gives you |
+|---|---|---|
+| `topic_dossier.md` / `.docx` | This document — the topic-decision summary | The verdict on each candidate and the evidence behind it |
+| `topic_dossier.bib` | The reference list, as BibTeX | Every cited paper with a resolvable DOI — lets you verify "open" yourself |
+| `literature_matrix.md` | The paper-by-paper comparison table | How each retrieved paper compares — method, claim, evidence type, limitation |
+| `topic_dossier.gaps.yml` | Machine-readable export | Structured data for a downstream tool or a later pass; not needed for reading |
+
+```
+en/
+├── topic_dossier.md / .docx
+├── topic_dossier.bib
+├── literature_matrix.md
+└── topic_dossier.gaps.yml
+```
+
+(A translated mirror, if produced, lives in a sibling-language folder.)
 
 ---
 
@@ -235,7 +261,7 @@ a fresh look, and what specifically to re-search.>
 
 > The `.gaps.yml` companion is machine-readable and is **not** part of the
 > human dossier above. It keeps the machine ids (`G1`, `G2`) and the formal
-> enum tokens. Its shape:
+> enum tokens.
 
 ```yaml
 dossier: <topic area>
@@ -255,7 +281,8 @@ open_questions:
     text: "<question the evidence could not settle>"
 ```
 
-The `.bib` companion is the Gate 1 reference list as BibTeX — built from the
-on-topic `search --adversarial --screen --json` results (NOT from
-`cite --format bibtex`, which resolves only already-ingested Zotero items —
-see SKILL.md §1 step 3). Every entry must have a resolvable DOI or arXiv ID.
+The `.bib` companion is the Gate 1 reference list as BibTeX — built from
+the on-topic `search --adversarial --screen --json` results (NOT from
+`cite --format bibtex`, which resolves only already-ingested Zotero items
+— see SKILL.md §1 step 3). Every entry must have a resolvable DOI or
+arXiv ID.


### PR DESCRIPTION
Reflows the gap-to-topic dossier as a research-grade decision memo: §1 Executive Decision Summary (metadata + verdict cards + key uncertainty) → §2 Candidate Definitions → §3 Decision Scorecards (per-candidate small tables) → §4 Evidence Base → §5 Gate-by-Gate Assessment (fixed Score / Evidence / Interpretation / Risk / Action-needed skeleton) → §6 Risks and Upgrade / Kill Tests → §7 Recommended Next Steps → Appendix A reproducibility log → Appendix B file list. Plugin 0.3.8 → 0.3.9. Companion gen_docx.js fixes (separator-row skip + verdict color coding) are out-of-repo. code-reviewer APPROVE.