### PR TITLE
fix(skill): gap-to-topic schema reference + research-hub discoverability (plugin 0.3.10 → 0.3.11)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,31 @@ graph rebuild (link out to the real tools instead)._
   `src/research_hub/skills_data/gap-to-topic/scripts/`.
 
 ### Fixed
+- **`gap-to-topic` schema reference + research-hub discoverability**
+  (`skills/gap-to-topic/references/dossier-template.md`,
+  `docs/ai-research-skills.md`, plugin `0.3.10 → 0.3.11`). Two
+  contract-vs-reality fixes ahead of the Stage 2 → 3a handoff wiring:
+  - **Schema reference refresh.** The `topic_dossier.gaps.yml` schema
+    in `references/dossier-template.md` was stale relative to what
+    `gap-to-topic` actually emits since v0.3.6 (the `--screen`
+    fit-check integration) and v0.3.9 (the 7-section reflow): missing
+    top-level `run_type` / `recall` (with full `screen` sub-block) /
+    `pipeline`; missing per-gap `open_confidence` /
+    `dead_end_evidence` / `borderline_reason` / `verdict` /
+    `verdict_reason`. The schema is now byte-aligned with the real
+    output and adds a top-level `downstream_consumer:
+    research-design-helper` key as a forward-compat hook recording
+    the contract reader.
+  - **Discoverability.** `docs/ai-research-skills.md` had zero mentions
+    of `gap-to-topic` despite the skill being shipped at v0.3.10.
+    Added a new Stage 2.5 row to the Stages table, a "Deciding whether
+    a research gap is worth pursuing" entry to the When-to-use table,
+    and a full `### gap-to-topic (v0.3.11)` section in All packaged
+    skills documenting Reads / Writes / handoff to Stage 3a /
+    trigger phrases.
+  - Pure additive changes (no removed fields, no enum tokens changed).
+    Mirror at `src/research_hub/skills_data/gap-to-topic/` updated in
+    parity.
 - **`gap-to-topic` dossier reflowed as a 7-section research-grade decision
   memo** (`skills/gap-to-topic/`, plugin `0.3.8 → 0.3.9`). The v0.3.8
   dossier rendered as "Markdown converted to Word" — wide scorecard with

--- a/docs/ai-research-skills.md
+++ b/docs/ai-research-skills.md
@@ -11,7 +11,8 @@ cover.
 |---|---|---|---|
 | 1. Discover sources | Find papers / data | research-hub | `research-hub`, `literature-triage-matrix` |
 | 2. Ingest + tag | Pull into Zotero / Obsidian | research-hub | `research-hub`, `zotero-library-curator` |
-| **3a. Frame the problem** | Sharpen RQ; design study | **YOU** (creative) | `research-design-helper` (Socratic guide) |
+| **2.5. Decide the topic** | 3-gate go/no-go on a candidate topic; produces a decision dossier | shared | `gap-to-topic` (emits `.gaps.yml` for the chosen candidate — Stage 3a wiring lands in v0.3.12) |
+| **3a. Frame the problem** | Sharpen RQ; design study | **YOU** (creative) | `research-design-helper` (Socratic guide; **v0.3.12+** will pre-fill from `gap-to-topic`'s `.gaps.yml` if present) |
 | **3b. Plan artifacts** | Manifest + experiment matrix | mechanical | `research-context-compressor`, `research-project-orienter` |
 | 4. Design & build the model | Implement | YOU + cross-cutting tools | (see Cross-cutting tools below) |
 | 5. Run experiments | Execute | YOU | (cross-cutting) |
@@ -61,6 +62,7 @@ The `research-hub-multi-ai` SKILL.md lists the routing rules.
 | Preparing a manuscript for AI-assisted writing/revision | `paper-memory-builder` | minutes |
 | Just downloaded a NotebookLM brief, want to verify it | `notebooklm-brief-verifier` | minutes |
 | Want a Zotero audit / dedupe / tag hygiene plan (no writes) | `zotero-library-curator` | minutes |
+| Deciding whether a research gap is worth pursuing (open / a contribution / feasible) | `gap-to-topic` | one session |
 | Starting a new study, want to sharpen the RQ + design before coding | `research-design-helper` | one session |
 | General research workflow (search → ingest → organize) | `research-hub` (the original CLI-operating skill) | continuous |
 | Multi-AI handoff (Claude ↔ Codex ↔ Gemini) | `research-hub-multi-ai` | as needed |
@@ -168,6 +170,34 @@ during identifiability discussion).
 Trigger phrases: "frame this research question", "design my study",
 "help me think through what model to build", "sharpen my hypothesis",
 "walk me through the design".
+
+### `gap-to-topic` (v0.3.11)
+Sits between Stage 2 and Stage 3a. Turns a research area into a go/no-go
+decision dossier for 1–N candidate thesis/proposal topics — a 3-gate
+verdict (is the gap **open**? is it a **contribution**? is it
+**feasible**?) with the evidence laid out so the researcher can verify
+it. Deliberately stops short of "is it worth doing" — that call is
+handed back to the researcher + advisor.
+
+**Reads**: user intent (Socratic §0), `research-hub search --adversarial
+--screen --json` results (§1), `.research/literature_matrix.md` (§1
+step 2 output), optional `.research/claims.yml` for cross-link.
+**Writes**: `.research/topic_dossier.md` + `.docx` (research-grade
+Word memo via `scripts/dossier_to_docx.js`, v0.3.10+),
+`.research/topic_dossier.bib`, `.research/topic_dossier.gaps.yml`,
+`.research/literature_matrix.md`.
+
+**Handoff to Stage 3a**: `.gaps.yml` is the machine-readable contract
+that `research-design-helper` **will read in v0.3.12+** to pre-fill its
+Socratic dialog (chosen candidate → segment 1 RQ; `open_questions[]` →
+segment 5 risks). The schema (top-level `downstream_consumer:
+research-design-helper` key as forward-compat hook) is documented in
+`references/dossier-template.md` Schema reference section; the wire-up
+itself ships in plugin v0.3.12 (Stage 2 → 3a integration PR).
+
+Trigger phrases: "is this research gap worth pursuing", "help me pick
+a thesis topic", "is this idea already taken", "find me a defensible
+research gap", "vet this research idea before I commit".
 
 ### `zotero-library-curator` (v0.67)
 Sits one layer above the standalone `zotero-skills` skill. Reads the

--- a/skills/gap-to-topic/references/dossier-template.md
+++ b/skills/gap-to-topic/references/dossier-template.md
@@ -261,25 +261,62 @@ en/
 
 > The `.gaps.yml` companion is machine-readable and is **not** part of the
 > human dossier above. It keeps the machine ids (`G1`, `G2`) and the formal
-> enum tokens.
+> enum tokens. **Downstream consumer:** `research-design-helper` (Stage 3a)
+> reads the chosen `gaps[]` entry + `open_questions[]` to pre-fill its
+> Socratic dialog.
 
 ```yaml
 dossier: <topic area>
 generated: "YYYY-MM-DD"
+run_type: "<short prose, e.g. 'gap-to-topic re-test on screened search'>"
+downstream_consumer: research-design-helper   # forward-compat hook; Stage 3a reads this
+recall:
+  tool: research-hub search --adversarial --screen --json
+  query_phrasings: 6
+  unique_papers: 435
+  tool_confidence: medium       # high | medium | low
+  dossier_confidence: medium    # high | medium | low
+  screen:                       # the fit-check BM25 relevance gate (search --screen)
+    gate: fit-check BM25 relevance gate (search --screen)
+    retrieved: <int>
+    kept: <int>
+    screened_out: <int>
+    tier: cold-start            # cold-start | <other-tier>
+    note: "<short prose, e.g. why the tier was chosen>"
+  note: "<backend caveat e.g. semantic-scholar rate-limited (HTTP 429)>"
+pipeline:                       # 4-step provenance chain
+  - research-hub search --adversarial --screen --json   # §1 step 1
+  - literature-triage-matrix -> literature_matrix.md     # §1 step 2 (on-topic kept:true)
+  - .bib from on-topic search --json results             # §1 step 3
+  - gap-to-topic gates §1-§4
 gaps:
   - id: G1
     name: "<readable candidate name>"
     statement: "<candidate>"
-    type: A            # A = method-limitation | B = unoccupied-application
-    open: open         # open | partially-occupied | occupied
-    dead_end_status: genuinely-open
-    contribution_type: problem-solving
-    feasibility: feasible
-    linked_claim: null  # claims.yml C-id, only if a manuscript draft exists
+    type: A | B                 # A = method-limitation | B = unoccupied-application
+    open: open                  # open | partially-occupied | occupied | partially-attempted
+    open_confidence: medium     # only if open / partially-occupied — high | medium | low
+    dead_end_status: genuinely-open    # not-assessed | genuinely-open | none |
+                                       # partially-attempted | full-dead-end
+    dead_end_evidence: >-       # paper-grounded prose; only when status != not-assessed
+      "<one-line evidence pointer with author + year + DOI>"
+    contribution_type: problem-solving   # not-assessed | problem-solving |
+                                         # incremental | borderline
+    borderline_reason: B1       # only if contribution_type == borderline; B1 | B2 | B3
+    feasibility: feasible       # not-assessed | feasible | feasible-with-effort | not-feasible
+    verdict: go                 # go | conditional-go | no-go
+    verdict_reason: >-          # one-sentence summary the downstream consumer can quote
+      "<short prose>"
+    linked_claim: null          # claims.yml C-id, only if a manuscript draft exists
 open_questions:
   - id: Q1
     text: "<question the evidence could not settle>"
 ```
+
+**Refresh policy:** when the v0.3.10+ schema is intentionally extended,
+the frozen handoff fixture at `tests/fixtures/topic_dossier_sample.gaps.yml`
+must be updated in the same PR so the cross-skill integration test
+stays meaningful.
 
 The `.bib` companion is the Gate 1 reference list as BibTeX — built from
 the on-topic `search --adversarial --screen --json` results (NOT from

--- a/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
+++ b/src/research_hub/skills_data/gap-to-topic/references/dossier-template.md
@@ -261,25 +261,62 @@ en/
 
 > The `.gaps.yml` companion is machine-readable and is **not** part of the
 > human dossier above. It keeps the machine ids (`G1`, `G2`) and the formal
-> enum tokens.
+> enum tokens. **Downstream consumer:** `research-design-helper` (Stage 3a)
+> reads the chosen `gaps[]` entry + `open_questions[]` to pre-fill its
+> Socratic dialog.
 
 ```yaml
 dossier: <topic area>
 generated: "YYYY-MM-DD"
+run_type: "<short prose, e.g. 'gap-to-topic re-test on screened search'>"
+downstream_consumer: research-design-helper   # forward-compat hook; Stage 3a reads this
+recall:
+  tool: research-hub search --adversarial --screen --json
+  query_phrasings: 6
+  unique_papers: 435
+  tool_confidence: medium       # high | medium | low
+  dossier_confidence: medium    # high | medium | low
+  screen:                       # the fit-check BM25 relevance gate (search --screen)
+    gate: fit-check BM25 relevance gate (search --screen)
+    retrieved: <int>
+    kept: <int>
+    screened_out: <int>
+    tier: cold-start            # cold-start | <other-tier>
+    note: "<short prose, e.g. why the tier was chosen>"
+  note: "<backend caveat e.g. semantic-scholar rate-limited (HTTP 429)>"
+pipeline:                       # 4-step provenance chain
+  - research-hub search --adversarial --screen --json   # §1 step 1
+  - literature-triage-matrix -> literature_matrix.md     # §1 step 2 (on-topic kept:true)
+  - .bib from on-topic search --json results             # §1 step 3
+  - gap-to-topic gates §1-§4
 gaps:
   - id: G1
     name: "<readable candidate name>"
     statement: "<candidate>"
-    type: A            # A = method-limitation | B = unoccupied-application
-    open: open         # open | partially-occupied | occupied
-    dead_end_status: genuinely-open
-    contribution_type: problem-solving
-    feasibility: feasible
-    linked_claim: null  # claims.yml C-id, only if a manuscript draft exists
+    type: A | B                 # A = method-limitation | B = unoccupied-application
+    open: open                  # open | partially-occupied | occupied | partially-attempted
+    open_confidence: medium     # only if open / partially-occupied — high | medium | low
+    dead_end_status: genuinely-open    # not-assessed | genuinely-open | none |
+                                       # partially-attempted | full-dead-end
+    dead_end_evidence: >-       # paper-grounded prose; only when status != not-assessed
+      "<one-line evidence pointer with author + year + DOI>"
+    contribution_type: problem-solving   # not-assessed | problem-solving |
+                                         # incremental | borderline
+    borderline_reason: B1       # only if contribution_type == borderline; B1 | B2 | B3
+    feasibility: feasible       # not-assessed | feasible | feasible-with-effort | not-feasible
+    verdict: go                 # go | conditional-go | no-go
+    verdict_reason: >-          # one-sentence summary the downstream consumer can quote
+      "<short prose>"
+    linked_claim: null          # claims.yml C-id, only if a manuscript draft exists
 open_questions:
   - id: Q1
     text: "<question the evidence could not settle>"
 ```
+
+**Refresh policy:** when the v0.3.10+ schema is intentionally extended,
+the frozen handoff fixture at `tests/fixtures/topic_dossier_sample.gaps.yml`
+must be updated in the same PR so the cross-skill integration test
+stays meaningful.
 
 The `.bib` companion is the Gate 1 reference list as BibTeX — built from
 the on-topic `search --adversarial --screen --json` results (NOT from


### PR DESCRIPTION
Two contract-vs-reality fixes ahead of the Stage 2 → 3a handoff wiring (which lands in plugin v0.3.12 — separate PR).

## Schema reference refresh

The `topic_dossier.gaps.yml` schema in `skills/gap-to-topic/references/dossier-template.md` was stale relative to what `gap-to-topic` actually emits since v0.3.6 (the `--screen` fit-check integration) and v0.3.9 (the 7-section reflow):

**Missing top-level keys** — now added:
- `run_type` (e.g. "gap-to-topic re-test on screened search")
- `recall` (with full nested `screen` sub-block: `gate`, `retrieved`, `kept`, `screened_out`, `tier`, `note`)
- `pipeline` (4-step provenance chain)

**Missing per-gap fields** — now added:
- `open_confidence: medium | high | low`
- `dead_end_evidence: <paper-grounded prose>`
- `borderline_reason: B1 | B2 | B3`
- `verdict: go | conditional-go | no-go`
- `verdict_reason: <one-sentence summary>`

**Forward-compat hook**:
- New top-level `downstream_consumer: research-design-helper` key recording the contract reader. The wire-up itself ships in plugin v0.3.12.

## Discoverability

`docs/ai-research-skills.md` had **zero mentions** of `gap-to-topic` despite the skill being shipped at v0.3.10. This PR adds:

- Stage 2.5 row in the Stages table
- "Deciding whether a research gap is worth pursuing" entry in the When-to-use table
- A full `### gap-to-topic (v0.3.11)` section in All packaged skills documenting Reads / Writes / Handoff to Stage 3a / trigger phrases. Forward-references to Stage 3a wiring use explicit future tense (v0.3.12+).

## Out of scope (deferred)

- The actual Stage 2 → 3a wire (research-design-helper reading `.gaps.yml`) ships in plugin v0.3.12 — separate PR.
- Marketplace propagation (ai-research-skills repo's README + pipeline.md + image prompt + skill-directory all missing gap-to-topic too) bundled into one umbrella PR after v0.3.12 lands.

## Validation

| Check | Result |
|---|---|
| `diff -rq skills/gap-to-topic/ src/research_hub/skills_data/gap-to-topic/` | clean — mirror parity OK |
| `PYTHONPATH=src python -m pytest tests/test_v068_3_version_sync.py -q` | 3/3 passed |
| `git grep -nF "0.3.10"` outside CHANGELOG | 3 intentional `v0.3.10+` history markers, no stale current-version pointers |
| Schema matches `~/.claude/audits/dogfood_runs/2026-05-21-gap-to-topic-llm-abm-profiles/en/topic_dossier.gaps.yml` | every top-level key + sub-key + enum token present |
| Pure additive: no removed fields, no enum tokens changed | ✅ |
| code-reviewer subagent | APPROVE (after fix-cycle resolving CHANGELOG ordering + forward-ref tense) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)