### PR TITLE
feat(skill): wire Stage 2 → 3a → 3b handoff (plugin 0.3.11 → 0.3.12)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,57 @@ graph rebuild (link out to the real tools instead)._
   flag still makes sense.
 
 ### Added
+- **Stage 2 → 3a → 3b handoff wiring**
+  (`skills/research-design-helper/`, `skills/research-context-compressor/`,
+  `tests/fixtures/topic_dossier_sample.gaps.yml`,
+  `tests/test_handoff_gap_to_topic_design_helper.py`, plugin
+  `0.3.11 → 0.3.12`). Two broken wires fixed as one coherent
+  user-facing capability:
+  - **`research-design-helper` reads `.research/topic_dossier.gaps.yml`**
+    as new Input #2. New Workflow §0 preamble auto-pre-fills segment 1
+    (RQ) from the chosen `gaps[].statement` and segment 5 (risks) from
+    `open_questions[]` + the specific concern hinted by
+    `gaps[].feasibility`. Segments 2–4 (mechanism / identifiability /
+    validation) are never pre-filled — the dossier doesn't carry that
+    material and pre-filling with non-content corrupts the Socratic
+    dialog. When the upstream `.gaps.yml` is absent, the skill behaves
+    exactly as before (no regression for standalone users). Candidate
+    selection is verdict-aware: filter `gaps[]` to
+    `verdict in {conditional-go, go}`, then auto-pick if one,
+    ask-the-user if 2+, halt with "nothing to frame" if zero.
+  - **`design_brief.md` frontmatter carries Stage 2 provenance.**
+    Two new optional fields: `source: topic_dossier.gaps.yml#<gap-id>`
+    (URI-fragment pointer to the chosen gap) and `gap_verdict:` (frozen
+    snapshot of `verdict` + first 60 chars of `verdict_reason`). The
+    brief becomes self-contained — a future reader sees which dossier
+    candidate this design was framed for. Provenance-protection: a
+    refresh that would change the `source` gap-id triggers a confirm
+    prompt instead of silent overwrite.
+  - **`research-context-compressor` reads `.research/design_brief.md`**
+    as new Input #2 under "For any project". Reads the frontmatter
+    (`project`, `source`, `gap_verdict`) + section 1 (Research
+    question) only. This implements the long-claimed `pipeline.md`
+    contract; the brief is the authority on the sharpened RQ and the
+    manifest mirrors it. If frontmatter `source` is set, copies that
+    gap-id into the manifest's `provenance.from_gap` field
+    (forward-compat with downstream tools).
+  - **First cross-skill handoff integration test** ships at
+    `tests/test_handoff_gap_to_topic_design_helper.py` with a frozen
+    fixture at `tests/fixtures/topic_dossier_sample.gaps.yml` (copied
+    from the v0.3.10 dogfood example). Asserts: fixture parses + has
+    v0.3.10+ top-level keys + `recall.screen` sub-block + per-gap
+    downstream-consumer fields + `open_questions[].text`; downstream
+    SKILL.md prose lists the handoff input + has the §0 preamble +
+    preserves the absent-`.gaps.yml` fallback; design_brief_template
+    frontmatter has `source` + `gap_verdict`;
+    research-context-compressor mentions `design_brief.md`; the
+    schema reference covers every key the fixture contains (drift
+    detector). Subsequent stage-to-stage wires (3a → 3b proper,
+    6 → 7, …) should follow this test shape.
+  - Mirrored to `src/research_hub/skills_data/`. Pure additive change
+    — no removed inputs, no breaking behaviour, no required new
+    fields. Users without a `.gaps.yml` see identical UX to v0.3.11.
+
 - **`dossier_to_docx.js` ships inside `skills/gap-to-topic/scripts/`**
   (plugin `0.3.9 → 0.3.10`). `topic_dossier.docx` is now a first-class
   contracted deliverable of the `gap-to-topic` skill. The generator converts

--- a/docs/ai-research-skills.md
+++ b/docs/ai-research-skills.md
@@ -11,8 +11,8 @@ cover.
 |---|---|---|---|
 | 1. Discover sources | Find papers / data | research-hub | `research-hub`, `literature-triage-matrix` |
 | 2. Ingest + tag | Pull into Zotero / Obsidian | research-hub | `research-hub`, `zotero-library-curator` |
-| **2.5. Decide the topic** | 3-gate go/no-go on a candidate topic; produces a decision dossier | shared | `gap-to-topic` (emits `.gaps.yml` for the chosen candidate — Stage 3a wiring lands in v0.3.12) |
-| **3a. Frame the problem** | Sharpen RQ; design study | **YOU** (creative) | `research-design-helper` (Socratic guide; **v0.3.12+** will pre-fill from `gap-to-topic`'s `.gaps.yml` if present) |
+| **2.5. Decide the topic** | 3-gate go/no-go on a candidate topic; produces a decision dossier | shared | `gap-to-topic` (emits `.gaps.yml` for the chosen candidate — read by Stage 3a in plugin v0.3.12+) |
+| **3a. Frame the problem** | Sharpen RQ; design study | **YOU** (creative) | `research-design-helper` (Socratic guide; pre-fills segments 1 + 5 from `gap-to-topic`'s `.gaps.yml` if present, v0.3.12+) |
 | **3b. Plan artifacts** | Manifest + experiment matrix | mechanical | `research-context-compressor`, `research-project-orienter` |
 | 4. Design & build the model | Implement | YOU + cross-cutting tools | (see Cross-cutting tools below) |
 | 5. Run experiments | Execute | YOU | (cross-cutting) |
@@ -162,9 +162,11 @@ register — and saves the result to `.research/design_brief.md`.
 Does NOT invent the research question or model design; like
 `research-context-compressor`, it leaves blanks rather than guess.
 
-**Reads**: `.research/project_manifest.yml`, optional `design_brief.md`
-(refresh mode), optional `literature_matrix.md` (for prior-art context
-during identifiability discussion).
+**Reads**: `.research/project_manifest.yml`, optional
+`.research/topic_dossier.gaps.yml` (Stage 2 handoff, v0.3.12+ — pre-fills
+segments 1 and 5 from the chosen `gaps[]` entry + `open_questions[]`),
+optional `design_brief.md` (refresh mode), optional `literature_matrix.md`
+(for prior-art context during identifiability discussion).
 **Writes**: `.research/design_brief.md`.
 
 Trigger phrases: "frame this research question", "design my study",
@@ -187,13 +189,17 @@ Word memo via `scripts/dossier_to_docx.js`, v0.3.10+),
 `.research/topic_dossier.bib`, `.research/topic_dossier.gaps.yml`,
 `.research/literature_matrix.md`.
 
-**Handoff to Stage 3a**: `.gaps.yml` is the machine-readable contract
-that `research-design-helper` **will read in v0.3.12+** to pre-fill its
-Socratic dialog (chosen candidate → segment 1 RQ; `open_questions[]` →
-segment 5 risks). The schema (top-level `downstream_consumer:
-research-design-helper` key as forward-compat hook) is documented in
-`references/dossier-template.md` Schema reference section; the wire-up
-itself ships in plugin v0.3.12 (Stage 2 → 3a integration PR).
+**Handoff to Stage 3a (plugin v0.3.12+)**: `.gaps.yml` is the
+machine-readable contract that `research-design-helper` reads to
+pre-fill its Socratic dialog — chosen candidate's `statement` →
+segment 1 RQ; `open_questions[]` → segment 5 risks. Candidate
+selection is verdict-aware (filters `gaps[]` to
+`verdict in {conditional-go, go}`). The schema (with the forward-compat
+`downstream_consumer: research-design-helper` top-level key) is
+documented in `references/dossier-template.md` Schema reference
+section. Provenance flows forward: `design_brief.md` frontmatter
+gets `source: topic_dossier.gaps.yml#<gap-id>` + a `gap_verdict`
+snapshot.
 
 Trigger phrases: "is this research gap worth pursuing", "help me pick
 a thesis topic", "is this idea already taken", "find me a defensible

--- a/docs/research-workspace-manifest.md
+++ b/docs/research-workspace-manifest.md
@@ -59,7 +59,7 @@ The same `.paper/` folder is shared with the existing
 | `.research/decisions.md` | shared | humans + skills append | humans + skills read |
 | `.research/open_questions.md` | shared | humans + skills append | humans + skills read |
 | `.research/literature_matrix.md` | research-hub | `literature-triage-matrix` | humans + writing skills |
-| `.research/design_brief.md` | research-hub | `research-design-helper` (v0.68) | `research-context-compressor` (notes presence), `research-project-orienter` (cites), humans |
+| `.research/design_brief.md` | research-hub | `research-design-helper` (v0.68; v0.3.12+ writes Stage 2 provenance to frontmatter) | `research-context-compressor` (v0.3.12+ reads frontmatter + section 1; copies `source` gap-id to manifest `provenance.from_gap`), `research-project-orienter` (cites), humans |
 | `.paper/journal_format.md` | `academic-writing-skills` | writing skill | writing skill |
 | `.paper/claims.yml` | research-hub | `paper-memory-builder` | `academic-writing-skills` |
 | `.paper/figures.yml` | research-hub | `paper-memory-builder` | `academic-writing-skills` |
@@ -142,6 +142,15 @@ paper_or_deliverable: "JOH 2026 second revision"
 recent_activity:                            # `git log --oneline -10` output, optional
   - "abc1234 Refactor CAT coupling layer"
   - "def5678 Add Harvey calibration robustness check"
+
+# Optional: Stage 2 → 3a provenance (written by research-context-compressor v0.3.12+)
+# When .research/design_brief.md frontmatter carries
+# `source: topic_dossier.gaps.yml#<gap-id>`, the compressor copies that
+# pointer here so downstream tools (project-orienter, future audit
+# scripts) can trace the manifest back to the gap-to-topic candidate
+# it was framed for.
+provenance:
+  from_gap: "topic_dossier.gaps.yml#G2"     # gap-id (URI-fragment) from the chosen gap-to-topic candidate
 ```
 
 **Required fields**: `project_name`, `research_area`, `research_question`,

--- a/skills/research-context-compressor/SKILL.md
+++ b/skills/research-context-compressor/SKILL.md
@@ -39,27 +39,36 @@ empty (see "What NOT to do"). Skim, do not deep-read.
 
 1. `README.md` at the repo root — project overview. Single most useful
    input.
+2. `.research/design_brief.md` if it exists — Stage 3a handoff from
+   `research-design-helper` (plugin v0.3.12+). Read the frontmatter
+   (`project`, `source`, `gap_verdict`) plus section 1
+   (Research question) only — informs the `project_manifest.yml`
+   `research_question` field. The brief is the authority on the
+   sharpened RQ; the manifest mirrors it. Don't deep-read; skim. If
+   frontmatter `source: topic_dossier.gaps.yml#<id>` is set, copy
+   that gap-id into the manifest's `provenance.from_gap` field
+   (forward-compat with the Stage 2 → 3a wire).
 
 **For code-based research projects** (Python / JS / R / Julia / etc.):
 
-2. `pyproject.toml` / `package.json` / `requirements.txt` /
+3. `pyproject.toml` / `package.json` / `requirements.txt` /
    `renv.lock` / `Project.toml` — primary tools.
-3. `scripts/` and `notebooks/` — main entrypoints.
-4. `data/` and `outputs/` — datasets and artifacts.
+4. `scripts/` and `notebooks/` — main entrypoints.
+5. `data/` and `outputs/` — datasets and artifacts.
 
 **For qualitative / archival / interpretive projects**:
 
-2. `notes/`, `drafts/`, `sources/` — manuscript-track work.
-3. `.obsidian/` — Obsidian vault settings, if present.
-4. Any plain-text bibliography file (`bibliography.md`, `sources.bib`,
+3. `notes/`, `drafts/`, `sources/` — manuscript-track work.
+4. `.obsidian/` — Obsidian vault settings, if present.
+5. Any plain-text bibliography file (`bibliography.md`, `sources.bib`,
    `references.json`).
 
 **For both**:
 
-5. `docs/` — long-form descriptions.
-6. `.git/HEAD` and `git log --oneline -20` — current branch + recent
+6. `docs/` — long-form descriptions.
+7. `.git/HEAD` and `git log --oneline -20` — current branch + recent
    activity, if a git repo.
-7. `.research/` (if it already exists) — for refresh, not first-time
+8. `.research/` (if it already exists) — for refresh, not first-time
    create.
 
 **An empty manifest field is better than an invented one.**

--- a/skills/research-design-helper/SKILL.md
+++ b/skills/research-design-helper/SKILL.md
@@ -32,13 +32,31 @@ Not for:
 In priority order:
 
 1. `.research/project_manifest.yml` if it exists — for project context (research_question may already be partially filled).
-2. `.research/design_brief.md` if it exists — for refresh, not first-run.
-3. `.research/literature_matrix.md` if it exists — for prior-art context when discussing identifiability.
-4. The user's free-text answers during the conversation.
+2. `.research/topic_dossier.gaps.yml` if it exists — Stage 2 handoff from `gap-to-topic` (plugin v0.3.12+). Read only the chosen `gaps[]` entry plus the top-level `open_questions[]`, NOT the full file. The chosen entry is identified by `verdict: conditional-go` (or `verdict: go`); the workflow §0 step pre-fills segment 1 (RQ) from `gaps[].statement` and segment 5 (risks) from `open_questions[]` + the specific concern hinted by `gaps[].feasibility`. This satisfies the conversational-skill rule below — no whole-corpus scan, only one structured handoff record.
+3. `.research/design_brief.md` if it exists — for refresh, not first-run.
+4. `.research/literature_matrix.md` if it exists — for prior-art context when discussing identifiability.
+5. The user's free-text answers during the conversation.
 
 Do NOT scan code, data, or PDFs. This is a conversational skill.
 
 ## Workflow
+
+### §0 — Detect Stage 2 handoff (gap-to-topic)
+
+Before starting the Socratic dialog, check whether `.research/topic_dossier.gaps.yml` exists.
+
+- **If absent** → behave exactly as before (skip to the 5-segment table below; no regression for users who run this skill standalone).
+- **If present** → filter `gaps[]` to entries with `verdict` in `{conditional-go, go}` (no-go verdicts are out of scope for Stage 3a; the user already decided not to pursue them). Then:
+  - **Filtered list has exactly one entry** → that's the chosen candidate. Auto-pre-fill:
+    - **Segment 1 (RQ)** ← `gaps[].statement` as the starting RQ to sharpen (NOT yet the final falsifiable form — segment 1 dialog still runs).
+    - **Segment 5 (Risk register)** ← one row per entry in `open_questions[]`, plus a row for the specific concern indicated by `gaps[].feasibility` (e.g. `feasible-with-effort` → a "binding constraint" risk row).
+    - Tell the user: *"I pre-filled segment 1 (RQ) and segment 5 (risks) from the `.gaps.yml` (Candidate `<id>` — `<verdict>`). Review and revise as we walk through."*
+  - **Filtered list has 2+ entries** → ask the user *"Which candidate are we designing for?"* before pre-filling. Use the user's answer as the chosen `gaps[]` entry. Do not assume.
+  - **Filtered list is empty** (every gap is `no-go`) → tell the user *"No viable candidate in this dossier — every gap is `no-go`. Nothing for Stage 3a to frame."* and stop. Do NOT proceed to the 5-segment dialog on a topic the dossier rejected.
+- **Segments 2 (mechanism), 3 (identifiability), 4 (validation) are NEVER pre-filled.** The `.gaps.yml` doesn't carry that material; pre-filling those segments with non-content corrupts the Socratic dialog. Leave them blank → `_TODO_` until the segment runs.
+- **Provenance.** When you write `.research/design_brief.md`, fill the frontmatter `source:` field with `topic_dossier.gaps.yml#<gap-id>` (e.g. `topic_dossier.gaps.yml#G2`) and the `gap_verdict:` field with a frozen snapshot of `verdict` + the first 60 chars of `verdict_reason`. This makes the brief self-contained — a future reader sees which dossier candidate this design was framed for.
+
+### §1 to §5 — the 5 Socratic segments
 
 Run the 5 Socratic segments **in order**, one at a time. For each, ask the listed questions, capture the user's answer, then save verbatim to the corresponding section of `.research/design_brief.md`. If the user can't answer a segment yet, write `_TODO: <reason>_` and move on; do not fabricate.
 
@@ -64,6 +82,8 @@ status: draft     # draft | reviewed | locked
 ```
 
 If the file already exists, **update don't replace**: keep human-edited sections intact, only fill blanks unless the user explicitly says "regenerate from scratch".
+
+**Provenance protection (v0.3.12+).** If the existing `design_brief.md` has frontmatter `source: topic_dossier.gaps.yml#<old-id>` and a different `gaps[]` entry is now being chosen (different id, OR `.gaps.yml` `generated:` date differs), ASK the user before refreshing — do not silently overwrite provenance. Phrasing: *"This brief was originally framed for `<old-id>` (`<old-verdict>`). The current `.gaps.yml` chooses `<new-id>` (`<new-verdict>`). Refresh and replace the provenance, or keep the old brief and start a new one?"*
 
 After saving, print a short report:
 

--- a/skills/research-design-helper/references/design_brief_template.md
+++ b/skills/research-design-helper/references/design_brief_template.md
@@ -3,6 +3,8 @@ project: ""
 last_updated: ""
 stage: design
 status: draft        # draft | reviewed | locked
+source: ""           # optional — Stage 2 provenance, e.g. `topic_dossier.gaps.yml#G2`
+gap_verdict: ""      # optional — frozen snapshot of <verdict> + first 60 chars of verdict_reason
 ---
 
 # Design brief

--- a/src/research_hub/skills_data/research-context-compressor/SKILL.md
+++ b/src/research_hub/skills_data/research-context-compressor/SKILL.md
@@ -39,27 +39,36 @@ empty (see "What NOT to do"). Skim, do not deep-read.
 
 1. `README.md` at the repo root — project overview. Single most useful
    input.
+2. `.research/design_brief.md` if it exists — Stage 3a handoff from
+   `research-design-helper` (plugin v0.3.12+). Read the frontmatter
+   (`project`, `source`, `gap_verdict`) plus section 1
+   (Research question) only — informs the `project_manifest.yml`
+   `research_question` field. The brief is the authority on the
+   sharpened RQ; the manifest mirrors it. Don't deep-read; skim. If
+   frontmatter `source: topic_dossier.gaps.yml#<id>` is set, copy
+   that gap-id into the manifest's `provenance.from_gap` field
+   (forward-compat with the Stage 2 → 3a wire).
 
 **For code-based research projects** (Python / JS / R / Julia / etc.):
 
-2. `pyproject.toml` / `package.json` / `requirements.txt` /
+3. `pyproject.toml` / `package.json` / `requirements.txt` /
    `renv.lock` / `Project.toml` — primary tools.
-3. `scripts/` and `notebooks/` — main entrypoints.
-4. `data/` and `outputs/` — datasets and artifacts.
+4. `scripts/` and `notebooks/` — main entrypoints.
+5. `data/` and `outputs/` — datasets and artifacts.
 
 **For qualitative / archival / interpretive projects**:
 
-2. `notes/`, `drafts/`, `sources/` — manuscript-track work.
-3. `.obsidian/` — Obsidian vault settings, if present.
-4. Any plain-text bibliography file (`bibliography.md`, `sources.bib`,
+3. `notes/`, `drafts/`, `sources/` — manuscript-track work.
+4. `.obsidian/` — Obsidian vault settings, if present.
+5. Any plain-text bibliography file (`bibliography.md`, `sources.bib`,
    `references.json`).
 
 **For both**:
 
-5. `docs/` — long-form descriptions.
-6. `.git/HEAD` and `git log --oneline -20` — current branch + recent
+6. `docs/` — long-form descriptions.
+7. `.git/HEAD` and `git log --oneline -20` — current branch + recent
    activity, if a git repo.
-7. `.research/` (if it already exists) — for refresh, not first-time
+8. `.research/` (if it already exists) — for refresh, not first-time
    create.
 
 **An empty manifest field is better than an invented one.**

--- a/src/research_hub/skills_data/research-design-helper/SKILL.md
+++ b/src/research_hub/skills_data/research-design-helper/SKILL.md
@@ -32,13 +32,31 @@ Not for:
 In priority order:
 
 1. `.research/project_manifest.yml` if it exists — for project context (research_question may already be partially filled).
-2. `.research/design_brief.md` if it exists — for refresh, not first-run.
-3. `.research/literature_matrix.md` if it exists — for prior-art context when discussing identifiability.
-4. The user's free-text answers during the conversation.
+2. `.research/topic_dossier.gaps.yml` if it exists — Stage 2 handoff from `gap-to-topic` (plugin v0.3.12+). Read only the chosen `gaps[]` entry plus the top-level `open_questions[]`, NOT the full file. The chosen entry is identified by `verdict: conditional-go` (or `verdict: go`); the workflow §0 step pre-fills segment 1 (RQ) from `gaps[].statement` and segment 5 (risks) from `open_questions[]` + the specific concern hinted by `gaps[].feasibility`. This satisfies the conversational-skill rule below — no whole-corpus scan, only one structured handoff record.
+3. `.research/design_brief.md` if it exists — for refresh, not first-run.
+4. `.research/literature_matrix.md` if it exists — for prior-art context when discussing identifiability.
+5. The user's free-text answers during the conversation.
 
 Do NOT scan code, data, or PDFs. This is a conversational skill.
 
 ## Workflow
+
+### §0 — Detect Stage 2 handoff (gap-to-topic)
+
+Before starting the Socratic dialog, check whether `.research/topic_dossier.gaps.yml` exists.
+
+- **If absent** → behave exactly as before (skip to the 5-segment table below; no regression for users who run this skill standalone).
+- **If present** → filter `gaps[]` to entries with `verdict` in `{conditional-go, go}` (no-go verdicts are out of scope for Stage 3a; the user already decided not to pursue them). Then:
+  - **Filtered list has exactly one entry** → that's the chosen candidate. Auto-pre-fill:
+    - **Segment 1 (RQ)** ← `gaps[].statement` as the starting RQ to sharpen (NOT yet the final falsifiable form — segment 1 dialog still runs).
+    - **Segment 5 (Risk register)** ← one row per entry in `open_questions[]`, plus a row for the specific concern indicated by `gaps[].feasibility` (e.g. `feasible-with-effort` → a "binding constraint" risk row).
+    - Tell the user: *"I pre-filled segment 1 (RQ) and segment 5 (risks) from the `.gaps.yml` (Candidate `<id>` — `<verdict>`). Review and revise as we walk through."*
+  - **Filtered list has 2+ entries** → ask the user *"Which candidate are we designing for?"* before pre-filling. Use the user's answer as the chosen `gaps[]` entry. Do not assume.
+  - **Filtered list is empty** (every gap is `no-go`) → tell the user *"No viable candidate in this dossier — every gap is `no-go`. Nothing for Stage 3a to frame."* and stop. Do NOT proceed to the 5-segment dialog on a topic the dossier rejected.
+- **Segments 2 (mechanism), 3 (identifiability), 4 (validation) are NEVER pre-filled.** The `.gaps.yml` doesn't carry that material; pre-filling those segments with non-content corrupts the Socratic dialog. Leave them blank → `_TODO_` until the segment runs.
+- **Provenance.** When you write `.research/design_brief.md`, fill the frontmatter `source:` field with `topic_dossier.gaps.yml#<gap-id>` (e.g. `topic_dossier.gaps.yml#G2`) and the `gap_verdict:` field with a frozen snapshot of `verdict` + the first 60 chars of `verdict_reason`. This makes the brief self-contained — a future reader sees which dossier candidate this design was framed for.
+
+### §1 to §5 — the 5 Socratic segments
 
 Run the 5 Socratic segments **in order**, one at a time. For each, ask the listed questions, capture the user's answer, then save verbatim to the corresponding section of `.research/design_brief.md`. If the user can't answer a segment yet, write `_TODO: <reason>_` and move on; do not fabricate.
 
@@ -64,6 +82,8 @@ status: draft     # draft | reviewed | locked
 ```
 
 If the file already exists, **update don't replace**: keep human-edited sections intact, only fill blanks unless the user explicitly says "regenerate from scratch".
+
+**Provenance protection (v0.3.12+).** If the existing `design_brief.md` has frontmatter `source: topic_dossier.gaps.yml#<old-id>` and a different `gaps[]` entry is now being chosen (different id, OR `.gaps.yml` `generated:` date differs), ASK the user before refreshing — do not silently overwrite provenance. Phrasing: *"This brief was originally framed for `<old-id>` (`<old-verdict>`). The current `.gaps.yml` chooses `<new-id>` (`<new-verdict>`). Refresh and replace the provenance, or keep the old brief and start a new one?"*
 
 After saving, print a short report:
 

--- a/src/research_hub/skills_data/research-design-helper/references/design_brief_template.md
+++ b/src/research_hub/skills_data/research-design-helper/references/design_brief_template.md
@@ -3,6 +3,8 @@ project: ""
 last_updated: ""
 stage: design
 status: draft        # draft | reviewed | locked
+source: ""           # optional — Stage 2 provenance, e.g. `topic_dossier.gaps.yml#G2`
+gap_verdict: ""      # optional — frozen snapshot of <verdict> + first 60 chars of verdict_reason
 ---
 
 # Design brief

--- a/tests/fixtures/topic_dossier_sample.gaps.yml
+++ b/tests/fixtures/topic_dossier_sample.gaps.yml
@@ -1,0 +1,106 @@
+# Frozen 2026-05-22 from
+# C:/Users/wenyu/.claude/audits/dogfood_runs/2026-05-21-gap-to-topic-llm-abm-profiles/en/topic_dossier.gaps.yml.
+#
+# Source of truth for the cross-skill handoff test
+# (tests/test_handoff_gap_to_topic_design_helper.py). The test asserts
+# this fixture parses as a valid v0.3.10+ gap-to-topic .gaps.yml output
+# and contains the keys the downstream consumer (research-design-helper)
+# reads in workflow §0 (gaps[].statement, gaps[].verdict, open_questions[]).
+#
+# Refresh policy: when gap-to-topic's emitted schema is intentionally
+# extended, refresh this fixture in the SAME PR and update the schema
+# reference in skills/gap-to-topic/references/dossier-template.md to match.
+# See CHANGELOG entry for v0.3.11 (schema refresh) for the precedent.
+
+dossier: LLM applications in water resources
+generated: "2026-05-22"
+run_type: gap-to-topic re-test (research-hub plugin v0.3.6 — §1 applies search --screen)
+downstream_consumer: research-design-helper   # v0.3.11+ contract reader (PR 0 schema refresh)
+recall:
+  tool: research-hub search --adversarial --screen --json
+  query_phrasings: 6
+  unique_papers: 435
+  tool_confidence: medium
+  dossier_confidence: medium
+  screen:
+    gate: fit-check BM25 relevance gate (search --screen)
+    retrieved: 25
+    kept: 25
+    screened_out: 0
+    tier: cold-start
+    note: >-
+      No blatant >=5x bimodal split in the returned batch, so the gate
+      (conservative by design) kept all 25. The agent still applied
+      relevance judgement when selecting the prior-art corpus.
+  note: >-
+    semantic-scholar backend rate-limited (HTTP 429) part of the run;
+    recall rests on crossref + openalex + arxiv.
+pipeline:
+  - research-hub search --adversarial --screen --json   # §1 step 1
+  - literature-triage-matrix -> literature_matrix.md     # §1 step 2 (on-topic kept:true)
+  - .bib from on-topic search --json results             # §1 step 3
+  - gap-to-topic gates §1-§4
+gaps:
+  - id: G1
+    name: "LLM-driven water resources management"
+    statement: >-
+      Use LLMs / LLM agents for water resources management and decision
+      support - hydrological forecasting, reservoir/river operations,
+      monitoring, planning.
+    type: B
+    open: occupied
+    dead_end_status: not-assessed   # Gate (1) no-go
+    contribution_type: not-assessed # Gate (1) no-go
+    feasibility: not-assessed       # Gate (1) no-go
+    verdict: no-go
+    verdict_reason: >-
+      Fails Gate (1) - occupied, firmly: primary studies plus a hydrology
+      LLM benchmark (HydroLLM), a systematic review (AI in water
+      regulation) and a bibliometric analysis of LLMs in hydrology.
+    linked_claim: null
+  - id: G2
+    name: "LLM agents for human behaviour in socio-hydrology"
+    statement: >-
+      Use LLM agents to represent heterogeneous stakeholder/household
+      decision-making in coupled human-water (socio-hydrology) modeling,
+      calibrated and validated against observed water-use/adaptation
+      behavior.
+    type: B
+    open: open
+    open_confidence: medium
+    dead_end_status: partially-attempted
+    dead_end_evidence: >-
+      Schuck 2026 (10.3389/frwa.2026.1749745) - a peer-reviewed perspective
+      cautioning on LLMs for human data in human-water research - engages
+      the exact G2 premise as a standing caution.
+    contribution_type: borderline
+    borderline_reason: B1   # partial novelty - Batista 2025 (LLM sentiment
+                            # for water governance), Braga 2025, Khaki 2025
+                            # are weaker realised forms of the capability
+    feasibility: feasible-with-effort
+    verdict: conditional-go
+    verdict_reason: >-
+      Open (medium confidence), partially-attempted on dead-end history,
+      borderline/B1 on contribution, feasible-with-effort. Worth-it call
+      handed to researcher + advisor (dossier section 4).
+    linked_claim: null
+open_questions:
+  - id: Q1
+    text: >-
+      Is G2 still open after a full-recall re-run with semantic-scholar
+      enabled? The openness verdict is medium-confidence pending that.
+  - id: Q2
+    text: >-
+      Can G2's validation design answer Schuck 2026's caution AND
+      out-distance Batista 2025's LLM-sentiment approach to water
+      governance? Batista 2025 is now a close in-domain analogue.
+  - id: Q3
+    text: >-
+      Does the empirical-calibration-against-observed-water-behaviour
+      requirement make G2 problem-solving or incremental? Turns on framing
+      (B1).
+  - id: Q4
+    text: >-
+      Can an existing socio-hydrology dataset/model (e.g. Jiang et al. 2026,
+      North China Plain) be reused as the behavioural-validation base, or
+      does G2 need primary data collection? Binding constraint on timeline.

--- a/tests/test_handoff_gap_to_topic_design_helper.py
+++ b/tests/test_handoff_gap_to_topic_design_helper.py
@@ -1,0 +1,362 @@
+"""Cross-skill integration test: gap-to-topic → research-design-helper.
+
+This is the **first cross-skill handoff integration test** in the
+research-hub skill family. Subsequent stage-to-stage wires (3a → 3b,
+6 → 7, ...) should follow this shape:
+
+  1. A frozen fixture under tests/fixtures/ representing the upstream
+     skill's emitted artifact (here: topic_dossier.gaps.yml).
+  2. Schema-parses-cleanly assertion (yaml.safe_load doesn't raise).
+  3. Schema-key-presence assertions for the fields the downstream skill
+     reads (here: gaps[].statement, gaps[].verdict, gaps[].feasibility,
+     open_questions[].text).
+  4. SKILL.md prose-contract assertions — the downstream skill's
+     SKILL.md must literally mention reading the upstream artifact in
+     its Inputs section, so the contract is documented for human
+     readers AND machine-checkable.
+  5. Inverse / regression assertions — the downstream skill must still
+     describe a fallback path when the upstream artifact is absent.
+
+Failures here indicate the handoff contract drifted between the two
+skills' SKILL.md prose and the actual artifact schema. Fix by either
+updating the fixture (if the schema was intentionally extended), the
+SKILL.md (if the prose missed a field), or both.
+
+See plan: ~/.claude/plans/enchanted-enchanting-anchor.md (PR 1 of the
+Stage 2 → 3a → 3b handoff sequence).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "topic_dossier_sample.gaps.yml"
+DESIGN_HELPER_SKILL = (
+    REPO_ROOT / "skills" / "research-design-helper" / "SKILL.md"
+)
+DESIGN_HELPER_TEMPLATE = (
+    REPO_ROOT
+    / "skills"
+    / "research-design-helper"
+    / "references"
+    / "design_brief_template.md"
+)
+CONTEXT_COMPRESSOR_SKILL = (
+    REPO_ROOT / "skills" / "research-context-compressor" / "SKILL.md"
+)
+GAP_TO_TOPIC_TEMPLATE = (
+    REPO_ROOT
+    / "skills"
+    / "gap-to-topic"
+    / "references"
+    / "dossier-template.md"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture-level assertions — the upstream artifact has the shape the
+# downstream skill expects.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def gaps_yaml() -> dict:
+    """Parse the frozen .gaps.yml fixture once per test module."""
+    assert FIXTURE.exists(), f"missing fixture: {FIXTURE}"
+    return yaml.safe_load(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_fixture_parses_as_valid_yaml(gaps_yaml: dict) -> None:
+    """Trivial guard — the fixture must be loadable. If this fails the
+    file was corrupted on disk, not a contract problem."""
+    assert isinstance(gaps_yaml, dict), "fixture root must be a mapping"
+
+
+def test_fixture_has_v0_3_10_plus_top_level_keys(gaps_yaml: dict) -> None:
+    """The v0.3.6+ + v0.3.9+ schema (refreshed in plugin v0.3.11) has
+    these top-level keys. Adding to this list is a SCHEMA EXTENSION —
+    refresh `dossier-template.md` Schema reference + bump the plugin.
+    Removing one is a BREAKING CHANGE.
+    """
+    expected = {
+        "dossier",  # the topic area
+        "generated",  # ISO date
+        "run_type",  # short prose describing the run
+        "recall",  # search backbone metadata + screen sub-block
+        "pipeline",  # 4-step provenance chain
+        "gaps",  # list of candidate gaps with verdicts
+        "open_questions",  # list of unresolved questions the dossier surfaced
+    }
+    actual = set(gaps_yaml.keys())
+    missing = expected - actual
+    assert not missing, (
+        f"fixture missing top-level keys the downstream consumer expects: "
+        f"{sorted(missing)}"
+    )
+
+
+def test_fixture_recall_has_screen_subblock(gaps_yaml: dict) -> None:
+    """`recall.screen` is the v0.3.6 fit-check BM25 gate metadata.
+    The schema reference promises it; the fixture must have it."""
+    assert "screen" in gaps_yaml["recall"], (
+        "recall.screen sub-block missing — fit-check BM25 gate metadata"
+    )
+    screen_keys = set(gaps_yaml["recall"]["screen"].keys())
+    expected = {"gate", "retrieved", "kept", "screened_out", "tier"}
+    missing = expected - screen_keys
+    assert not missing, (
+        f"recall.screen missing keys: {sorted(missing)}"
+    )
+
+
+def test_fixture_gap_entry_has_downstream_consumer_fields(
+    gaps_yaml: dict,
+) -> None:
+    """Each `gaps[]` entry must carry the fields the downstream consumer
+    (research-design-helper §0) reads. If any is missing, pre-fill
+    cannot run."""
+    required_per_gap = {
+        "id",  # G1, G2, ...
+        "name",  # human-readable label
+        "statement",  # one-sentence statement, feeds Segment 1 (RQ)
+        "verdict",  # go | conditional-go | no-go — filter key
+        "feasibility",  # informs Segment 5 (Risks)
+    }
+    for gap in gaps_yaml["gaps"]:
+        actual = set(gap.keys())
+        missing = required_per_gap - actual
+        assert not missing, (
+            f"gap {gap.get('id', '<unknown>')} missing fields: "
+            f"{sorted(missing)}"
+        )
+
+
+def test_fixture_open_questions_have_text_field(gaps_yaml: dict) -> None:
+    """`open_questions[]` feeds Segment 5 (Risk register) pre-fill —
+    each entry needs a `text` field."""
+    for q in gaps_yaml["open_questions"]:
+        assert "text" in q, f"open_question missing text: {q}"
+        assert q["text"], f"open_question has empty text: {q}"
+
+
+def test_fixture_at_least_one_go_eligible_candidate(gaps_yaml: dict) -> None:
+    """The §0 workflow filters gaps to `verdict in {conditional-go, go}`.
+    An all-no-go fixture is a valid edge case (the §0 step would say
+    'nothing to frame') but is not useful for testing the pre-fill
+    path; our dogfood fixture must have at least one go-eligible gap.
+    """
+    go_eligible = [
+        g for g in gaps_yaml["gaps"] if g["verdict"] in {"conditional-go", "go"}
+    ]
+    assert go_eligible, (
+        "fixture has no conditional-go or go candidate; pre-fill path "
+        "is unexercised. Refresh the fixture."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Downstream-skill contract assertions — research-design-helper's
+# SKILL.md must literally describe reading .gaps.yml.
+# ---------------------------------------------------------------------------
+
+
+def test_design_helper_skill_md_lists_gaps_yml_as_input() -> None:
+    """research-design-helper Inputs section must mention
+    topic_dossier.gaps.yml. If this fails, the prose contract was
+    rolled back without updating this test."""
+    text = DESIGN_HELPER_SKILL.read_text(encoding="utf-8")
+    inputs_section = _extract_section(text, "## Inputs")
+    assert "topic_dossier.gaps.yml" in inputs_section, (
+        "research-design-helper Inputs section no longer mentions "
+        "topic_dossier.gaps.yml — handoff contract broke"
+    )
+
+
+def test_design_helper_skill_md_has_section_0_preamble() -> None:
+    """The §0 workflow preamble (the auto-pre-fill logic) must exist
+    AND describe verdict-based filtering inside the §0 block itself
+    (not just anywhere in the file — `conditional-go` also appears in
+    the Inputs section above, so we must scope to §0).
+    """
+    text = DESIGN_HELPER_SKILL.read_text(encoding="utf-8")
+    assert "### §0 — Detect Stage 2 handoff" in text, (
+        "Workflow §0 preamble missing — pre-fill logic undocumented"
+    )
+    section_0 = _extract_section(text, "### §0 — Detect Stage 2 handoff")
+    # Filter-by-verdict logic must live inside the §0 block, not just
+    # be incidentally present elsewhere
+    assert "conditional-go" in section_0, (
+        "§0 block does not mention `conditional-go` — filter logic absent"
+    )
+    assert "no-go" in section_0, (
+        "§0 block does not mention `no-go` — three-branch logic incomplete"
+    )
+    # Fallback-on-absence must be the first branch
+    assert "If absent" in section_0, (
+        "§0 block missing the absent-fallback branch"
+    )
+
+
+def test_design_helper_skill_md_section_0_covers_three_branches() -> None:
+    """The §0 block must describe all three filtered-list branches:
+    exactly-one, 2+, zero. If any branch is silently deleted, the user
+    experience regresses."""
+    text = DESIGN_HELPER_SKILL.read_text(encoding="utf-8")
+    section_0 = _extract_section(text, "### §0 — Detect Stage 2 handoff")
+    # Exactly-one-candidate branch — auto-pre-fill
+    assert "auto-pre-fill" in section_0.lower() or "auto pre-fill" in section_0.lower(), (
+        "§0 missing the auto-pre-fill (exactly-one-candidate) branch"
+    )
+    # 2+ branch — ask the user
+    assert "Which candidate" in section_0, (
+        "§0 missing the 2+ candidates branch (ask-the-user)"
+    )
+    # zero branch — halt
+    assert "No viable candidate" in section_0 or "nothing to frame" in section_0.lower(), (
+        "§0 missing the zero-candidates branch (halt with nothing-to-frame)"
+    )
+
+
+def test_design_helper_skill_md_preserves_fallback_behaviour() -> None:
+    """INVERSE assertion — if .gaps.yml is absent the skill must NOT
+    regress. The Inputs section must still list its 4 fallback inputs
+    (project_manifest.yml, design_brief.md, literature_matrix.md, free
+    text) and the §0 preamble must say 'If absent → behave exactly as
+    before'.
+    """
+    text = DESIGN_HELPER_SKILL.read_text(encoding="utf-8")
+    inputs_section = _extract_section(text, "## Inputs")
+    for required in (
+        "project_manifest.yml",
+        "design_brief.md",
+        "literature_matrix.md",
+    ):
+        assert required in inputs_section, (
+            f"Fallback input {required!r} removed from Inputs — regression"
+        )
+    assert "If absent" in text and "behave exactly as before" in text, (
+        "§0 must explicitly preserve fallback behaviour when .gaps.yml is "
+        "absent (no regression for standalone users)"
+    )
+
+
+def test_design_brief_template_has_provenance_frontmatter() -> None:
+    """The design_brief.md frontmatter must accept the two new fields
+    that record Stage 2 → 3a provenance."""
+    text = DESIGN_HELPER_TEMPLATE.read_text(encoding="utf-8")
+    # Extract the YAML frontmatter (between the first two `---` lines)
+    m = re.search(r"\A---\n(.*?)\n---\n", text, re.S)
+    assert m, "design_brief_template.md missing frontmatter"
+    frontmatter = m.group(1)
+    assert "source:" in frontmatter, (
+        "frontmatter missing `source:` — Stage 2 provenance field"
+    )
+    assert "gap_verdict:" in frontmatter, (
+        "frontmatter missing `gap_verdict:` — frozen verdict snapshot field"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3a → 3b contract: research-context-compressor reads design_brief.md
+# ---------------------------------------------------------------------------
+
+
+def test_context_compressor_skill_md_reads_design_brief() -> None:
+    """research-context-compressor Inputs must mention design_brief.md.
+    The marketplace pipeline.md has long claimed it does; this fix
+    makes the skill's own prose match.
+    """
+    text = CONTEXT_COMPRESSOR_SKILL.read_text(encoding="utf-8")
+    inputs_section = _extract_section(text, "## Inputs")
+    assert "design_brief.md" in inputs_section, (
+        "research-context-compressor Inputs section does not mention "
+        "design_brief.md — pipeline.md promise still uncorroborated"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema-reference vs fixture: the upstream skill's schema doc must
+# cover the keys the fixture has.
+# ---------------------------------------------------------------------------
+
+
+def test_gap_to_topic_schema_reference_covers_fixture_top_level_keys(
+    gaps_yaml: dict,
+) -> None:
+    """Defensive check — the Schema reference section in
+    skills/gap-to-topic/references/dossier-template.md must document
+    every top-level key the fixture contains. If a key is in the
+    fixture but not in the schema reference, the contract doc is
+    stale."""
+    schema_text = GAP_TO_TOPIC_TEMPLATE.read_text(encoding="utf-8")
+    schema_section = _extract_section(schema_text, "## Schema reference")
+    for key in gaps_yaml.keys():
+        # Allow the key to appear either as a top-level YAML key
+        # (e.g. `dossier:` at column 0) or as inline prose
+        # (e.g. "top-level `recall`"). Both are valid documentation.
+        if re.search(rf"^\s*{re.escape(key)}:", schema_section, re.M):
+            continue
+        if f"`{key}`" in schema_section:
+            continue
+        pytest.fail(
+            f"top-level key {key!r} appears in fixture but not in the "
+            f"gap-to-topic Schema reference — contract drift"
+        )
+
+
+def test_gap_to_topic_schema_reference_covers_fixture_per_gap_fields(
+    gaps_yaml: dict,
+) -> None:
+    """Per-gap-field drift detector. If gap-to-topic starts emitting
+    a new per-gap key (e.g. `impact_magnitude`) but the schema
+    reference forgets to document it, this test catches the drift in
+    CI rather than 6 months later.
+
+    Reads the `gaps:` block from the schema reference and asserts every
+    key present in `gaps[0]` of the fixture is also documented there
+    (either as a literal key under `gaps:` in the example YAML, or as
+    inline prose with backticks).
+    """
+    schema_text = GAP_TO_TOPIC_TEMPLATE.read_text(encoding="utf-8")
+    schema_section = _extract_section(schema_text, "## Schema reference")
+
+    # Use the first gap as the canonical key-set sample
+    gap_sample = gaps_yaml["gaps"][0]
+    for field in gap_sample.keys():
+        # The schema reference shows the field either as an indented
+        # YAML key under `gaps:` — possibly with a leading list-marker
+        # (e.g. `  - id: G1`) or just indented (e.g. `    name: ...`) —
+        # or as inline prose with backticks (e.g. "per-gap `verdict`").
+        if re.search(rf"^\s+(?:- )?{re.escape(field)}:", schema_section, re.M):
+            continue
+        if f"`{field}`" in schema_section:
+            continue
+        pytest.fail(
+            f"per-gap field {field!r} appears in fixture but not in the "
+            f"gap-to-topic Schema reference `gaps:` block — contract drift"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_section(markdown_text: str, heading: str) -> str:
+    """Return the text from `heading` to the next `## ` heading.
+
+    `heading` should include the leading hashes (e.g. `## Inputs`).
+    """
+    m = re.search(
+        rf"^{re.escape(heading)}.*?(?=^## \w|\Z)",
+        markdown_text,
+        re.S | re.M,
+    )
+    if not m:
+        raise AssertionError(f"section {heading!r} not found")
+    return m.group(0)


### PR DESCRIPTION
First cross-skill handoff in the research-hub family. Two broken wires fixed as one coherent user-facing capability: `gap-to-topic`'s `.gaps.yml` now flows into `research-design-helper`, and `design_brief.md` flows into `research-context-compressor`.

## What ships

### `research-design-helper` reads `topic_dossier.gaps.yml`

- New Input #2 (between `project_manifest.yml` and `design_brief.md`). Reads only the chosen `gaps[]` entry + `open_questions[]` — preserves the conversational-skill rule.
- New Workflow §0 preamble auto-pre-fills:
  - **Segment 1 (RQ)** ← `gaps[].statement`
  - **Segment 5 (Risks)** ← `open_questions[]` + `gaps[].feasibility` hint
- Segments 2–4 (mechanism / identifiability / validation) **never** pre-filled — dossier doesn't carry that material; pre-filling corrupts Socratic dialog.
- **Verdict-aware** candidate selection:
  - Filter `gaps[]` to `verdict in {conditional-go, go}`
  - exactly 1 → auto-pre-fill
  - 2+ → ask user
  - 0 → halt with "nothing to frame"
- **No regression** when upstream `.gaps.yml` absent — fallback to today's behaviour.

### `design_brief.md` frontmatter carries Stage 2 provenance

Two new optional fields:
```yaml
source: "topic_dossier.gaps.yml#G2"   # URI-fragment pointer to chosen gap
gap_verdict: "<frozen snapshot>"       # verdict + first 60 chars of verdict_reason
```

Provenance-protection: refresh that would change `source` triggers a confirm prompt instead of silent overwrite.

### `research-context-compressor` reads `design_brief.md`

New Input #2 under "For any project". Reads frontmatter + section 1 only. **Implements the long-claimed pipeline.md contract.** If frontmatter `source` is set, copies that gap-id into the manifest's `provenance.from_gap` field — registered in `docs/research-workspace-manifest.md`.

### First cross-skill handoff integration test

- `tests/fixtures/topic_dossier_sample.gaps.yml` — frozen from the v0.3.10 dogfood example (LLM-ABM socio-hydrology).
- `tests/test_handoff_gap_to_topic_design_helper.py` — **14 tests** covering:
  - Fixture parses + v0.3.10+ top-level keys + `recall.screen` sub-block + per-gap downstream-consumer fields
  - SKILL.md prose contract: Inputs lists `.gaps.yml`, §0 preamble describes 3 filter branches, fallback preserved
  - Frontmatter has `source` + `gap_verdict`
  - Stage 3a → 3b: compressor mentions `design_brief.md`
  - Drift detectors: schema reference covers every top-level key + every per-gap field the fixture contains

Subsequent stage-to-stage wires (3a → 3b proper, 6 → 7, …) should follow this test shape.

## Files

| Modified | Notes |
|---|---|
| `.claude-plugin/plugin.json` | `0.3.11 → 0.3.12` |
| `CHANGELOG.md` | New `### Added` block under `[Unreleased]` |
| `docs/ai-research-skills.md` | Stage 2.5 + 3a rows present-tense; `### gap-to-topic` Handoff block updated; Reads list for `### research-design-helper` updated |
| `docs/research-workspace-manifest.md` | `provenance.from_gap` registered in schema + ownership table updated |
| `skills/research-design-helper/SKILL.md` | Inputs + Workflow §0 + provenance-protection |
| `skills/research-design-helper/references/design_brief_template.md` | `source` + `gap_verdict` frontmatter fields |
| `skills/research-context-compressor/SKILL.md` | New `design_brief.md` Input + renumbered downstream branches |
| `src/research_hub/skills_data/...` × 3 | Byte-identical mirrors |

| New |
|---|
| `tests/fixtures/topic_dossier_sample.gaps.yml` |
| `tests/test_handoff_gap_to_topic_design_helper.py` (14 tests) |

## Validation

| Check | Result |
|---|---|
| `pytest tests/test_handoff_gap_to_topic_design_helper.py tests/test_v068_3_version_sync.py -q` | **17/17** passed |
| `diff -rq skills/ src/research_hub/skills_data/` | clean |
| `git grep -nF "0.3.11"` outside CHANGELOG | 1 intentional version-since marker (`### gap-to-topic (v0.3.11)` heading — gap-to-topic itself didn't change in v0.3.12, only its downstream consumer did) |
| code-reviewer subagent | APPROVE (after fix-cycle for W1 manifest schema + W2 stale Reads list + W3 fixture/schema consistency + S1/S3 test tightenings) |

Pure additive change: no removed inputs, no breaking behaviour, no required new fields. Users without a `.gaps.yml` see identical UX to v0.3.11.

## Next

After this lands → **operator dogfood** at `~/.claude/audits/dogfood_runs/2026-05-22-research-design-helper-llm-abm-socio-hydrology/`: run `research-design-helper` against Candidate 2 (LLM agents for socio-hydrology) from the v0.3.10 dossier to verify the handoff in practice. Then a marketplace propagation PR carries the Stage 2 → 3a → 3b story to `ai-research-skills` (catalog 1.5.14 → 1.5.15, research-workspace 0.3.10 → 0.3.12) and bundles the catalog drift hygiene umbrella (README, pipeline.md, image-prompt all currently missing gap-to-topic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)