### PR TITLE
fix(skill): gap-to-topic — ship dossier_to_docx.js as first-class .docx artifact (plugin 0.3.9 → 0.3.10)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,23 @@ graph rebuild (link out to the real tools instead)._
   (`--with-pdfs` only) — they are lower-level entry points where an explicit
   flag still makes sense.
 
+### Added
+- **`dossier_to_docx.js` ships inside `skills/gap-to-topic/scripts/`**
+  (plugin `0.3.9 → 0.3.10`). `topic_dossier.docx` is now a first-class
+  contracted deliverable of the `gap-to-topic` skill. The generator converts
+  `topic_dossier.md` to a styled Word document using `docx` 9.x: heading
+  styles (H1/H2 navy, H3 dark grey), bullet lists via numbering reference,
+  tables with dual-width DXA column sizing, bilingual verdict colour coding
+  (light red "Do not pursue" / "不予推進", light yellow conditional
+  "Worth pursuing … only if" / "值得推進…條件", light green unconditional,
+  light grey "Not assessed" / "未評估"), Markdown separator-row skip, and an
+  optional TOC + page break after the first table (`--no-toc` to suppress).
+  Font auto-selects: filename matching `.zh|zh-|zh_|-tw|-cn` → Microsoft
+  JhengHei; else Arial. Prerequisite: `npm install -g docx`. SKILL.md updated
+  with §4.5 "Generate .docx" workflow step; front-matter description and "What
+  it produces" updated to list `.docx` as a first-class artifact. Mirrored to
+  `src/research_hub/skills_data/gap-to-topic/scripts/`.
+
 ### Fixed
 - **`gap-to-topic` dossier reflowed as a 7-section research-grade decision
   memo** (`skills/gap-to-topic/`, plugin `0.3.8 → 0.3.9`). The v0.3.8

--- a/skills/gap-to-topic/SKILL.md
+++ b/skills/gap-to-topic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gap-to-topic
-description: Turn a research area into a go/no-go decision dossier for ONE candidate thesis/proposal topic — a 3-gate verdict (is the gap open? is it a contribution? is it feasible?) with the evidence laid out so the researcher can verify it. Use when the user asks "is this gap worth pursuing", "help me pick a thesis topic", "is this idea already taken", "find me a defensible research gap", "vet this research idea before I commit", or "should I do this". NOT a literature review (use `literature-triage-matrix` for a comparison matrix) and NOT a study design (use `research-design-helper` once a topic is chosen). Produces a `.research/topic_dossier.md` plus a `.bib` and a `.gaps.yml`.
+description: Turn a research area into a go/no-go decision dossier for ONE candidate thesis/proposal topic — a 3-gate verdict (is the gap open? is it a contribution? is it feasible?) with the evidence laid out so the researcher can verify it. Use when the user asks "is this gap worth pursuing", "help me pick a thesis topic", "is this idea already taken", "find me a defensible research gap", "vet this research idea before I commit", or "should I do this". NOT a literature review (use `literature-triage-matrix` for a comparison matrix) and NOT a study design (use `research-design-helper` once a topic is chosen). Produces a `.research/topic_dossier.md`, a `.research/topic_dossier.docx` (Word, colour-coded), a `.bib`, and a `.gaps.yml`.
 compatibility: Pure agentskills.io-spec skill. Domain-agnostic; works alongside Zotero/Obsidian/NotebookLM workflows but requires none of them.
 ---
 
@@ -37,12 +37,14 @@ Not for:
 
 ## What it produces
 
-`.research/topic_dossier.md` — a **research-grade decision memo**: first
-page enables a decision; the body supports verification; the appendices
-support a re-run. Reads top-to-bottom in Word with no decoding — no codes
-(`G1`/`G2` stay only in `.gaps.yml`), no decorative glyphs, plain-language
-verdicts, decision-relevant tables in the body and reference / log tables
-in the appendices.
+`.research/topic_dossier.md` and `.research/topic_dossier.docx` — a
+**research-grade decision memo** in Markdown and as a colour-coded Word
+document: first page enables a decision; the body supports verification; the
+appendices support a re-run. Reads top-to-bottom in Word with no decoding —
+no codes (`G1`/`G2` stay only in `.gaps.yml`), no decorative glyphs,
+plain-language verdicts, decision-relevant tables in the body and reference /
+log tables in the appendices. Verdict cells are colour-coded in the .docx
+(light red / yellow / green / grey by verdict phrase, bilingual en + zh-TW).
 
 | Section | What it covers |
 |---|---|
@@ -180,6 +182,26 @@ data public? what does it cost? how long to obtain? — and record a verdict.
 The dossier ends by stating explicitly: it has assembled the three
 gate-verdicts; whether the gap is *worth doing* is the researcher's and
 advisor's call. The skill never makes that call.
+
+### §4.5 — Generate .docx
+
+After `.research/topic_dossier.md` is written, run the bundled generator to
+produce the matching Word deliverable:
+
+```bash
+# From the dossier's output directory (e.g. .research/ or en/)
+node /path/to/skills/gap-to-topic/scripts/dossier_to_docx.js topic_dossier [--no-toc]
+```
+
+Prerequisite: `npm install -g docx` (or `cd scripts && npm install docx` for a
+local install). See `scripts/README.md` for full invocation details and the
+zh-TW case.
+
+The script produces `topic_dossier.docx` alongside the `.md`. It colour-codes
+verdict cells (light red / yellow / green / grey), auto-selects font
+(Microsoft JhengHei for zh-TW filenames, Arial otherwise), skips Markdown
+separator rows, and inserts a TOC + page break after the first table (suppress
+with `--no-toc`).
 
 ## Honesty rules
 

--- a/skills/gap-to-topic/scripts/README.md
+++ b/skills/gap-to-topic/scripts/README.md
@@ -1,0 +1,66 @@
+# scripts/dossier_to_docx.js
+
+Convert a `gap-to-topic` dossier Markdown file into a styled Word document
+(.docx) using `docx` 9.x.
+
+## What it produces
+
+A `.docx` file alongside the source `.md` with:
+
+- Heading styles (H1 navy, H2 navy, H3 dark grey) using the auto-selected font
+- Bullet lists via a numbering reference (not a unicode glyph)
+- Tables with dual-width DXA column sizing
+- Verdict colour coding on scorecard and verdict-card cells:
+  - "Do not pursue" / "不予推進" — light red `#F4DEDE`
+  - "Worth pursuing … only if" / conditional — light yellow `#FFF4D6`
+  - "Worth pursuing" (unconditional) — light green `#E2F0DA`
+  - "Not assessed" / "未評估" — light grey `#EEEEEE`
+- Table separator rows (`|---|---|`) skipped — they do not appear as "---" cells in Word
+- Optional Table of Contents + page break inserted after the first table
+  (omit with `--no-toc` for short docs where Word's empty TOC field is distracting)
+
+Font auto-selection: if the filename contains `.zh`, `zh-`, `zh_`, `-tw`, or
+`-cn` (case-insensitive), the document body uses **Microsoft JhengHei**;
+otherwise **Arial**.
+
+## Prerequisite
+
+Install the `docx` npm package before running the script:
+
+```
+# Global install (available everywhere):
+npm install -g docx
+
+# Local install (available only from the scripts/ directory):
+cd scripts && npm install docx
+```
+
+If `docx` is not installed, Node.js will throw a `Cannot find module 'docx'`
+error when the script is run. Install it and re-run.
+
+## Invocation
+
+Run from the directory that contains your `topic_dossier.md` (the dossier
+output directory — typically `.research/` or `en/` / `zh-TW/`):
+
+```bash
+# English dossier (Arial font, with TOC):
+node /path/to/skills/gap-to-topic/scripts/dossier_to_docx.js topic_dossier
+
+# English dossier, skip TOC:
+node /path/to/skills/gap-to-topic/scripts/dossier_to_docx.js topic_dossier --no-toc
+
+# zh-TW dossier (JhengHei font):
+node /path/to/skills/gap-to-topic/scripts/dossier_to_docx.js topic_dossier.zh-TW --no-toc
+
+# Absolute path (writes .docx alongside the .md):
+node dossier_to_docx.js /abs/path/to/en/topic_dossier
+```
+
+The output `.docx` is written to the same directory as the `.md` file.
+
+## Integration in the gap-to-topic workflow
+
+After `gap-to-topic` writes `.research/topic_dossier.md`, run this script from
+that directory to produce the matching `.docx` deliverable. See SKILL.md §4.5
+for the contracted post-processing step.

--- a/skills/gap-to-topic/scripts/dossier_to_docx.js
+++ b/skills/gap-to-topic/scripts/dossier_to_docx.js
@@ -1,0 +1,264 @@
+// dossier_to_docx.js — convert a gap-to-topic dossier (.md) to a styled Word document (.docx)
+//
+// Prerequisite: npm install -g docx   (or: cd scripts && npm install docx  for local)
+//
+// Usage:
+//   node dossier_to_docx.js [stem-or-path] [--no-toc]
+//
+//   stem-or-path  Stem name ("topic_dossier") relative to cwd, OR an absolute path
+//                 (with or without .md/.docx extension — the script adds them).
+//                 Default: "topic_dossier"
+//   --no-toc      Skip the Table of Contents field (avoid empty Word TOC on short docs).
+//
+// Examples:
+//   node dossier_to_docx.js topic_dossier --no-toc
+//   node dossier_to_docx.js /abs/path/to/en/topic_dossier
+//   node dossier_to_docx.js topic_dossier.zh-TW   (triggers JhengHei font)
+//
+// Font auto-selection:
+//   filename matches /.zh|zh-|zh_|-tw|-cn/i  -> Microsoft JhengHei
+//   otherwise                                 -> Arial
+//
+// Verdict colour coding (cells in scorecards and verdict cards):
+//   "Do not pursue" / "不予推進"              -> light red   (#F4DEDE)
+//   "Worth pursuing … only if" / conditional  -> light yellow (#FFF4D6)
+//   "Worth pursuing" (unconditional)          -> light green  (#E2F0DA)
+//   "Not assessed" / "未評估"                 -> light grey   (#EEEEEE)
+//   All other cells                           -> white
+
+const fs = require("fs");
+const path = require("path");
+const {
+  Document, Packer, Paragraph, TextRun, Table, TableRow, TableCell,
+  AlignmentType, LevelFormat, TableOfContents, HeadingLevel, BorderStyle,
+  WidthType, ShadingType, PageBreak,
+} = require("docx");
+
+// ---- argument parsing ----
+const NOTOC = process.argv.includes("--no-toc");
+const ARG = process.argv.slice(2).find((a) => !a.startsWith("--")) || "topic_dossier";
+
+// Strip .md or .docx extension if provided so we work from the bare stem
+const stem = ARG.replace(/\.(md|docx)$/i, "");
+
+// Font: detect Chinese filename pattern
+const FONT = /\.zh|zh-|zh_|-tw|-cn/i.test(stem) ? "Microsoft JhengHei" : "Arial";
+
+// Resolve source (.md) and output (.docx) paths.
+// If the stem is absolute (contains a path separator), write alongside it.
+// Otherwise resolve relative to process.cwd() so the script works from any directory.
+const isAbs = path.isAbsolute(stem) || stem.includes("/") || stem.includes("\\");
+const SRC = isAbs ? path.resolve(stem + ".md") : path.resolve(process.cwd(), stem + ".md");
+const OUT = isAbs ? path.resolve(stem + ".docx") : path.resolve(process.cwd(), stem + ".docx");
+
+const CONTENT_W = 9360;
+
+// ---- inline markdown -> TextRun[] ----
+function parseInline(text, base = {}) {
+  const runs = [];
+  const re = /(\*\*[^*]+\*\*|`[^`]+`|\*[^*]+\*)/g;
+  let last = 0, m;
+  while ((m = re.exec(text))) {
+    if (m.index > last) runs.push(new TextRun({ text: text.slice(last, m.index), ...base }));
+    const t = m[0];
+    if (t.startsWith("**")) runs.push(new TextRun({ text: t.slice(2, -2), bold: true, ...base }));
+    else if (t.startsWith("`")) runs.push(new TextRun({ text: t.slice(1, -1), font: "Consolas", size: 19, ...base }));
+    else runs.push(new TextRun({ text: t.slice(1, -1), italics: true, ...base }));
+    last = re.lastIndex;
+  }
+  if (last < text.length) runs.push(new TextRun({ text: text.slice(last), ...base }));
+  if (!runs.length) runs.push(new TextRun({ text: "", ...base }));
+  return runs;
+}
+
+// ---- block parser ----
+if (!fs.existsSync(SRC)) {
+  console.error("ERROR: source file not found:", SRC);
+  process.exit(1);
+}
+const lines = fs.readFileSync(SRC, "utf8").replace(/\r\n/g, "\n").split("\n");
+const blocks = [];
+let i = 0;
+function lastBlock() { return blocks[blocks.length - 1]; }
+while (i < lines.length) {
+  const ln = lines[i];
+  const t = ln.trim();
+  if (/^#{1,3}\s/.test(t)) {
+    const level = t.match(/^#+/)[0].length;
+    blocks.push({ type: "h", level, text: t.replace(/^#+\s/, "") });
+    i++; continue;
+  }
+  if (t === "---") { blocks.push({ type: "hr" }); i++; continue; }
+  if (t === "") { blocks.push({ type: "blank" }); i++; continue; }
+  if (t.startsWith(">")) {
+    const buf = [];
+    while (i < lines.length && lines[i].trim().startsWith(">")) {
+      buf.push(lines[i].trim().replace(/^>\s?/, "")); i++;
+    }
+    blocks.push({ type: "note", text: buf.join(" ").replace(/\s+/g, " ").trim() });
+    continue;
+  }
+  if (t.startsWith("|")) {
+    const rows = [];
+    while (i < lines.length && lines[i].trim().startsWith("|")) {
+      const cells = lines[i].trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map(c => c.trim());
+      // Skip Markdown table separator row (|---|---|, |:---|---:|, …) —
+      // it is alignment metadata, not a data row; the previous parser
+      // pushed it and Word rendered a literal "---" row.
+      const isSep = cells.length > 0 && cells.every(c => /^:?-+:?$/.test(c));
+      if (!isSep) rows.push(cells);
+      i++;
+    }
+    blocks.push({ type: "table", rows });
+    continue;
+  }
+  if (t.startsWith("- ")) {
+    let txt = t.slice(2);
+    i++;
+    while (i < lines.length && /^\s{2,}\S/.test(lines[i])) { txt += " " + lines[i].trim(); i++; }
+    const lb = lastBlock();
+    if (lb && lb.type === "list") lb.items.push(txt);
+    else blocks.push({ type: "list", items: [txt] });
+    continue;
+  }
+  // normal paragraph (join wrapped lines until blank / marker)
+  let txt = t;
+  i++;
+  while (i < lines.length) {
+    const nx = lines[i], nt = nx.trim();
+    if (nt === "" || nt === "---" || /^#{1,3}\s/.test(nt) || nt.startsWith("|") || nt.startsWith(">") || nt.startsWith("- ")) break;
+    txt += " " + nt; i++;
+  }
+  blocks.push({ type: "p", text: txt });
+}
+
+// ---- render ----
+const border = { style: BorderStyle.SINGLE, size: 1, color: "BFBFBF" };
+const borders = { top: border, bottom: border, left: border, right: border,
+  insideHorizontal: border, insideVertical: border };
+const colWidths = (n) => {
+  if (n === 2) return [2400, 6960];
+  if (n === 4) return [1000, 2790, 3570, 2000];
+  if (n === 5) return [560, 3960, 560, 1480, 2800];
+  const w = Math.floor(CONTENT_W / n); return Array(n).fill(w);
+};
+
+// Cell-shading colour by row (header = dark blue) and, for non-header
+// cells, by verdict-keyword detection. Patterns are checked in order:
+// conditional "only if" must win over the plain green case.
+function cellFill(r, cell) {
+  if (r === 0) return "1F3B5B"; // header dark blue
+  const lc = cell.toLowerCase();
+  // English verdict keywords
+  if (/do not pursue/.test(lc)) return "F4DEDE";          // light red
+  if (/worth pursuing/.test(lc) && /only if/.test(lc)) return "FFF4D6"; // light yellow
+  if (/worth pursuing/.test(lc)) return "E2F0DA";         // light green
+  if (/not assessed/.test(lc)) return "EEEEEE";           // light grey
+  // zh-TW verdict keywords (toLowerCase is a no-op on CJK so cell is raw)
+  if (/不予推進/.test(cell)) return "F4DEDE";              // light red
+  if (/值得推進/.test(cell) && /只|須|待決|條件/.test(cell)) return "FFF4D6"; // light yellow
+  if (/值得推進/.test(cell)) return "E2F0DA";              // light green
+  if (/未評估/.test(cell)) return "EEEEEE";                // light grey
+  return "FFFFFF";                                         // default white
+}
+
+function mkTable(rows) {
+  const n = rows[0].length;
+  const cw = colWidths(n);
+  return new Table({
+    width: { size: CONTENT_W, type: WidthType.DXA },
+    columnWidths: cw,
+    rows: rows.map((cells, r) => new TableRow({
+      tableHeader: r === 0,
+      children: cells.map((cell, c) => new TableCell({
+        borders,
+        width: { size: cw[c], type: WidthType.DXA },
+        shading: { fill: cellFill(r, cell), type: ShadingType.CLEAR },
+        margins: { top: 70, bottom: 70, left: 110, right: 110 },
+        children: [new Paragraph({
+          spacing: { before: 20, after: 20 },
+          children: parseInline(cell, r === 0 ? { bold: true, color: "FFFFFF", size: 19 } : { size: 19 }),
+        })],
+      })),
+    })),
+  });
+}
+
+const children = [];
+let tocInserted = false;
+for (const b of blocks) {
+  if (b.type === "blank" || b.type === "hr") continue;
+  if (b.type === "h") {
+    const hl = b.level === 1 ? HeadingLevel.HEADING_1 : b.level === 2 ? HeadingLevel.HEADING_2 : HeadingLevel.HEADING_3;
+    children.push(new Paragraph({ heading: hl, children: parseInline(b.text) }));
+  } else if (b.type === "note") {
+    children.push(new Paragraph({
+      spacing: { before: 60, after: 120 },
+      indent: { left: 360 },
+      border: { left: { style: BorderStyle.SINGLE, size: 12, color: "B0B0B0", space: 12 } },
+      children: parseInline(b.text, { italics: true, color: "5A5A5A", size: 19 }),
+    }));
+  } else if (b.type === "p") {
+    children.push(new Paragraph({ spacing: { before: 80, after: 80 }, children: parseInline(b.text) }));
+  } else if (b.type === "list") {
+    for (const it of b.items) {
+      children.push(new Paragraph({
+        numbering: { reference: "bullets", level: 0 },
+        spacing: { before: 40, after: 40 },
+        children: parseInline(it),
+      }));
+    }
+  } else if (b.type === "table") {
+    children.push(new Paragraph({ spacing: { before: 80, after: 80 }, children: [] }));
+    children.push(mkTable(b.rows));
+    children.push(new Paragraph({ spacing: { after: 80 }, children: [] }));
+    if (!tocInserted && !NOTOC) {
+      tocInserted = true;
+      children.push(new Paragraph({ pageBreakBefore: true, heading: HeadingLevel.HEADING_2,
+        children: [new TextRun("Contents")] }));
+      children.push(new TableOfContents("Table of Contents", { hyperlink: true, headingStyleRange: "1-3" }));
+      children.push(new Paragraph({ children: [new PageBreak()] }));
+    }
+  }
+}
+
+const doc = new Document({
+  styles: {
+    default: { document: { run: { font: FONT, size: 22 } } },
+    paragraphStyles: [
+      { id: "Heading1", name: "Heading 1", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 34, bold: true, font: FONT, color: "1F3B5B" },
+        paragraph: { spacing: { before: 240, after: 200 }, outlineLevel: 0 } },
+      { id: "Heading2", name: "Heading 2", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 27, bold: true, font: FONT, color: "1F3B5B" },
+        paragraph: { spacing: { before: 260, after: 120 }, outlineLevel: 1 } },
+      { id: "Heading3", name: "Heading 3", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 23, bold: true, font: FONT, color: "2E2E2E" },
+        paragraph: { spacing: { before: 160, after: 60 }, outlineLevel: 2 } },
+    ],
+  },
+  numbering: {
+    config: [
+      { reference: "bullets",
+        levels: [{ level: 0, format: LevelFormat.BULLET, text: "•", alignment: AlignmentType.LEFT,
+          style: { paragraph: { indent: { left: 420, hanging: 280 } } } }] },
+    ],
+  },
+  sections: [{
+    properties: {
+      page: {
+        size: { width: 12240, height: 15840 },
+        margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 },
+      },
+    },
+    children,
+  }],
+});
+
+Packer.toBuffer(doc).then(buf => {
+  fs.writeFileSync(OUT, buf);
+  console.log("WROTE", OUT, buf.length, "bytes");
+}).catch(err => {
+  console.error("ERROR generating docx:", err.message);
+  process.exit(1);
+});

--- a/src/research_hub/skills_data/gap-to-topic/SKILL.md
+++ b/src/research_hub/skills_data/gap-to-topic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gap-to-topic
-description: Turn a research area into a go/no-go decision dossier for ONE candidate thesis/proposal topic — a 3-gate verdict (is the gap open? is it a contribution? is it feasible?) with the evidence laid out so the researcher can verify it. Use when the user asks "is this gap worth pursuing", "help me pick a thesis topic", "is this idea already taken", "find me a defensible research gap", "vet this research idea before I commit", or "should I do this". NOT a literature review (use `literature-triage-matrix` for a comparison matrix) and NOT a study design (use `research-design-helper` once a topic is chosen). Produces a `.research/topic_dossier.md` plus a `.bib` and a `.gaps.yml`.
+description: Turn a research area into a go/no-go decision dossier for ONE candidate thesis/proposal topic — a 3-gate verdict (is the gap open? is it a contribution? is it feasible?) with the evidence laid out so the researcher can verify it. Use when the user asks "is this gap worth pursuing", "help me pick a thesis topic", "is this idea already taken", "find me a defensible research gap", "vet this research idea before I commit", or "should I do this". NOT a literature review (use `literature-triage-matrix` for a comparison matrix) and NOT a study design (use `research-design-helper` once a topic is chosen). Produces a `.research/topic_dossier.md`, a `.research/topic_dossier.docx` (Word, colour-coded), a `.bib`, and a `.gaps.yml`.
 compatibility: Pure agentskills.io-spec skill. Domain-agnostic; works alongside Zotero/Obsidian/NotebookLM workflows but requires none of them.
 ---
 
@@ -37,12 +37,14 @@ Not for:
 
 ## What it produces
 
-`.research/topic_dossier.md` — a **research-grade decision memo**: first
-page enables a decision; the body supports verification; the appendices
-support a re-run. Reads top-to-bottom in Word with no decoding — no codes
-(`G1`/`G2` stay only in `.gaps.yml`), no decorative glyphs, plain-language
-verdicts, decision-relevant tables in the body and reference / log tables
-in the appendices.
+`.research/topic_dossier.md` and `.research/topic_dossier.docx` — a
+**research-grade decision memo** in Markdown and as a colour-coded Word
+document: first page enables a decision; the body supports verification; the
+appendices support a re-run. Reads top-to-bottom in Word with no decoding —
+no codes (`G1`/`G2` stay only in `.gaps.yml`), no decorative glyphs,
+plain-language verdicts, decision-relevant tables in the body and reference /
+log tables in the appendices. Verdict cells are colour-coded in the .docx
+(light red / yellow / green / grey by verdict phrase, bilingual en + zh-TW).
 
 | Section | What it covers |
 |---|---|
@@ -180,6 +182,26 @@ data public? what does it cost? how long to obtain? — and record a verdict.
 The dossier ends by stating explicitly: it has assembled the three
 gate-verdicts; whether the gap is *worth doing* is the researcher's and
 advisor's call. The skill never makes that call.
+
+### §4.5 — Generate .docx
+
+After `.research/topic_dossier.md` is written, run the bundled generator to
+produce the matching Word deliverable:
+
+```bash
+# From the dossier's output directory (e.g. .research/ or en/)
+node /path/to/skills/gap-to-topic/scripts/dossier_to_docx.js topic_dossier [--no-toc]
+```
+
+Prerequisite: `npm install -g docx` (or `cd scripts && npm install docx` for a
+local install). See `scripts/README.md` for full invocation details and the
+zh-TW case.
+
+The script produces `topic_dossier.docx` alongside the `.md`. It colour-codes
+verdict cells (light red / yellow / green / grey), auto-selects font
+(Microsoft JhengHei for zh-TW filenames, Arial otherwise), skips Markdown
+separator rows, and inserts a TOC + page break after the first table (suppress
+with `--no-toc`).
 
 ## Honesty rules
 

--- a/src/research_hub/skills_data/gap-to-topic/scripts/README.md
+++ b/src/research_hub/skills_data/gap-to-topic/scripts/README.md
@@ -1,0 +1,66 @@
+# scripts/dossier_to_docx.js
+
+Convert a `gap-to-topic` dossier Markdown file into a styled Word document
+(.docx) using `docx` 9.x.
+
+## What it produces
+
+A `.docx` file alongside the source `.md` with:
+
+- Heading styles (H1 navy, H2 navy, H3 dark grey) using the auto-selected font
+- Bullet lists via a numbering reference (not a unicode glyph)
+- Tables with dual-width DXA column sizing
+- Verdict colour coding on scorecard and verdict-card cells:
+  - "Do not pursue" / "不予推進" — light red `#F4DEDE`
+  - "Worth pursuing … only if" / conditional — light yellow `#FFF4D6`
+  - "Worth pursuing" (unconditional) — light green `#E2F0DA`
+  - "Not assessed" / "未評估" — light grey `#EEEEEE`
+- Table separator rows (`|---|---|`) skipped — they do not appear as "---" cells in Word
+- Optional Table of Contents + page break inserted after the first table
+  (omit with `--no-toc` for short docs where Word's empty TOC field is distracting)
+
+Font auto-selection: if the filename contains `.zh`, `zh-`, `zh_`, `-tw`, or
+`-cn` (case-insensitive), the document body uses **Microsoft JhengHei**;
+otherwise **Arial**.
+
+## Prerequisite
+
+Install the `docx` npm package before running the script:
+
+```
+# Global install (available everywhere):
+npm install -g docx
+
+# Local install (available only from the scripts/ directory):
+cd scripts && npm install docx
+```
+
+If `docx` is not installed, Node.js will throw a `Cannot find module 'docx'`
+error when the script is run. Install it and re-run.
+
+## Invocation
+
+Run from the directory that contains your `topic_dossier.md` (the dossier
+output directory — typically `.research/` or `en/` / `zh-TW/`):
+
+```bash
+# English dossier (Arial font, with TOC):
+node /path/to/skills/gap-to-topic/scripts/dossier_to_docx.js topic_dossier
+
+# English dossier, skip TOC:
+node /path/to/skills/gap-to-topic/scripts/dossier_to_docx.js topic_dossier --no-toc
+
+# zh-TW dossier (JhengHei font):
+node /path/to/skills/gap-to-topic/scripts/dossier_to_docx.js topic_dossier.zh-TW --no-toc
+
+# Absolute path (writes .docx alongside the .md):
+node dossier_to_docx.js /abs/path/to/en/topic_dossier
+```
+
+The output `.docx` is written to the same directory as the `.md` file.
+
+## Integration in the gap-to-topic workflow
+
+After `gap-to-topic` writes `.research/topic_dossier.md`, run this script from
+that directory to produce the matching `.docx` deliverable. See SKILL.md §4.5
+for the contracted post-processing step.

--- a/src/research_hub/skills_data/gap-to-topic/scripts/dossier_to_docx.js
+++ b/src/research_hub/skills_data/gap-to-topic/scripts/dossier_to_docx.js
@@ -1,0 +1,264 @@
+// dossier_to_docx.js — convert a gap-to-topic dossier (.md) to a styled Word document (.docx)
+//
+// Prerequisite: npm install -g docx   (or: cd scripts && npm install docx  for local)
+//
+// Usage:
+//   node dossier_to_docx.js [stem-or-path] [--no-toc]
+//
+//   stem-or-path  Stem name ("topic_dossier") relative to cwd, OR an absolute path
+//                 (with or without .md/.docx extension — the script adds them).
+//                 Default: "topic_dossier"
+//   --no-toc      Skip the Table of Contents field (avoid empty Word TOC on short docs).
+//
+// Examples:
+//   node dossier_to_docx.js topic_dossier --no-toc
+//   node dossier_to_docx.js /abs/path/to/en/topic_dossier
+//   node dossier_to_docx.js topic_dossier.zh-TW   (triggers JhengHei font)
+//
+// Font auto-selection:
+//   filename matches /.zh|zh-|zh_|-tw|-cn/i  -> Microsoft JhengHei
+//   otherwise                                 -> Arial
+//
+// Verdict colour coding (cells in scorecards and verdict cards):
+//   "Do not pursue" / "不予推進"              -> light red   (#F4DEDE)
+//   "Worth pursuing … only if" / conditional  -> light yellow (#FFF4D6)
+//   "Worth pursuing" (unconditional)          -> light green  (#E2F0DA)
+//   "Not assessed" / "未評估"                 -> light grey   (#EEEEEE)
+//   All other cells                           -> white
+
+const fs = require("fs");
+const path = require("path");
+const {
+  Document, Packer, Paragraph, TextRun, Table, TableRow, TableCell,
+  AlignmentType, LevelFormat, TableOfContents, HeadingLevel, BorderStyle,
+  WidthType, ShadingType, PageBreak,
+} = require("docx");
+
+// ---- argument parsing ----
+const NOTOC = process.argv.includes("--no-toc");
+const ARG = process.argv.slice(2).find((a) => !a.startsWith("--")) || "topic_dossier";
+
+// Strip .md or .docx extension if provided so we work from the bare stem
+const stem = ARG.replace(/\.(md|docx)$/i, "");
+
+// Font: detect Chinese filename pattern
+const FONT = /\.zh|zh-|zh_|-tw|-cn/i.test(stem) ? "Microsoft JhengHei" : "Arial";
+
+// Resolve source (.md) and output (.docx) paths.
+// If the stem is absolute (contains a path separator), write alongside it.
+// Otherwise resolve relative to process.cwd() so the script works from any directory.
+const isAbs = path.isAbsolute(stem) || stem.includes("/") || stem.includes("\\");
+const SRC = isAbs ? path.resolve(stem + ".md") : path.resolve(process.cwd(), stem + ".md");
+const OUT = isAbs ? path.resolve(stem + ".docx") : path.resolve(process.cwd(), stem + ".docx");
+
+const CONTENT_W = 9360;
+
+// ---- inline markdown -> TextRun[] ----
+function parseInline(text, base = {}) {
+  const runs = [];
+  const re = /(\*\*[^*]+\*\*|`[^`]+`|\*[^*]+\*)/g;
+  let last = 0, m;
+  while ((m = re.exec(text))) {
+    if (m.index > last) runs.push(new TextRun({ text: text.slice(last, m.index), ...base }));
+    const t = m[0];
+    if (t.startsWith("**")) runs.push(new TextRun({ text: t.slice(2, -2), bold: true, ...base }));
+    else if (t.startsWith("`")) runs.push(new TextRun({ text: t.slice(1, -1), font: "Consolas", size: 19, ...base }));
+    else runs.push(new TextRun({ text: t.slice(1, -1), italics: true, ...base }));
+    last = re.lastIndex;
+  }
+  if (last < text.length) runs.push(new TextRun({ text: text.slice(last), ...base }));
+  if (!runs.length) runs.push(new TextRun({ text: "", ...base }));
+  return runs;
+}
+
+// ---- block parser ----
+if (!fs.existsSync(SRC)) {
+  console.error("ERROR: source file not found:", SRC);
+  process.exit(1);
+}
+const lines = fs.readFileSync(SRC, "utf8").replace(/\r\n/g, "\n").split("\n");
+const blocks = [];
+let i = 0;
+function lastBlock() { return blocks[blocks.length - 1]; }
+while (i < lines.length) {
+  const ln = lines[i];
+  const t = ln.trim();
+  if (/^#{1,3}\s/.test(t)) {
+    const level = t.match(/^#+/)[0].length;
+    blocks.push({ type: "h", level, text: t.replace(/^#+\s/, "") });
+    i++; continue;
+  }
+  if (t === "---") { blocks.push({ type: "hr" }); i++; continue; }
+  if (t === "") { blocks.push({ type: "blank" }); i++; continue; }
+  if (t.startsWith(">")) {
+    const buf = [];
+    while (i < lines.length && lines[i].trim().startsWith(">")) {
+      buf.push(lines[i].trim().replace(/^>\s?/, "")); i++;
+    }
+    blocks.push({ type: "note", text: buf.join(" ").replace(/\s+/g, " ").trim() });
+    continue;
+  }
+  if (t.startsWith("|")) {
+    const rows = [];
+    while (i < lines.length && lines[i].trim().startsWith("|")) {
+      const cells = lines[i].trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map(c => c.trim());
+      // Skip Markdown table separator row (|---|---|, |:---|---:|, …) —
+      // it is alignment metadata, not a data row; the previous parser
+      // pushed it and Word rendered a literal "---" row.
+      const isSep = cells.length > 0 && cells.every(c => /^:?-+:?$/.test(c));
+      if (!isSep) rows.push(cells);
+      i++;
+    }
+    blocks.push({ type: "table", rows });
+    continue;
+  }
+  if (t.startsWith("- ")) {
+    let txt = t.slice(2);
+    i++;
+    while (i < lines.length && /^\s{2,}\S/.test(lines[i])) { txt += " " + lines[i].trim(); i++; }
+    const lb = lastBlock();
+    if (lb && lb.type === "list") lb.items.push(txt);
+    else blocks.push({ type: "list", items: [txt] });
+    continue;
+  }
+  // normal paragraph (join wrapped lines until blank / marker)
+  let txt = t;
+  i++;
+  while (i < lines.length) {
+    const nx = lines[i], nt = nx.trim();
+    if (nt === "" || nt === "---" || /^#{1,3}\s/.test(nt) || nt.startsWith("|") || nt.startsWith(">") || nt.startsWith("- ")) break;
+    txt += " " + nt; i++;
+  }
+  blocks.push({ type: "p", text: txt });
+}
+
+// ---- render ----
+const border = { style: BorderStyle.SINGLE, size: 1, color: "BFBFBF" };
+const borders = { top: border, bottom: border, left: border, right: border,
+  insideHorizontal: border, insideVertical: border };
+const colWidths = (n) => {
+  if (n === 2) return [2400, 6960];
+  if (n === 4) return [1000, 2790, 3570, 2000];
+  if (n === 5) return [560, 3960, 560, 1480, 2800];
+  const w = Math.floor(CONTENT_W / n); return Array(n).fill(w);
+};
+
+// Cell-shading colour by row (header = dark blue) and, for non-header
+// cells, by verdict-keyword detection. Patterns are checked in order:
+// conditional "only if" must win over the plain green case.
+function cellFill(r, cell) {
+  if (r === 0) return "1F3B5B"; // header dark blue
+  const lc = cell.toLowerCase();
+  // English verdict keywords
+  if (/do not pursue/.test(lc)) return "F4DEDE";          // light red
+  if (/worth pursuing/.test(lc) && /only if/.test(lc)) return "FFF4D6"; // light yellow
+  if (/worth pursuing/.test(lc)) return "E2F0DA";         // light green
+  if (/not assessed/.test(lc)) return "EEEEEE";           // light grey
+  // zh-TW verdict keywords (toLowerCase is a no-op on CJK so cell is raw)
+  if (/不予推進/.test(cell)) return "F4DEDE";              // light red
+  if (/值得推進/.test(cell) && /只|須|待決|條件/.test(cell)) return "FFF4D6"; // light yellow
+  if (/值得推進/.test(cell)) return "E2F0DA";              // light green
+  if (/未評估/.test(cell)) return "EEEEEE";                // light grey
+  return "FFFFFF";                                         // default white
+}
+
+function mkTable(rows) {
+  const n = rows[0].length;
+  const cw = colWidths(n);
+  return new Table({
+    width: { size: CONTENT_W, type: WidthType.DXA },
+    columnWidths: cw,
+    rows: rows.map((cells, r) => new TableRow({
+      tableHeader: r === 0,
+      children: cells.map((cell, c) => new TableCell({
+        borders,
+        width: { size: cw[c], type: WidthType.DXA },
+        shading: { fill: cellFill(r, cell), type: ShadingType.CLEAR },
+        margins: { top: 70, bottom: 70, left: 110, right: 110 },
+        children: [new Paragraph({
+          spacing: { before: 20, after: 20 },
+          children: parseInline(cell, r === 0 ? { bold: true, color: "FFFFFF", size: 19 } : { size: 19 }),
+        })],
+      })),
+    })),
+  });
+}
+
+const children = [];
+let tocInserted = false;
+for (const b of blocks) {
+  if (b.type === "blank" || b.type === "hr") continue;
+  if (b.type === "h") {
+    const hl = b.level === 1 ? HeadingLevel.HEADING_1 : b.level === 2 ? HeadingLevel.HEADING_2 : HeadingLevel.HEADING_3;
+    children.push(new Paragraph({ heading: hl, children: parseInline(b.text) }));
+  } else if (b.type === "note") {
+    children.push(new Paragraph({
+      spacing: { before: 60, after: 120 },
+      indent: { left: 360 },
+      border: { left: { style: BorderStyle.SINGLE, size: 12, color: "B0B0B0", space: 12 } },
+      children: parseInline(b.text, { italics: true, color: "5A5A5A", size: 19 }),
+    }));
+  } else if (b.type === "p") {
+    children.push(new Paragraph({ spacing: { before: 80, after: 80 }, children: parseInline(b.text) }));
+  } else if (b.type === "list") {
+    for (const it of b.items) {
+      children.push(new Paragraph({
+        numbering: { reference: "bullets", level: 0 },
+        spacing: { before: 40, after: 40 },
+        children: parseInline(it),
+      }));
+    }
+  } else if (b.type === "table") {
+    children.push(new Paragraph({ spacing: { before: 80, after: 80 }, children: [] }));
+    children.push(mkTable(b.rows));
+    children.push(new Paragraph({ spacing: { after: 80 }, children: [] }));
+    if (!tocInserted && !NOTOC) {
+      tocInserted = true;
+      children.push(new Paragraph({ pageBreakBefore: true, heading: HeadingLevel.HEADING_2,
+        children: [new TextRun("Contents")] }));
+      children.push(new TableOfContents("Table of Contents", { hyperlink: true, headingStyleRange: "1-3" }));
+      children.push(new Paragraph({ children: [new PageBreak()] }));
+    }
+  }
+}
+
+const doc = new Document({
+  styles: {
+    default: { document: { run: { font: FONT, size: 22 } } },
+    paragraphStyles: [
+      { id: "Heading1", name: "Heading 1", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 34, bold: true, font: FONT, color: "1F3B5B" },
+        paragraph: { spacing: { before: 240, after: 200 }, outlineLevel: 0 } },
+      { id: "Heading2", name: "Heading 2", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 27, bold: true, font: FONT, color: "1F3B5B" },
+        paragraph: { spacing: { before: 260, after: 120 }, outlineLevel: 1 } },
+      { id: "Heading3", name: "Heading 3", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 23, bold: true, font: FONT, color: "2E2E2E" },
+        paragraph: { spacing: { before: 160, after: 60 }, outlineLevel: 2 } },
+    ],
+  },
+  numbering: {
+    config: [
+      { reference: "bullets",
+        levels: [{ level: 0, format: LevelFormat.BULLET, text: "•", alignment: AlignmentType.LEFT,
+          style: { paragraph: { indent: { left: 420, hanging: 280 } } } }] },
+    ],
+  },
+  sections: [{
+    properties: {
+      page: {
+        size: { width: 12240, height: 15840 },
+        margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 },
+      },
+    },
+    children,
+  }],
+});
+
+Packer.toBuffer(doc).then(buf => {
+  fs.writeFileSync(OUT, buf);
+  console.log("WROTE", OUT, buf.length, "bytes");
+}).catch(err => {
+  console.error("ERROR generating docx:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Ships `scripts/dossier_to_docx.js` inside `skills/gap-to-topic/` — a `docx` 9.x generator adapted from the dogfood-validated `gen_docx.js`
- `topic_dossier.docx` is now a first-class contracted deliverable (SKILL.md front-matter, "What it produces", new §4.5 workflow step)
- Bilingual verdict colour coding (en + zh-TW), JhengHei/Arial font auto-selection, Markdown separator-row skip, optional `--no-toc` flag
- Byte-identical mirror to `src/research_hub/skills_data/gap-to-topic/scripts/`
- plugin.json bumped `0.3.9 → 0.3.10`; CHANGELOG.md `### Added` entry

## Verification checklist

- [x] `diff -rq skills/gap-to-topic/ src/research_hub/skills_data/gap-to-topic/` — no output (byte parity clean)
- [x] `tests/test_v068_3_version_sync.py` — 3/3 passed
- [x] Dogfood test on `2026-05-21-gap-to-topic-llm-abm-profiles/en/topic_dossier.md`:
  - `.docx` produced (16 092 bytes)
  - ZIP opens cleanly (22 entries, `word/document.xml` present)
  - 9 tables / 2 red cells / 2 yellow cells / 2 grey cells — matches v0.3.9 acceptance pattern
- [x] No `node_modules`, `package.json`, or `.docx` artifacts committed
- [x] Code-reviewer gate passed (trigger 1: ≥3 files AND ≥50 LOC)

## Dogfood reference

`C:/Users/wenyu/.claude/audits/dogfood_runs/2026-05-21-gap-to-topic-llm-abm-profiles/` — en/ and zh-TW/ both regenerated and pass all v0.3.9 acceptance checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)