### PR TITLE
fix(skill): codex review tightenings — C2 multi-eligible fixture + C4 placeholder marker (plugin 0.3.14 → 0.3.15)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,45 @@ graph rebuild (link out to the real tools instead)._
   `src/research_hub/skills_data/gap-to-topic/scripts/`.
 
 ### Fixed
+- **Codex review tightenings — multi-eligible fixture + design_brief
+  placeholder marker** (`tests/fixtures/topic_dossier_multi_eligible_sample.gaps.yml`,
+  `skills/research-design-helper/references/design_brief_template.md`,
+  `skills/research-design-helper/SKILL.md`,
+  `tests/test_handoff_gap_to_topic_design_helper.py`, plugin
+  `0.3.14 → 0.3.15`). Two follow-ups from the independent Codex
+  evaluation of the v0.3.12 + v0.3.13 + v0.3.14 deliverables
+  (`.ai/codex_eval_report.md`, verdict ship-with-fixes):
+  - **C2 — multi-eligible fixture.** The §0 "2+ candidates, ask the
+    user" branch was documented in SKILL.md and verified by the
+    branch-coverage prose test, but never exercised against a real
+    fixture with multiple `verdict ∈ {conditional-go, go}` entries.
+    New synthetic fixture
+    `tests/fixtures/topic_dossier_multi_eligible_sample.gaps.yml`
+    ships 3 gaps (G1 conditional-go, G2 conditional-go, G3 no-go) so
+    the filter produces 2 eligibles. Two new tests:
+    (a) `test_multi_eligible_fixture_parses_and_has_2plus_go_eligible`
+    asserts the fixture's filter result keeps the 2+ branch
+    exercised (guards against fixture decay), and (b) a
+    parametrized `test_fixture_parses_and_drives_correct_section_0_branch`
+    runs across both fixtures asserting each drives its expected §0
+    branch (auto-pre-fill vs ask-the-user). A future third fixture
+    for the zero-eligible halt branch can be added with one tuple.
+  - **C4 — design_brief placeholder marker.** The v0.3.12 dogfood
+    filled segments 2–4 with test-fit placeholder content (not from
+    real Socratic dialog) and used an ad-hoc `_TEST-FIT-PLACEHOLDER_`
+    inline tag. Codified as a structured frontmatter field:
+    `placeholder_segments: []` (list of segment numbers). Example:
+    `placeholder_segments: [2, 3, 4]` means segments 2–4 are
+    placeholders, downstream tools should refuse to gate real
+    research on a brief with non-empty list. SKILL.md adds a
+    "Placeholder marker (v0.3.15+)" paragraph in the Output section
+    explaining when to use it. New test
+    `test_design_brief_template_has_placeholder_segments_field`
+    asserts the frontmatter accepts the field.
+  - Pure additive: no removed fields, no changed enum tokens, no
+    behaviour change on absent/empty placeholder list. Mirrored to
+    `src/research_hub/skills_data/`.
+
 - **`research-context-compressor` Output spec shows
   `provenance.from_gap`; `research-design-helper` §0 forbids
   in-file pre-fill annotations** (`skills/research-context-compressor/SKILL.md`,

--- a/skills/research-design-helper/SKILL.md
+++ b/skills/research-design-helper/SKILL.md
@@ -85,6 +85,8 @@ If the file already exists, **update don't replace**: keep human-edited sections
 
 **Provenance protection (v0.3.12+).** If the existing `design_brief.md` has frontmatter `source: topic_dossier.gaps.yml#<old-id>` and a different `gaps[]` entry is now being chosen (different id, OR `.gaps.yml` `generated:` date differs), ASK the user before refreshing — do not silently overwrite provenance. Phrasing: *"This brief was originally framed for `<old-id>` (`<old-verdict>`). The current `.gaps.yml` chooses `<new-id>` (`<new-verdict>`). Refresh and replace the provenance, or keep the old brief and start a new one?"*
 
+**Placeholder marker (v0.3.15+).** When any segment is filled with **test-fit / dogfood placeholder content** (e.g. an AI-generated stub written to exercise the Stage 3a → 3b wire without a real Socratic dialog), record those segment numbers in the frontmatter `placeholder_segments:` list. Example: `placeholder_segments: [2, 3, 4]` means segments 2–4 are placeholders, not from the researcher's actual answers. **Downstream tools should refuse to gate real research on a brief with non-empty `placeholder_segments`.** When all 5 segments are filled by genuine Socratic dialog, leave the list empty (`[]`). This pattern was added after the v0.3.12 dogfood, where segments 2–4 were written as test-fit content to validate the wire — a future reader needs a machine-checkable signal that those segments aren't advisor-ready.
+
 After saving, print a short report:
 
 ```

--- a/skills/research-design-helper/references/design_brief_template.md
+++ b/skills/research-design-helper/references/design_brief_template.md
@@ -5,6 +5,11 @@ stage: design
 status: draft        # draft | reviewed | locked
 source: ""           # optional — Stage 2 provenance, e.g. `topic_dossier.gaps.yml#G2`
 gap_verdict: ""      # optional — frozen snapshot of <verdict> + first 60 chars of verdict_reason
+placeholder_segments: []   # optional — list of segment numbers whose content is test-fit / dogfood placeholder,
+                           #            NOT real Socratic dialog output. Example: [2, 3, 4] means segments 2-4
+                           #            were filled by AI-generated stubs for testing the wire, not by the
+                           #            researcher's actual answers. Downstream tools should refuse to gate
+                           #            real research on a brief with non-empty placeholder_segments.
 ---
 
 # Design brief

--- a/src/research_hub/skills_data/research-design-helper/SKILL.md
+++ b/src/research_hub/skills_data/research-design-helper/SKILL.md
@@ -85,6 +85,8 @@ If the file already exists, **update don't replace**: keep human-edited sections
 
 **Provenance protection (v0.3.12+).** If the existing `design_brief.md` has frontmatter `source: topic_dossier.gaps.yml#<old-id>` and a different `gaps[]` entry is now being chosen (different id, OR `.gaps.yml` `generated:` date differs), ASK the user before refreshing — do not silently overwrite provenance. Phrasing: *"This brief was originally framed for `<old-id>` (`<old-verdict>`). The current `.gaps.yml` chooses `<new-id>` (`<new-verdict>`). Refresh and replace the provenance, or keep the old brief and start a new one?"*
 
+**Placeholder marker (v0.3.15+).** When any segment is filled with **test-fit / dogfood placeholder content** (e.g. an AI-generated stub written to exercise the Stage 3a → 3b wire without a real Socratic dialog), record those segment numbers in the frontmatter `placeholder_segments:` list. Example: `placeholder_segments: [2, 3, 4]` means segments 2–4 are placeholders, not from the researcher's actual answers. **Downstream tools should refuse to gate real research on a brief with non-empty `placeholder_segments`.** When all 5 segments are filled by genuine Socratic dialog, leave the list empty (`[]`). This pattern was added after the v0.3.12 dogfood, where segments 2–4 were written as test-fit content to validate the wire — a future reader needs a machine-checkable signal that those segments aren't advisor-ready.
+
 After saving, print a short report:
 
 ```

--- a/src/research_hub/skills_data/research-design-helper/references/design_brief_template.md
+++ b/src/research_hub/skills_data/research-design-helper/references/design_brief_template.md
@@ -5,6 +5,11 @@ stage: design
 status: draft        # draft | reviewed | locked
 source: ""           # optional — Stage 2 provenance, e.g. `topic_dossier.gaps.yml#G2`
 gap_verdict: ""      # optional — frozen snapshot of <verdict> + first 60 chars of verdict_reason
+placeholder_segments: []   # optional — list of segment numbers whose content is test-fit / dogfood placeholder,
+                           #            NOT real Socratic dialog output. Example: [2, 3, 4] means segments 2-4
+                           #            were filled by AI-generated stubs for testing the wire, not by the
+                           #            researcher's actual answers. Downstream tools should refuse to gate
+                           #            real research on a brief with non-empty placeholder_segments.
 ---
 
 # Design brief

--- a/tests/fixtures/topic_dossier_multi_eligible_sample.gaps.yml
+++ b/tests/fixtures/topic_dossier_multi_eligible_sample.gaps.yml
@@ -1,0 +1,102 @@
+# Synthetic fixture — multi-eligible candidates exercise the §0
+# "2+ candidates, ask user" branch (codex C2, v0.3.15).
+#
+# Three gaps total:
+#   G1  → verdict: conditional-go   (eligible — counts toward filter)
+#   G2  → verdict: conditional-go   (eligible — counts toward filter)
+#   G3  → verdict: no-go            (filtered OUT)
+#
+# Filtered eligible-list length = 2, so research-design-helper §0
+# must hit the "ask the user which candidate are we designing for?"
+# branch instead of auto-pre-filling.
+#
+# This is synthetic (not from any real dogfood run) — the
+# topic is a plausible-sounding cross-domain example that does NOT
+# need to be defensible research, only to exercise the schema shape.
+
+dossier: "Synthetic multi-eligible scenario (LLM-augmented modelling)"
+generated: "2026-05-23"
+run_type: "synthetic fixture for codex C2 — §0 2+ candidates branch"
+downstream_consumer: research-design-helper
+recall:
+  tool: research-hub search --adversarial --screen --json
+  query_phrasings: 6
+  unique_papers: 200
+  tool_confidence: medium
+  dossier_confidence: medium
+  screen:
+    gate: fit-check BM25 relevance gate (search --screen)
+    retrieved: 30
+    kept: 28
+    screened_out: 2
+    tier: cold-start
+    note: synthetic — counts plausible, not from a real run
+  note: synthetic fixture, not a real dossier
+pipeline:
+  - research-hub search --adversarial --screen --json
+  - literature-triage-matrix -> literature_matrix.md
+  - .bib from on-topic search --json results
+  - gap-to-topic gates §1-§4
+gaps:
+  - id: G1
+    name: "LLM agents for forecasting in domain A"
+    statement: >-
+      Use LLM agents calibrated on domain-A observational data to predict
+      held-out outcomes; compare against a discrete-choice baseline.
+    type: B
+    open: open
+    open_confidence: medium
+    dead_end_status: partially-attempted
+    dead_end_evidence: >-
+      A 2025 caution paper raises construct-validity concerns for this
+      framing in adjacent domains.
+    contribution_type: borderline
+    borderline_reason: B1
+    feasibility: feasible-with-effort
+    verdict: conditional-go
+    verdict_reason: >-
+      Open (medium confidence); borderline contribution; feasible with a
+      held-out validation pilot against a discrete-choice baseline.
+    linked_claim: null
+  - id: G2
+    name: "LLM-augmented evidence synthesis for domain B"
+    statement: >-
+      Use LLMs to synthesise cross-paper evidence in domain B and flag
+      inconsistencies that human reviewers miss, validated against a
+      gold-standard human-annotated subset.
+    type: B
+    open: open
+    open_confidence: medium
+    dead_end_status: none
+    dead_end_evidence: ""
+    contribution_type: borderline
+    borderline_reason: B2
+    feasibility: feasible-with-effort
+    verdict: conditional-go
+    verdict_reason: >-
+      Open (medium confidence); borderline contribution; feasible with
+      access to a gold-standard human-annotated subset for validation.
+    linked_claim: null
+  - id: G3
+    name: "Generic LLM-as-judge for paper rankings"
+    statement: >-
+      Use LLM as judge to rank papers in domain C by quality.
+    type: B
+    open: occupied
+    dead_end_status: not-assessed
+    contribution_type: not-assessed
+    feasibility: not-assessed
+    verdict: no-go
+    verdict_reason: >-
+      Occupied — multiple existing benchmarks and validated rubrics make
+      this an established sub-field, not a research opening.
+    linked_claim: null
+open_questions:
+  - id: Q1
+    text: >-
+      For G1, is the domain-A observational dataset's held-out subset
+      large enough for adequate statistical power (>= 500 samples)?
+  - id: Q2
+    text: >-
+      For G2, does an existing human-annotated gold-standard subset exist
+      in domain B, or does this require primary annotation?

--- a/tests/test_handoff_gap_to_topic_design_helper.py
+++ b/tests/test_handoff_gap_to_topic_design_helper.py
@@ -36,6 +36,9 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURE = REPO_ROOT / "tests" / "fixtures" / "topic_dossier_sample.gaps.yml"
+FIXTURE_MULTI_ELIGIBLE = (
+    REPO_ROOT / "tests" / "fixtures" / "topic_dossier_multi_eligible_sample.gaps.yml"
+)
 DESIGN_HELPER_SKILL = (
     REPO_ROOT / "skills" / "research-design-helper" / "SKILL.md"
 )
@@ -296,6 +299,91 @@ def test_context_compressor_skill_md_outputs_show_provenance_from_gap() -> None:
     assert "from_gap" in outputs_section, (
         "Outputs section mentions `provenance` but not `from_gap` — "
         "the example block must show the full field path"
+    )
+
+
+def test_multi_eligible_fixture_parses_and_has_2plus_go_eligible() -> None:
+    """v0.3.15 (codex C2): the multi-eligible fixture exercises the §0
+    2+ candidates branch. Filtering to verdict ∈ {conditional-go, go}
+    must yield 2+ entries — otherwise the fixture has decayed and the
+    branch is once again unexercised.
+    """
+    assert FIXTURE_MULTI_ELIGIBLE.exists(), (
+        f"missing multi-eligible fixture: {FIXTURE_MULTI_ELIGIBLE}"
+    )
+    data = yaml.safe_load(FIXTURE_MULTI_ELIGIBLE.read_text(encoding="utf-8"))
+    go_eligible = [
+        g for g in data["gaps"] if g["verdict"] in {"conditional-go", "go"}
+    ]
+    assert len(go_eligible) >= 2, (
+        f"multi-eligible fixture has only {len(go_eligible)} go-eligible "
+        f"candidate(s); the §0 2+ branch is unexercised. Add another "
+        f"conditional-go or go entry."
+    )
+
+
+@pytest.mark.parametrize(
+    "fixture_path,expected_branch",
+    [
+        (
+            "topic_dossier_sample.gaps.yml",
+            "single-eligible-auto-prefill",
+        ),
+        (
+            "topic_dossier_multi_eligible_sample.gaps.yml",
+            "multi-eligible-ask-user",
+        ),
+    ],
+)
+def test_fixture_parses_and_drives_correct_section_0_branch(
+    fixture_path: str, expected_branch: str
+) -> None:
+    """v0.3.15 (codex C2): both fixtures parse cleanly AND drive
+    distinct §0 branches based on the count of go-eligible candidates
+    (conditional-go or go). Parametrized so a future third fixture
+    (e.g. all-no-go zero-eligible) can be added with one tuple
+    instead of a new test function.
+    """
+    path = REPO_ROOT / "tests" / "fixtures" / fixture_path
+    assert path.exists(), f"missing fixture: {path}"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    go_eligible = [
+        g for g in data["gaps"] if g["verdict"] in {"conditional-go", "go"}
+    ]
+    n = len(go_eligible)
+    if expected_branch == "single-eligible-auto-prefill":
+        assert n == 1, (
+            f"{fixture_path} should drive the auto-prefill branch "
+            f"(exactly 1 go-eligible) but has {n}"
+        )
+    elif expected_branch == "multi-eligible-ask-user":
+        assert n >= 2, (
+            f"{fixture_path} should drive the ask-the-user branch "
+            f"(2+ go-eligible) but has {n}"
+        )
+    elif expected_branch == "zero-eligible-halt":
+        assert n == 0, (
+            f"{fixture_path} should drive the halt branch "
+            f"(0 go-eligible) but has {n}"
+        )
+    else:
+        pytest.fail(f"unknown expected_branch: {expected_branch}")
+
+
+def test_design_brief_template_has_placeholder_segments_field() -> None:
+    """v0.3.15 (codex C4): design_brief frontmatter must accept an
+    optional `placeholder_segments:` field so test-fit / dogfood
+    placeholder content (segments filled by non-Socratic means) can be
+    machine-flagged. A future tool can detect briefs with a non-empty
+    list here and refuse to gate research on them.
+    """
+    text = DESIGN_HELPER_TEMPLATE.read_text(encoding="utf-8")
+    m = re.match(r"\A---\n(.*?)\n---\n", text, re.S)
+    assert m, "design_brief_template.md missing frontmatter"
+    frontmatter = m.group(1)
+    assert "placeholder_segments:" in frontmatter, (
+        "frontmatter missing `placeholder_segments:` — codex C4 "
+        "(placeholder warning pattern) not shipped"
     )
 
 


### PR DESCRIPTION
Two follow-ups from the independent codex evaluation of the v0.3.12 + v0.3.13 + v0.3.14 deliverables (`.ai/codex_eval_report.md`, verdict **ship-with-fixes**). Both are pure additive — no removed fields, no changed enum tokens.

## C2 — Multi-eligible fixture exercises the §0 2+ branch

The §0 "Filtered list has 2+ entries → ask the user" branch was documented in SKILL.md (v0.3.12) and verified by a prose branch-coverage test (v0.3.13), but **never run against a real fixture with multiple `verdict ∈ {conditional-go, go}` entries**.

**New synthetic fixture** `tests/fixtures/topic_dossier_multi_eligible_sample.gaps.yml` ships 3 gaps:

| ID | Verdict | Filter eligible? |
|---|---|---|
| G1 | `conditional-go` | ✓ |
| G2 | `conditional-go` | ✓ |
| G3 | `no-go` | ✗ (filtered out) |

Filter yields 2 eligibles → exercises the ask-the-user branch.

**Two new tests:**
1. `test_multi_eligible_fixture_parses_and_has_2plus_go_eligible` — asserts `len(filtered) >= 2`. Guards against fixture decay.
2. `test_fixture_parses_and_drives_correct_section_0_branch` — parametrized across BOTH fixtures, asserts each drives its expected §0 branch:
   - `topic_dossier_sample.gaps.yml` → `single-eligible-auto-prefill` (n == 1)
   - `topic_dossier_multi_eligible_sample.gaps.yml` → `multi-eligible-ask-user` (n >= 2)
   - Third zero-eligible halt branch is named in the elif chain — future zero-eligible fixture adds with one tuple.

## C4 — `design_brief.md` placeholder_segments frontmatter field

The v0.3.12 dogfood filled segments 2–4 with test-fit placeholder content (not from real Socratic dialog) using an ad-hoc `_TEST-FIT-PLACEHOLDER_` inline tag. **Codified as a structured frontmatter field:**

```yaml
placeholder_segments: []   # optional — list of segment numbers whose content is test-fit / dogfood placeholder
```

Example: `placeholder_segments: [2, 3, 4]` means segments 2–4 are placeholders. **Downstream tools should refuse to gate real research on a brief with non-empty list.**

SKILL.md adds a `## Placeholder marker (v0.3.15+)` paragraph in the Output section. Backwards-compatible: existing briefs without the field default to empty list (no placeholders), zero behaviour change.

New test `test_design_brief_template_has_placeholder_segments_field` asserts the frontmatter accepts the field.

## Validation

| Check | Result |
|---|---|
| `pytest tests/test_handoff_gap_to_topic_design_helper.py tests/test_v068_3_version_sync.py -v` | **24/24** passed (17→21 handoff cases + 3 version sync — the new parametrized test expands to 2 collected IDs) |
| `diff -rq skills/ src/research_hub/skills_data/` | clean |
| `git grep -nF "0.3.14"` outside CHANGELOG | 4 intentional `v0.3.14+` since-version markers (no stale current-version pointers) |
| code-reviewer subagent | APPROVE (W1 = pre-existing CHANGELOG `[Unreleased]` subsection order `Changed → Added → Fixed` violates Keep-a-Changelog `Added → Changed → Fixed`; not introduced by this PR; deferred as scope discipline) |

## Next (queued, blocked by this PR merge)

Catalog 1.5.16 propagation PR — bundles v0.3.13 + v0.3.14 + v0.3.15 in ai-research-skills marketplace; also addresses codex C1 (`docs/examples.md` verdict-shape table relabel `Not assessed` as gate-cell/status, not 4th candidate verdict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)