### PR TITLE
feat(skill): ship brief_to_docx.js for research-design-helper (plugin 0.3.13 → 0.3.14)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,37 @@ graph rebuild (link out to the real tools instead)._
   flag still makes sense.
 
 ### Added
+- **`brief_to_docx.js` ships inside `skills/research-design-helper/scripts/`**
+  (plugin `0.3.13 → 0.3.14`). Sister script to
+  `skills/gap-to-topic/scripts/dossier_to_docx.js` — same Markdown → Word
+  converter (heading styles, bullet lists via numbering reference,
+  tables with dual-width DXA, en / zh-TW font auto-select, Markdown
+  separator-row skip), but default stem is `design_brief` instead of
+  `topic_dossier`. Makes the Stage 3a artifact shareable with advisors
+  / committee members who prefer Word over Markdown.
+  - **Not part of the contracted Stage 3a output.** `design_brief.md`
+    remains the canonical artifact; the `.docx` is an optional
+    convenience for human consumption only. Downstream skills (Stage
+    3b `research-context-compressor`) read the `.md` frontmatter +
+    section 1 directly, not the `.docx`.
+  - **Verdict-colour regex inherited verbatim but does NOT fire on
+    design brief content** — no "Do not pursue" / "Not assessed" /
+    "不予推進" / "未評估" strings appear in a design brief. Keeping
+    the regex unchanged means a single fix to the dossier generator
+    lands in both scripts via parallel PRs.
+  - SKILL.md adds `## Generate .docx (optional, plugin v0.3.14+)`
+    section between `## Output` and `## Token-saving behavior`,
+    mirroring the gap-to-topic `§4.5 Generate .docx` pattern.
+  - `scripts/README.md` ships alongside, documenting prereq
+    (`npm install -g docx`), invocation examples (en + zh-TW), and
+    the design-brief-specific deviation (the regex no-op).
+  - New test
+    `test_design_helper_has_brief_to_docx_script_and_skill_md_section`
+    asserts `scripts/brief_to_docx.js` exists, the SKILL.md has the
+    new `## Generate .docx (optional` heading, and the script's
+    default stem is `design_brief` not `topic_dossier`.
+  - Mirrored to `src/research_hub/skills_data/`.
+
 - **Stage 2 → 3a → 3b handoff wiring**
   (`skills/research-design-helper/`, `skills/research-context-compressor/`,
   `tests/fixtures/topic_dossier_sample.gaps.yml`,

--- a/skills/research-design-helper/SKILL.md
+++ b/skills/research-design-helper/SKILL.md
@@ -96,6 +96,34 @@ After saving, print a short report:
   Suggested next: refine the validation baseline, then re-run with "regenerate from scratch" to lock the brief.
 ```
 
+## Generate .docx (optional, plugin v0.3.14+)
+
+After writing `.research/design_brief.md`, an **optional** Word version
+can be generated via the sister script at
+`scripts/brief_to_docx.js`. The `.docx` is a convenience for sharing the
+brief with advisors / committee members who prefer Word — it is NOT
+part of the contracted Stage 3a output and is not consumed by
+downstream skills (Stage 3b reads `design_brief.md` frontmatter + §1
+directly).
+
+```bash
+# From the directory that contains design_brief.md:
+node /path/to/skills/research-design-helper/scripts/brief_to_docx.js design_brief --no-toc
+
+# zh-TW variant (auto-selects Microsoft JhengHei):
+node /path/to/skills/research-design-helper/scripts/brief_to_docx.js design_brief.zh-TW --no-toc
+```
+
+Prerequisite: `npm install -g docx` (one-time). The `--no-toc` flag is
+recommended for design briefs — they're typically short enough that
+Word's auto-generated empty TOC field is more distracting than useful.
+
+The script is a near-byte copy of the `gap-to-topic`
+`scripts/dossier_to_docx.js` generator (same Markdown → Word logic,
+same font auto-selection, same separator-row skip). The dossier's
+verdict-colour regex is inherited verbatim but does not fire on design
+brief content — see `scripts/README.md` for the rationale.
+
 ## Token-saving behavior
 
 - Don't repeat the user's answers back at length — quote in the written brief, summarize one sentence in chat.

--- a/skills/research-design-helper/scripts/README.md
+++ b/skills/research-design-helper/scripts/README.md
@@ -1,0 +1,82 @@
+# scripts/brief_to_docx.js
+
+Convert a `research-design-helper` design brief Markdown file into a styled
+Word document (.docx) using `docx` 9.x.
+
+This is the **sister script** to
+`skills/gap-to-topic/scripts/dossier_to_docx.js` — same Markdown → Word
+converter, but the default stem is `design_brief` (the Stage 3a artifact)
+instead of `topic_dossier` (the Stage 2 artifact). The two scripts share
+the same internal logic so a single fix lands in both via parallel PRs.
+
+## What it produces
+
+A `.docx` file alongside the source `.md` with:
+
+- Heading styles (H1 navy, H2 navy, H3 dark grey) using the auto-selected font
+- Bullet lists via a numbering reference (not a unicode glyph)
+- Tables with dual-width DXA column sizing (the design brief §5 risk
+  register renders cleanly as a 4-column table)
+- Table separator rows (`|---|---|`) skipped — they do not appear as
+  "---" cells in Word
+- Optional Table of Contents + page break inserted after the first table
+  (omit with `--no-toc` for short docs where Word's empty TOC field is
+  distracting — recommended for `design_brief.md` which has only 5
+  sections)
+
+The verdict-colour coding regex (light red / yellow / green / grey
+on scorecard / verdict cells) is inherited from `dossier_to_docx.js`
+verbatim. It does NOT fire on `design_brief.md` content (no "Do not
+pursue" / "Not assessed" / "不予推進" / "未評估" strings appear in a
+design brief), which is the correct no-op behaviour. Leaving the
+regex in keeps the two scripts byte-near-identical so future maintenance
+patches land in parallel.
+
+Font auto-selection: if the filename contains `.zh`, `zh-`, `zh_`, `-tw`, or
+`-cn` (case-insensitive), the document body uses **Microsoft JhengHei**;
+otherwise **Arial**.
+
+## Prerequisite
+
+Install the `docx` npm package before running the script:
+
+```
+# Global install (available everywhere):
+npm install -g docx
+
+# Local install (available only from the scripts/ directory):
+cd scripts && npm install docx
+```
+
+If `docx` is not installed, Node.js will throw a `Cannot find module 'docx'`
+error when the script is run. Install it and re-run.
+
+## Invocation
+
+Run from the directory that contains your `design_brief.md` (typically
+`.research/`):
+
+```bash
+# English brief (Arial font, no TOC recommended for short docs):
+node /path/to/skills/research-design-helper/scripts/brief_to_docx.js design_brief --no-toc
+
+# zh-TW brief (JhengHei font auto-selected by filename):
+node /path/to/skills/research-design-helper/scripts/brief_to_docx.js design_brief.zh-TW --no-toc
+
+# Absolute path (writes .docx alongside the .md):
+node brief_to_docx.js /abs/path/to/.research/design_brief
+```
+
+The output `.docx` is written to the same directory as the `.md` file.
+
+## Integration in the research-design-helper workflow
+
+`design_brief.md` is the canonical Stage 3a artifact and remains the
+primary deliverable. The `.docx` is an **optional convenience** for
+sharing with advisors / committee members who prefer Word over Markdown
+— it is NOT part of the contracted output and is not consumed by
+downstream skills (Stage 3b reads the `.md` frontmatter + section 1
+directly).
+
+See SKILL.md `## Generate .docx (optional)` for the post-processing
+step.

--- a/skills/research-design-helper/scripts/brief_to_docx.js
+++ b/skills/research-design-helper/scripts/brief_to_docx.js
@@ -1,0 +1,272 @@
+// brief_to_docx.js — convert a research-design-helper design_brief (.md) to a styled Word document (.docx)
+//
+// Sister script to skills/gap-to-topic/scripts/dossier_to_docx.js — same
+// Markdown → Word converter, default stem "design_brief" (Stage 3a artifact)
+// instead of "topic_dossier" (Stage 2 artifact). The verdict-colour regex
+// is kept verbatim from the dossier generator; it simply doesn't fire on
+// design_brief content (no "Do not pursue" / "Not assessed" strings),
+// which is the correct no-op behaviour.
+//
+// Prerequisite: npm install -g docx   (or: cd scripts && npm install docx  for local)
+//
+// Usage:
+//   node brief_to_docx.js [stem-or-path] [--no-toc]
+//
+//   stem-or-path  Stem name ("design_brief") relative to cwd, OR an absolute path
+//                 (with or without .md/.docx extension — the script adds them).
+//                 Default: "design_brief"
+//   --no-toc      Skip the Table of Contents field (avoid empty Word TOC on short docs).
+//
+// Examples:
+//   node brief_to_docx.js design_brief --no-toc
+//   node brief_to_docx.js /abs/path/to/en/design_brief
+//   node brief_to_docx.js design_brief.zh-TW   (triggers JhengHei font)
+//
+// Font auto-selection:
+//   filename matches /.zh|zh-|zh_|-tw|-cn/i  -> Microsoft JhengHei
+//   otherwise                                 -> Arial
+//
+// Verdict colour coding inherited from dossier_to_docx.js (cells in
+// scorecards / verdict cards — does NOT fire on design_brief content):
+//   "Do not pursue" / "不予推進"              -> light red   (#F4DEDE)
+//   "Worth pursuing … only if" / conditional  -> light yellow (#FFF4D6)
+//   "Worth pursuing" (unconditional)          -> light green  (#E2F0DA)
+//   "Not assessed" / "未評估"                 -> light grey   (#EEEEEE)
+//   All other cells                           -> white
+
+const fs = require("fs");
+const path = require("path");
+const {
+  Document, Packer, Paragraph, TextRun, Table, TableRow, TableCell,
+  AlignmentType, LevelFormat, TableOfContents, HeadingLevel, BorderStyle,
+  WidthType, ShadingType, PageBreak,
+} = require("docx");
+
+// ---- argument parsing ----
+const NOTOC = process.argv.includes("--no-toc");
+const ARG = process.argv.slice(2).find((a) => !a.startsWith("--")) || "design_brief";
+
+// Strip .md or .docx extension if provided so we work from the bare stem
+const stem = ARG.replace(/\.(md|docx)$/i, "");
+
+// Font: detect Chinese filename pattern
+const FONT = /\.zh|zh-|zh_|-tw|-cn/i.test(stem) ? "Microsoft JhengHei" : "Arial";
+
+// Resolve source (.md) and output (.docx) paths.
+// If the stem is absolute (contains a path separator), write alongside it.
+// Otherwise resolve relative to process.cwd() so the script works from any directory.
+const isAbs = path.isAbsolute(stem) || stem.includes("/") || stem.includes("\\");
+const SRC = isAbs ? path.resolve(stem + ".md") : path.resolve(process.cwd(), stem + ".md");
+const OUT = isAbs ? path.resolve(stem + ".docx") : path.resolve(process.cwd(), stem + ".docx");
+
+const CONTENT_W = 9360;
+
+// ---- inline markdown -> TextRun[] ----
+function parseInline(text, base = {}) {
+  const runs = [];
+  const re = /(\*\*[^*]+\*\*|`[^`]+`|\*[^*]+\*)/g;
+  let last = 0, m;
+  while ((m = re.exec(text))) {
+    if (m.index > last) runs.push(new TextRun({ text: text.slice(last, m.index), ...base }));
+    const t = m[0];
+    if (t.startsWith("**")) runs.push(new TextRun({ text: t.slice(2, -2), bold: true, ...base }));
+    else if (t.startsWith("`")) runs.push(new TextRun({ text: t.slice(1, -1), font: "Consolas", size: 19, ...base }));
+    else runs.push(new TextRun({ text: t.slice(1, -1), italics: true, ...base }));
+    last = re.lastIndex;
+  }
+  if (last < text.length) runs.push(new TextRun({ text: text.slice(last), ...base }));
+  if (!runs.length) runs.push(new TextRun({ text: "", ...base }));
+  return runs;
+}
+
+// ---- block parser ----
+if (!fs.existsSync(SRC)) {
+  console.error("ERROR: source file not found:", SRC);
+  process.exit(1);
+}
+const lines = fs.readFileSync(SRC, "utf8").replace(/\r\n/g, "\n").split("\n");
+const blocks = [];
+let i = 0;
+function lastBlock() { return blocks[blocks.length - 1]; }
+while (i < lines.length) {
+  const ln = lines[i];
+  const t = ln.trim();
+  if (/^#{1,3}\s/.test(t)) {
+    const level = t.match(/^#+/)[0].length;
+    blocks.push({ type: "h", level, text: t.replace(/^#+\s/, "") });
+    i++; continue;
+  }
+  if (t === "---") { blocks.push({ type: "hr" }); i++; continue; }
+  if (t === "") { blocks.push({ type: "blank" }); i++; continue; }
+  if (t.startsWith(">")) {
+    const buf = [];
+    while (i < lines.length && lines[i].trim().startsWith(">")) {
+      buf.push(lines[i].trim().replace(/^>\s?/, "")); i++;
+    }
+    blocks.push({ type: "note", text: buf.join(" ").replace(/\s+/g, " ").trim() });
+    continue;
+  }
+  if (t.startsWith("|")) {
+    const rows = [];
+    while (i < lines.length && lines[i].trim().startsWith("|")) {
+      const cells = lines[i].trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map(c => c.trim());
+      // Skip Markdown table separator row (|---|---|, |:---|---:|, …) —
+      // it is alignment metadata, not a data row; the previous parser
+      // pushed it and Word rendered a literal "---" row.
+      const isSep = cells.length > 0 && cells.every(c => /^:?-+:?$/.test(c));
+      if (!isSep) rows.push(cells);
+      i++;
+    }
+    blocks.push({ type: "table", rows });
+    continue;
+  }
+  if (t.startsWith("- ")) {
+    let txt = t.slice(2);
+    i++;
+    while (i < lines.length && /^\s{2,}\S/.test(lines[i])) { txt += " " + lines[i].trim(); i++; }
+    const lb = lastBlock();
+    if (lb && lb.type === "list") lb.items.push(txt);
+    else blocks.push({ type: "list", items: [txt] });
+    continue;
+  }
+  // normal paragraph (join wrapped lines until blank / marker)
+  let txt = t;
+  i++;
+  while (i < lines.length) {
+    const nx = lines[i], nt = nx.trim();
+    if (nt === "" || nt === "---" || /^#{1,3}\s/.test(nt) || nt.startsWith("|") || nt.startsWith(">") || nt.startsWith("- ")) break;
+    txt += " " + nt; i++;
+  }
+  blocks.push({ type: "p", text: txt });
+}
+
+// ---- render ----
+const border = { style: BorderStyle.SINGLE, size: 1, color: "BFBFBF" };
+const borders = { top: border, bottom: border, left: border, right: border,
+  insideHorizontal: border, insideVertical: border };
+const colWidths = (n) => {
+  if (n === 2) return [2400, 6960];
+  if (n === 4) return [1000, 2790, 3570, 2000];
+  if (n === 5) return [560, 3960, 560, 1480, 2800];
+  const w = Math.floor(CONTENT_W / n); return Array(n).fill(w);
+};
+
+// Cell-shading colour by row (header = dark blue) and, for non-header
+// cells, by verdict-keyword detection. Patterns are checked in order:
+// conditional "only if" must win over the plain green case.
+function cellFill(r, cell) {
+  if (r === 0) return "1F3B5B"; // header dark blue
+  const lc = cell.toLowerCase();
+  // English verdict keywords
+  if (/do not pursue/.test(lc)) return "F4DEDE";          // light red
+  if (/worth pursuing/.test(lc) && /only if/.test(lc)) return "FFF4D6"; // light yellow
+  if (/worth pursuing/.test(lc)) return "E2F0DA";         // light green
+  if (/not assessed/.test(lc)) return "EEEEEE";           // light grey
+  // zh-TW verdict keywords (toLowerCase is a no-op on CJK so cell is raw)
+  if (/不予推進/.test(cell)) return "F4DEDE";              // light red
+  if (/值得推進/.test(cell) && /只|須|待決|條件/.test(cell)) return "FFF4D6"; // light yellow
+  if (/值得推進/.test(cell)) return "E2F0DA";              // light green
+  if (/未評估/.test(cell)) return "EEEEEE";                // light grey
+  return "FFFFFF";                                         // default white
+}
+
+function mkTable(rows) {
+  const n = rows[0].length;
+  const cw = colWidths(n);
+  return new Table({
+    width: { size: CONTENT_W, type: WidthType.DXA },
+    columnWidths: cw,
+    rows: rows.map((cells, r) => new TableRow({
+      tableHeader: r === 0,
+      children: cells.map((cell, c) => new TableCell({
+        borders,
+        width: { size: cw[c], type: WidthType.DXA },
+        shading: { fill: cellFill(r, cell), type: ShadingType.CLEAR },
+        margins: { top: 70, bottom: 70, left: 110, right: 110 },
+        children: [new Paragraph({
+          spacing: { before: 20, after: 20 },
+          children: parseInline(cell, r === 0 ? { bold: true, color: "FFFFFF", size: 19 } : { size: 19 }),
+        })],
+      })),
+    })),
+  });
+}
+
+const children = [];
+let tocInserted = false;
+for (const b of blocks) {
+  if (b.type === "blank" || b.type === "hr") continue;
+  if (b.type === "h") {
+    const hl = b.level === 1 ? HeadingLevel.HEADING_1 : b.level === 2 ? HeadingLevel.HEADING_2 : HeadingLevel.HEADING_3;
+    children.push(new Paragraph({ heading: hl, children: parseInline(b.text) }));
+  } else if (b.type === "note") {
+    children.push(new Paragraph({
+      spacing: { before: 60, after: 120 },
+      indent: { left: 360 },
+      border: { left: { style: BorderStyle.SINGLE, size: 12, color: "B0B0B0", space: 12 } },
+      children: parseInline(b.text, { italics: true, color: "5A5A5A", size: 19 }),
+    }));
+  } else if (b.type === "p") {
+    children.push(new Paragraph({ spacing: { before: 80, after: 80 }, children: parseInline(b.text) }));
+  } else if (b.type === "list") {
+    for (const it of b.items) {
+      children.push(new Paragraph({
+        numbering: { reference: "bullets", level: 0 },
+        spacing: { before: 40, after: 40 },
+        children: parseInline(it),
+      }));
+    }
+  } else if (b.type === "table") {
+    children.push(new Paragraph({ spacing: { before: 80, after: 80 }, children: [] }));
+    children.push(mkTable(b.rows));
+    children.push(new Paragraph({ spacing: { after: 80 }, children: [] }));
+    if (!tocInserted && !NOTOC) {
+      tocInserted = true;
+      children.push(new Paragraph({ pageBreakBefore: true, heading: HeadingLevel.HEADING_2,
+        children: [new TextRun("Contents")] }));
+      children.push(new TableOfContents("Table of Contents", { hyperlink: true, headingStyleRange: "1-3" }));
+      children.push(new Paragraph({ children: [new PageBreak()] }));
+    }
+  }
+}
+
+const doc = new Document({
+  styles: {
+    default: { document: { run: { font: FONT, size: 22 } } },
+    paragraphStyles: [
+      { id: "Heading1", name: "Heading 1", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 34, bold: true, font: FONT, color: "1F3B5B" },
+        paragraph: { spacing: { before: 240, after: 200 }, outlineLevel: 0 } },
+      { id: "Heading2", name: "Heading 2", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 27, bold: true, font: FONT, color: "1F3B5B" },
+        paragraph: { spacing: { before: 260, after: 120 }, outlineLevel: 1 } },
+      { id: "Heading3", name: "Heading 3", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 23, bold: true, font: FONT, color: "2E2E2E" },
+        paragraph: { spacing: { before: 160, after: 60 }, outlineLevel: 2 } },
+    ],
+  },
+  numbering: {
+    config: [
+      { reference: "bullets",
+        levels: [{ level: 0, format: LevelFormat.BULLET, text: "•", alignment: AlignmentType.LEFT,
+          style: { paragraph: { indent: { left: 420, hanging: 280 } } } }] },
+    ],
+  },
+  sections: [{
+    properties: {
+      page: {
+        size: { width: 12240, height: 15840 },
+        margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 },
+      },
+    },
+    children,
+  }],
+});
+
+Packer.toBuffer(doc).then(buf => {
+  fs.writeFileSync(OUT, buf);
+  console.log("WROTE", OUT, buf.length, "bytes");
+}).catch(err => {
+  console.error("ERROR generating docx:", err.message);
+  process.exit(1);
+});

--- a/src/research_hub/skills_data/research-design-helper/SKILL.md
+++ b/src/research_hub/skills_data/research-design-helper/SKILL.md
@@ -96,6 +96,34 @@ After saving, print a short report:
   Suggested next: refine the validation baseline, then re-run with "regenerate from scratch" to lock the brief.
 ```
 
+## Generate .docx (optional, plugin v0.3.14+)
+
+After writing `.research/design_brief.md`, an **optional** Word version
+can be generated via the sister script at
+`scripts/brief_to_docx.js`. The `.docx` is a convenience for sharing the
+brief with advisors / committee members who prefer Word — it is NOT
+part of the contracted Stage 3a output and is not consumed by
+downstream skills (Stage 3b reads `design_brief.md` frontmatter + §1
+directly).
+
+```bash
+# From the directory that contains design_brief.md:
+node /path/to/skills/research-design-helper/scripts/brief_to_docx.js design_brief --no-toc
+
+# zh-TW variant (auto-selects Microsoft JhengHei):
+node /path/to/skills/research-design-helper/scripts/brief_to_docx.js design_brief.zh-TW --no-toc
+```
+
+Prerequisite: `npm install -g docx` (one-time). The `--no-toc` flag is
+recommended for design briefs — they're typically short enough that
+Word's auto-generated empty TOC field is more distracting than useful.
+
+The script is a near-byte copy of the `gap-to-topic`
+`scripts/dossier_to_docx.js` generator (same Markdown → Word logic,
+same font auto-selection, same separator-row skip). The dossier's
+verdict-colour regex is inherited verbatim but does not fire on design
+brief content — see `scripts/README.md` for the rationale.
+
 ## Token-saving behavior
 
 - Don't repeat the user's answers back at length — quote in the written brief, summarize one sentence in chat.

--- a/src/research_hub/skills_data/research-design-helper/scripts/README.md
+++ b/src/research_hub/skills_data/research-design-helper/scripts/README.md
@@ -1,0 +1,82 @@
+# scripts/brief_to_docx.js
+
+Convert a `research-design-helper` design brief Markdown file into a styled
+Word document (.docx) using `docx` 9.x.
+
+This is the **sister script** to
+`skills/gap-to-topic/scripts/dossier_to_docx.js` — same Markdown → Word
+converter, but the default stem is `design_brief` (the Stage 3a artifact)
+instead of `topic_dossier` (the Stage 2 artifact). The two scripts share
+the same internal logic so a single fix lands in both via parallel PRs.
+
+## What it produces
+
+A `.docx` file alongside the source `.md` with:
+
+- Heading styles (H1 navy, H2 navy, H3 dark grey) using the auto-selected font
+- Bullet lists via a numbering reference (not a unicode glyph)
+- Tables with dual-width DXA column sizing (the design brief §5 risk
+  register renders cleanly as a 4-column table)
+- Table separator rows (`|---|---|`) skipped — they do not appear as
+  "---" cells in Word
+- Optional Table of Contents + page break inserted after the first table
+  (omit with `--no-toc` for short docs where Word's empty TOC field is
+  distracting — recommended for `design_brief.md` which has only 5
+  sections)
+
+The verdict-colour coding regex (light red / yellow / green / grey
+on scorecard / verdict cells) is inherited from `dossier_to_docx.js`
+verbatim. It does NOT fire on `design_brief.md` content (no "Do not
+pursue" / "Not assessed" / "不予推進" / "未評估" strings appear in a
+design brief), which is the correct no-op behaviour. Leaving the
+regex in keeps the two scripts byte-near-identical so future maintenance
+patches land in parallel.
+
+Font auto-selection: if the filename contains `.zh`, `zh-`, `zh_`, `-tw`, or
+`-cn` (case-insensitive), the document body uses **Microsoft JhengHei**;
+otherwise **Arial**.
+
+## Prerequisite
+
+Install the `docx` npm package before running the script:
+
+```
+# Global install (available everywhere):
+npm install -g docx
+
+# Local install (available only from the scripts/ directory):
+cd scripts && npm install docx
+```
+
+If `docx` is not installed, Node.js will throw a `Cannot find module 'docx'`
+error when the script is run. Install it and re-run.
+
+## Invocation
+
+Run from the directory that contains your `design_brief.md` (typically
+`.research/`):
+
+```bash
+# English brief (Arial font, no TOC recommended for short docs):
+node /path/to/skills/research-design-helper/scripts/brief_to_docx.js design_brief --no-toc
+
+# zh-TW brief (JhengHei font auto-selected by filename):
+node /path/to/skills/research-design-helper/scripts/brief_to_docx.js design_brief.zh-TW --no-toc
+
+# Absolute path (writes .docx alongside the .md):
+node brief_to_docx.js /abs/path/to/.research/design_brief
+```
+
+The output `.docx` is written to the same directory as the `.md` file.
+
+## Integration in the research-design-helper workflow
+
+`design_brief.md` is the canonical Stage 3a artifact and remains the
+primary deliverable. The `.docx` is an **optional convenience** for
+sharing with advisors / committee members who prefer Word over Markdown
+— it is NOT part of the contracted output and is not consumed by
+downstream skills (Stage 3b reads the `.md` frontmatter + section 1
+directly).
+
+See SKILL.md `## Generate .docx (optional)` for the post-processing
+step.

--- a/src/research_hub/skills_data/research-design-helper/scripts/brief_to_docx.js
+++ b/src/research_hub/skills_data/research-design-helper/scripts/brief_to_docx.js
@@ -1,0 +1,272 @@
+// brief_to_docx.js — convert a research-design-helper design_brief (.md) to a styled Word document (.docx)
+//
+// Sister script to skills/gap-to-topic/scripts/dossier_to_docx.js — same
+// Markdown → Word converter, default stem "design_brief" (Stage 3a artifact)
+// instead of "topic_dossier" (Stage 2 artifact). The verdict-colour regex
+// is kept verbatim from the dossier generator; it simply doesn't fire on
+// design_brief content (no "Do not pursue" / "Not assessed" strings),
+// which is the correct no-op behaviour.
+//
+// Prerequisite: npm install -g docx   (or: cd scripts && npm install docx  for local)
+//
+// Usage:
+//   node brief_to_docx.js [stem-or-path] [--no-toc]
+//
+//   stem-or-path  Stem name ("design_brief") relative to cwd, OR an absolute path
+//                 (with or without .md/.docx extension — the script adds them).
+//                 Default: "design_brief"
+//   --no-toc      Skip the Table of Contents field (avoid empty Word TOC on short docs).
+//
+// Examples:
+//   node brief_to_docx.js design_brief --no-toc
+//   node brief_to_docx.js /abs/path/to/en/design_brief
+//   node brief_to_docx.js design_brief.zh-TW   (triggers JhengHei font)
+//
+// Font auto-selection:
+//   filename matches /.zh|zh-|zh_|-tw|-cn/i  -> Microsoft JhengHei
+//   otherwise                                 -> Arial
+//
+// Verdict colour coding inherited from dossier_to_docx.js (cells in
+// scorecards / verdict cards — does NOT fire on design_brief content):
+//   "Do not pursue" / "不予推進"              -> light red   (#F4DEDE)
+//   "Worth pursuing … only if" / conditional  -> light yellow (#FFF4D6)
+//   "Worth pursuing" (unconditional)          -> light green  (#E2F0DA)
+//   "Not assessed" / "未評估"                 -> light grey   (#EEEEEE)
+//   All other cells                           -> white
+
+const fs = require("fs");
+const path = require("path");
+const {
+  Document, Packer, Paragraph, TextRun, Table, TableRow, TableCell,
+  AlignmentType, LevelFormat, TableOfContents, HeadingLevel, BorderStyle,
+  WidthType, ShadingType, PageBreak,
+} = require("docx");
+
+// ---- argument parsing ----
+const NOTOC = process.argv.includes("--no-toc");
+const ARG = process.argv.slice(2).find((a) => !a.startsWith("--")) || "design_brief";
+
+// Strip .md or .docx extension if provided so we work from the bare stem
+const stem = ARG.replace(/\.(md|docx)$/i, "");
+
+// Font: detect Chinese filename pattern
+const FONT = /\.zh|zh-|zh_|-tw|-cn/i.test(stem) ? "Microsoft JhengHei" : "Arial";
+
+// Resolve source (.md) and output (.docx) paths.
+// If the stem is absolute (contains a path separator), write alongside it.
+// Otherwise resolve relative to process.cwd() so the script works from any directory.
+const isAbs = path.isAbsolute(stem) || stem.includes("/") || stem.includes("\\");
+const SRC = isAbs ? path.resolve(stem + ".md") : path.resolve(process.cwd(), stem + ".md");
+const OUT = isAbs ? path.resolve(stem + ".docx") : path.resolve(process.cwd(), stem + ".docx");
+
+const CONTENT_W = 9360;
+
+// ---- inline markdown -> TextRun[] ----
+function parseInline(text, base = {}) {
+  const runs = [];
+  const re = /(\*\*[^*]+\*\*|`[^`]+`|\*[^*]+\*)/g;
+  let last = 0, m;
+  while ((m = re.exec(text))) {
+    if (m.index > last) runs.push(new TextRun({ text: text.slice(last, m.index), ...base }));
+    const t = m[0];
+    if (t.startsWith("**")) runs.push(new TextRun({ text: t.slice(2, -2), bold: true, ...base }));
+    else if (t.startsWith("`")) runs.push(new TextRun({ text: t.slice(1, -1), font: "Consolas", size: 19, ...base }));
+    else runs.push(new TextRun({ text: t.slice(1, -1), italics: true, ...base }));
+    last = re.lastIndex;
+  }
+  if (last < text.length) runs.push(new TextRun({ text: text.slice(last), ...base }));
+  if (!runs.length) runs.push(new TextRun({ text: "", ...base }));
+  return runs;
+}
+
+// ---- block parser ----
+if (!fs.existsSync(SRC)) {
+  console.error("ERROR: source file not found:", SRC);
+  process.exit(1);
+}
+const lines = fs.readFileSync(SRC, "utf8").replace(/\r\n/g, "\n").split("\n");
+const blocks = [];
+let i = 0;
+function lastBlock() { return blocks[blocks.length - 1]; }
+while (i < lines.length) {
+  const ln = lines[i];
+  const t = ln.trim();
+  if (/^#{1,3}\s/.test(t)) {
+    const level = t.match(/^#+/)[0].length;
+    blocks.push({ type: "h", level, text: t.replace(/^#+\s/, "") });
+    i++; continue;
+  }
+  if (t === "---") { blocks.push({ type: "hr" }); i++; continue; }
+  if (t === "") { blocks.push({ type: "blank" }); i++; continue; }
+  if (t.startsWith(">")) {
+    const buf = [];
+    while (i < lines.length && lines[i].trim().startsWith(">")) {
+      buf.push(lines[i].trim().replace(/^>\s?/, "")); i++;
+    }
+    blocks.push({ type: "note", text: buf.join(" ").replace(/\s+/g, " ").trim() });
+    continue;
+  }
+  if (t.startsWith("|")) {
+    const rows = [];
+    while (i < lines.length && lines[i].trim().startsWith("|")) {
+      const cells = lines[i].trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map(c => c.trim());
+      // Skip Markdown table separator row (|---|---|, |:---|---:|, …) —
+      // it is alignment metadata, not a data row; the previous parser
+      // pushed it and Word rendered a literal "---" row.
+      const isSep = cells.length > 0 && cells.every(c => /^:?-+:?$/.test(c));
+      if (!isSep) rows.push(cells);
+      i++;
+    }
+    blocks.push({ type: "table", rows });
+    continue;
+  }
+  if (t.startsWith("- ")) {
+    let txt = t.slice(2);
+    i++;
+    while (i < lines.length && /^\s{2,}\S/.test(lines[i])) { txt += " " + lines[i].trim(); i++; }
+    const lb = lastBlock();
+    if (lb && lb.type === "list") lb.items.push(txt);
+    else blocks.push({ type: "list", items: [txt] });
+    continue;
+  }
+  // normal paragraph (join wrapped lines until blank / marker)
+  let txt = t;
+  i++;
+  while (i < lines.length) {
+    const nx = lines[i], nt = nx.trim();
+    if (nt === "" || nt === "---" || /^#{1,3}\s/.test(nt) || nt.startsWith("|") || nt.startsWith(">") || nt.startsWith("- ")) break;
+    txt += " " + nt; i++;
+  }
+  blocks.push({ type: "p", text: txt });
+}
+
+// ---- render ----
+const border = { style: BorderStyle.SINGLE, size: 1, color: "BFBFBF" };
+const borders = { top: border, bottom: border, left: border, right: border,
+  insideHorizontal: border, insideVertical: border };
+const colWidths = (n) => {
+  if (n === 2) return [2400, 6960];
+  if (n === 4) return [1000, 2790, 3570, 2000];
+  if (n === 5) return [560, 3960, 560, 1480, 2800];
+  const w = Math.floor(CONTENT_W / n); return Array(n).fill(w);
+};
+
+// Cell-shading colour by row (header = dark blue) and, for non-header
+// cells, by verdict-keyword detection. Patterns are checked in order:
+// conditional "only if" must win over the plain green case.
+function cellFill(r, cell) {
+  if (r === 0) return "1F3B5B"; // header dark blue
+  const lc = cell.toLowerCase();
+  // English verdict keywords
+  if (/do not pursue/.test(lc)) return "F4DEDE";          // light red
+  if (/worth pursuing/.test(lc) && /only if/.test(lc)) return "FFF4D6"; // light yellow
+  if (/worth pursuing/.test(lc)) return "E2F0DA";         // light green
+  if (/not assessed/.test(lc)) return "EEEEEE";           // light grey
+  // zh-TW verdict keywords (toLowerCase is a no-op on CJK so cell is raw)
+  if (/不予推進/.test(cell)) return "F4DEDE";              // light red
+  if (/值得推進/.test(cell) && /只|須|待決|條件/.test(cell)) return "FFF4D6"; // light yellow
+  if (/值得推進/.test(cell)) return "E2F0DA";              // light green
+  if (/未評估/.test(cell)) return "EEEEEE";                // light grey
+  return "FFFFFF";                                         // default white
+}
+
+function mkTable(rows) {
+  const n = rows[0].length;
+  const cw = colWidths(n);
+  return new Table({
+    width: { size: CONTENT_W, type: WidthType.DXA },
+    columnWidths: cw,
+    rows: rows.map((cells, r) => new TableRow({
+      tableHeader: r === 0,
+      children: cells.map((cell, c) => new TableCell({
+        borders,
+        width: { size: cw[c], type: WidthType.DXA },
+        shading: { fill: cellFill(r, cell), type: ShadingType.CLEAR },
+        margins: { top: 70, bottom: 70, left: 110, right: 110 },
+        children: [new Paragraph({
+          spacing: { before: 20, after: 20 },
+          children: parseInline(cell, r === 0 ? { bold: true, color: "FFFFFF", size: 19 } : { size: 19 }),
+        })],
+      })),
+    })),
+  });
+}
+
+const children = [];
+let tocInserted = false;
+for (const b of blocks) {
+  if (b.type === "blank" || b.type === "hr") continue;
+  if (b.type === "h") {
+    const hl = b.level === 1 ? HeadingLevel.HEADING_1 : b.level === 2 ? HeadingLevel.HEADING_2 : HeadingLevel.HEADING_3;
+    children.push(new Paragraph({ heading: hl, children: parseInline(b.text) }));
+  } else if (b.type === "note") {
+    children.push(new Paragraph({
+      spacing: { before: 60, after: 120 },
+      indent: { left: 360 },
+      border: { left: { style: BorderStyle.SINGLE, size: 12, color: "B0B0B0", space: 12 } },
+      children: parseInline(b.text, { italics: true, color: "5A5A5A", size: 19 }),
+    }));
+  } else if (b.type === "p") {
+    children.push(new Paragraph({ spacing: { before: 80, after: 80 }, children: parseInline(b.text) }));
+  } else if (b.type === "list") {
+    for (const it of b.items) {
+      children.push(new Paragraph({
+        numbering: { reference: "bullets", level: 0 },
+        spacing: { before: 40, after: 40 },
+        children: parseInline(it),
+      }));
+    }
+  } else if (b.type === "table") {
+    children.push(new Paragraph({ spacing: { before: 80, after: 80 }, children: [] }));
+    children.push(mkTable(b.rows));
+    children.push(new Paragraph({ spacing: { after: 80 }, children: [] }));
+    if (!tocInserted && !NOTOC) {
+      tocInserted = true;
+      children.push(new Paragraph({ pageBreakBefore: true, heading: HeadingLevel.HEADING_2,
+        children: [new TextRun("Contents")] }));
+      children.push(new TableOfContents("Table of Contents", { hyperlink: true, headingStyleRange: "1-3" }));
+      children.push(new Paragraph({ children: [new PageBreak()] }));
+    }
+  }
+}
+
+const doc = new Document({
+  styles: {
+    default: { document: { run: { font: FONT, size: 22 } } },
+    paragraphStyles: [
+      { id: "Heading1", name: "Heading 1", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 34, bold: true, font: FONT, color: "1F3B5B" },
+        paragraph: { spacing: { before: 240, after: 200 }, outlineLevel: 0 } },
+      { id: "Heading2", name: "Heading 2", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 27, bold: true, font: FONT, color: "1F3B5B" },
+        paragraph: { spacing: { before: 260, after: 120 }, outlineLevel: 1 } },
+      { id: "Heading3", name: "Heading 3", basedOn: "Normal", next: "Normal", quickFormat: true,
+        run: { size: 23, bold: true, font: FONT, color: "2E2E2E" },
+        paragraph: { spacing: { before: 160, after: 60 }, outlineLevel: 2 } },
+    ],
+  },
+  numbering: {
+    config: [
+      { reference: "bullets",
+        levels: [{ level: 0, format: LevelFormat.BULLET, text: "•", alignment: AlignmentType.LEFT,
+          style: { paragraph: { indent: { left: 420, hanging: 280 } } } }] },
+    ],
+  },
+  sections: [{
+    properties: {
+      page: {
+        size: { width: 12240, height: 15840 },
+        margin: { top: 1440, right: 1440, bottom: 1440, left: 1440 },
+      },
+    },
+    children,
+  }],
+});
+
+Packer.toBuffer(doc).then(buf => {
+  fs.writeFileSync(OUT, buf);
+  console.log("WROTE", OUT, buf.length, "bytes");
+}).catch(err => {
+  console.error("ERROR generating docx:", err.message);
+  process.exit(1);
+});

--- a/tests/test_handoff_gap_to_topic_design_helper.py
+++ b/tests/test_handoff_gap_to_topic_design_helper.py
@@ -299,6 +299,48 @@ def test_context_compressor_skill_md_outputs_show_provenance_from_gap() -> None:
     )
 
 
+def test_design_helper_has_brief_to_docx_script_and_skill_md_section() -> None:
+    """v0.3.14 (F4 fast-follow): research-design-helper ships
+    `scripts/brief_to_docx.js` as the sister generator to
+    gap-to-topic's `scripts/dossier_to_docx.js`. The .docx is an
+    optional convenience for human review (not contracted output).
+    """
+    script_path = (
+        REPO_ROOT / "skills" / "research-design-helper" / "scripts" / "brief_to_docx.js"
+    )
+    assert script_path.exists(), (
+        "research-design-helper/scripts/brief_to_docx.js missing — "
+        "v0.3.14 F4 ship contract broken"
+    )
+    # Default stem must be design_brief, not the dossier sibling's default
+    script_text = script_path.read_text(encoding="utf-8")
+    assert '|| "design_brief"' in script_text, (
+        "brief_to_docx.js default stem is not `design_brief` — copy "
+        "from dossier_to_docx.js was incomplete (forgot to change the "
+        "fallback in the ARG line)"
+    )
+    # SKILL.md gains the optional .docx section
+    skill_text = DESIGN_HELPER_SKILL.read_text(encoding="utf-8")
+    assert "## Generate .docx (optional" in skill_text, (
+        "research-design-helper SKILL.md missing the `## Generate .docx "
+        "(optional ...)` section that documents brief_to_docx.js usage"
+    )
+    # Mirror parity check (skills_data/ has the same script)
+    mirror_path = (
+        REPO_ROOT
+        / "src"
+        / "research_hub"
+        / "skills_data"
+        / "research-design-helper"
+        / "scripts"
+        / "brief_to_docx.js"
+    )
+    assert mirror_path.exists(), (
+        "Mirror `src/research_hub/skills_data/research-design-helper/"
+        "scripts/brief_to_docx.js` missing — version-sync test will fail"
+    )
+
+
 def test_design_helper_skill_md_segment_1_no_prefill_annotation_rule() -> None:
     """v0.3.13 (F2 fast-follow): §0 must explicitly forbid writing a
     `_PRE-FILL_`-style annotation inside the design_brief.md file


### PR DESCRIPTION
Closes F4 from the v0.3.12 dogfood VERIFICATION — `design_brief.md` can now be converted to Word for advisor / committee review.

## What ships

Sister script to `skills/gap-to-topic/scripts/dossier_to_docx.js` — same Markdown → Word converter, but default stem is `design_brief` instead of `topic_dossier`. The two scripts share internal logic so future fixes can land in parallel.

| File | Notes |
|---|---|
| `skills/research-design-helper/scripts/brief_to_docx.js` | NEW. Near-byte copy of `dossier_to_docx.js` with header rewritten + default stem changed. |
| `skills/research-design-helper/scripts/README.md` | NEW. Prereq (`npm install -g docx`) + invocation examples (en + zh-TW) + the regex-no-op rationale. |
| `skills/research-design-helper/SKILL.md` | Adds `## Generate .docx (optional, plugin v0.3.14+)` section between `## Output` and `## Token-saving behavior`. |
| `src/research_hub/skills_data/...` × 3 | Byte-identical mirrors. |
| `.claude-plugin/plugin.json` | `0.3.13 → 0.3.14`. |
| `CHANGELOG.md` | `### Added` entry. |
| `tests/test_handoff_gap_to_topic_design_helper.py` | New test asserting script exists + default stem is `design_brief` + SKILL.md has the optional .docx section + mirror parity. |

## Not part of the contracted Stage 3a output

`design_brief.md` remains the canonical artifact. The `.docx` is an **optional convenience** for human consumption only. Downstream skills (Stage 3b `research-context-compressor`) read the `.md` frontmatter + section 1 directly, not the `.docx`.

## Verdict-colour regex inherited verbatim — does NOT fire on design brief content

No `"Do not pursue"` / `"Not assessed"` / `"不予推進"` / `"未評估"` strings appear in a design brief. Keeping the regex unchanged means a single fix to the dossier generator can land in both scripts via parallel PRs.

## Validation

| Check | Result |
|---|---|
| `pytest tests/test_handoff_gap_to_topic_design_helper.py tests/test_v068_3_version_sync.py -q` | **20/20** passed |
| `diff -rq skills/ src/research_hub/skills_data/` | clean |
| **End-to-end dogfood** | Copied script to the v0.3.12 dogfood `.research/` dir, ran on real `design_brief.md`, produced **13943-byte `design_brief.docx`** with no errors. Script-functional verified end-to-end on real Stage 3a output. |

## Codex review

Independent codex review (`.ai/codex_eval_report.md`) verdict: **ship-with-fixes** — fixes are doc-quality / adoption-safety, NOT blockers for this PR. Codex's specific suggestions (C1 examples.md, C2 multi-eligible fixture, C4 placeholder warning) are queued for v0.3.15 + the catalog propagation PR.

## Next

- v0.3.15: codex C2 (multi-eligible fixture exercising the 2+ branch) + C4 (design_brief template placeholder warning).
- Catalog 1.5.15 → 1.5.16: bundled propagation of v0.3.13 + v0.3.14 + codex C1 (examples.md `Not assessed` row label fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)