### PR TITLE
fix(skill): paper-memory-builder F-cross2 sentinel + F-cross3 evidence scanning (plugin 0.3.15 → 0.3.16)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "research-workspace",
   "description": "11 research-hub skills: literature triage matrix, context compression, project orientation, design dialog, multi-AI routing, NotebookLM brief verification, paper-memory builder, paper summarizer, Zotero curator, the gap-to-topic decision dossier, and the research-hub orchestrator. Auto-discovered from skills/<name>/SKILL.md.",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "author": {
     "name": "Wenyu Chiou"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,47 @@ graph rebuild (link out to the real tools instead)._
   `src/research_hub/skills_data/gap-to-topic/scripts/`.
 
 ### Fixed
+- **`paper-memory-builder` doc enhancements — F-cross2 figures.yml
+  sentinel + F-cross3 evidence-artifact scanning** (`skills/paper-memory-builder/SKILL.md`,
+  `skills/paper-memory-builder/references/yaml-schemas.md`,
+  `tests/test_handoff_gap_to_topic_design_helper.py`, plugin
+  `0.3.15 → 0.3.16`). Two small doc improvements surfaced by the
+  Stage 7-8 dogfood (`~/.claude/audits/dogfood_runs/2026-05-23-paper-memory-academic-writing-stage-7-8/VERIFICATION.md`):
+  - **F-cross2 — figures.yml `file:` sentinel values.** The schema
+    requires `figures[].file` (required field), but real-world
+    Word-based research workflows often have figures embedded
+    directly inside the `.docx` manuscript with no separable source
+    file. Adds a `### file: sentinel values (v0.3.16+)` section to
+    `references/yaml-schemas.md` documenting three sentinels:
+    `embedded-in-manuscript`, `embedded-in-supporting-information`,
+    `embedded-in-presentation`. Downstream consumers
+    (academic-writing-skills figure-text checks, future
+    figure-archive tooling) treat these as "present in manuscript,
+    no separable artifact to verify independently." Documented
+    limitation, not a permanent solution — future versions may add
+    a pre-processing step that extracts embedded figures.
+  - **F-cross3 — SKILL.md "Scanning the paper repo for evidence
+    artifacts" sub-section.** The previous Inputs section only
+    described figures + manifest files but real research repos
+    contain many non-figure evidence artifacts (simulation CSVs,
+    analysis scripts, drawio sources, reviewer-response artifacts).
+    The new sub-section documents typical artifact types and shows
+    an example of populating `claims[].evidence_artifacts` with
+    artifact PATHs for non-figure evidence (e.g. a chi-squared test
+    claim might cite an `outputs/llm-abm_decision_log.csv` + the
+    analysis script that ran it, in addition to the manuscript
+    anchor). Makes the audit trail end-to-end traceable.
+  - **Tests:** added 2 new test cases to
+    `test_handoff_gap_to_topic_design_helper.py`:
+    (1) `test_paper_memory_yaml_schemas_documents_file_sentinel_values`
+    asserts all 3 sentinels appear in `yaml-schemas.md`;
+    (2) `test_paper_memory_skill_md_documents_evidence_artifact_scanning`
+    asserts the SKILL.md Inputs section has the new sub-section AND
+    mentions at least 3 non-figure artifact types (Simulation,
+    Analysis scripts, Drawio).
+  - Pure additive prose change. Mirrored to
+    `src/research_hub/skills_data/paper-memory-builder/`.
+
 - **Codex review tightenings — multi-eligible fixture + design_brief
   placeholder marker** (`tests/fixtures/topic_dossier_multi_eligible_sample.gaps.yml`,
   `skills/research-design-helper/references/design_brief_template.md`,

--- a/skills/paper-memory-builder/SKILL.md
+++ b/skills/paper-memory-builder/SKILL.md
@@ -48,6 +48,53 @@ In priority order:
 5. **`.research/literature_matrix.md`** — for citation key lookup if the
    manuscript references "Smith 2024" but you need to disambiguate.
 
+### Scanning the paper repo for evidence artifacts (v0.3.16+)
+
+Beyond the manuscript + figures, real research repos typically contain
+sibling artifacts that populate `claims[].evidence_artifacts` for
+non-figure evidence. When scanning, look for:
+
+- **Simulation / experiment outputs** — `*.csv`, `*.parquet`, `*.npz`,
+  `*.h5`, `*.json` log files under `outputs/`, `results/`, or
+  repo-root sibling dirs. Common patterns: `<experiment_id>_log.csv`,
+  `run_log.csv`, `adaptation_log.csv`. These back claims like
+  *"χ²=891, p<0.0001 across 50 runs"* (the chi-squared output came from
+  the per-agent decision log, not from a figure).
+- **Analysis scripts** — `*.py`, `*.R`, `*.jl`, `*.ipynb` files that
+  produce evidence numbers. The script itself is rarely the evidence
+  artifact, but its OUTPUT path is. Trace the script → output pairing
+  if the manuscript cites a number computed by a script.
+- **Drawio / SVG framework diagrams** — `*.drawio`, `*.svg` sources for
+  conceptual figures (e.g. framework architecture, decision-flow
+  diagrams). These often back claim text like *"Figure 1 shows the
+  module architecture"* even when the embedded image in the .docx is
+  rendered from the drawio source.
+- **Reviewer-response artifacts** — `Review Response-YYYYMMDD.docx`
+  files (operator-side response prep). Not consumed by
+  `paper-memory-builder` directly but listed here as a typical sibling
+  artifact; `academic-writing-skills` reviewer-response workflow uses
+  these.
+
+Populate `claims[].evidence_artifacts` with the artifact PATH (relative
+to the paper repo root), not the artifact contents. Example:
+
+```yaml
+- id: C8
+  text: "Chi-squared test on coping-appraisal keywords yields χ²=891, p<0.0001..."
+  evidence_artifacts:
+    - "outputs/llm-abm_decision_log.csv"        # raw per-agent text used in chi-sq
+    - "scripts/analyze_appraisal_keywords.py"   # script that ran the test
+    - "Result section §4.2 (chi-squared paragraph)"  # manuscript anchor
+  figure_or_table: ["TabS5"]
+  status: draft
+```
+
+This makes the audit trail traceable end-to-end: claim → manuscript
+sentence → figure/table reference → underlying data file → analysis
+code. Cross-plugin consumers like `academic-writing-skills` (claim-
+evidence audit) can then verify the chain is intact before accepting
+the claim as supported.
+
 ## Outputs
 
 Write to `<project-root>/.paper/`:

--- a/skills/paper-memory-builder/references/yaml-schemas.md
+++ b/skills/paper-memory-builder/references/yaml-schemas.md
@@ -66,6 +66,39 @@ figures:
 
 **Required per figure:** `id`, `file`, `supports_claims` (may be `[]`).
 
+### `file:` sentinel values (v0.3.16+)
+
+For figures that have NO separable source file on disk, `file:`
+accepts these documented sentinel values instead of a real path:
+
+| Sentinel | Use when |
+|---|---|
+| `embedded-in-manuscript` | Figure is embedded directly inside the `.docx` / `.tex` / Word manuscript with no separable source file (typical for Word-based research workflows where figures are pasted or rendered inline). |
+| `embedded-in-supporting-information` | Same as above, but for figures in the SI / Appendix manuscript file. |
+| `embedded-in-presentation` | Figure originates in a `.pptx` deck (some workflows author in PowerPoint and export to manuscript). |
+
+Downstream consumers (`academic-writing-skills` figure-text consistency
+checks, future figure-archive tooling) treat sentinel values as
+"present in manuscript, no separable artifact to verify
+independently." This is a documented limitation, NOT a permanent
+solution — a future paper-memory-builder version may add a
+pre-processing step that extracts embedded figures to a
+`.paper/figures/` subdir, at which point the sentinel becomes a real
+path. Until then, the sentinel is the honest representation.
+
+Example:
+
+```yaml
+figures:
+  - id: "Fig2"
+    file: "embedded-in-manuscript"
+    panels: ["(a) baseline", "(b) intervention"]
+    key_numbers: ["10-year simulation", "50 runs"]
+    supports_claims: ["C1", "C4"]
+    caption_in_manuscript: >-
+      Figure 2. Yearly adaptation trajectories ...
+```
+
 ## See also
 
 - `revision_history_schema.md` — schema + append-only rules for `revision_history.yml`.

--- a/src/research_hub/skills_data/paper-memory-builder/SKILL.md
+++ b/src/research_hub/skills_data/paper-memory-builder/SKILL.md
@@ -48,6 +48,53 @@ In priority order:
 5. **`.research/literature_matrix.md`** — for citation key lookup if the
    manuscript references "Smith 2024" but you need to disambiguate.
 
+### Scanning the paper repo for evidence artifacts (v0.3.16+)
+
+Beyond the manuscript + figures, real research repos typically contain
+sibling artifacts that populate `claims[].evidence_artifacts` for
+non-figure evidence. When scanning, look for:
+
+- **Simulation / experiment outputs** — `*.csv`, `*.parquet`, `*.npz`,
+  `*.h5`, `*.json` log files under `outputs/`, `results/`, or
+  repo-root sibling dirs. Common patterns: `<experiment_id>_log.csv`,
+  `run_log.csv`, `adaptation_log.csv`. These back claims like
+  *"χ²=891, p<0.0001 across 50 runs"* (the chi-squared output came from
+  the per-agent decision log, not from a figure).
+- **Analysis scripts** — `*.py`, `*.R`, `*.jl`, `*.ipynb` files that
+  produce evidence numbers. The script itself is rarely the evidence
+  artifact, but its OUTPUT path is. Trace the script → output pairing
+  if the manuscript cites a number computed by a script.
+- **Drawio / SVG framework diagrams** — `*.drawio`, `*.svg` sources for
+  conceptual figures (e.g. framework architecture, decision-flow
+  diagrams). These often back claim text like *"Figure 1 shows the
+  module architecture"* even when the embedded image in the .docx is
+  rendered from the drawio source.
+- **Reviewer-response artifacts** — `Review Response-YYYYMMDD.docx`
+  files (operator-side response prep). Not consumed by
+  `paper-memory-builder` directly but listed here as a typical sibling
+  artifact; `academic-writing-skills` reviewer-response workflow uses
+  these.
+
+Populate `claims[].evidence_artifacts` with the artifact PATH (relative
+to the paper repo root), not the artifact contents. Example:
+
+```yaml
+- id: C8
+  text: "Chi-squared test on coping-appraisal keywords yields χ²=891, p<0.0001..."
+  evidence_artifacts:
+    - "outputs/llm-abm_decision_log.csv"        # raw per-agent text used in chi-sq
+    - "scripts/analyze_appraisal_keywords.py"   # script that ran the test
+    - "Result section §4.2 (chi-squared paragraph)"  # manuscript anchor
+  figure_or_table: ["TabS5"]
+  status: draft
+```
+
+This makes the audit trail traceable end-to-end: claim → manuscript
+sentence → figure/table reference → underlying data file → analysis
+code. Cross-plugin consumers like `academic-writing-skills` (claim-
+evidence audit) can then verify the chain is intact before accepting
+the claim as supported.
+
 ## Outputs
 
 Write to `<project-root>/.paper/`:

--- a/src/research_hub/skills_data/paper-memory-builder/references/yaml-schemas.md
+++ b/src/research_hub/skills_data/paper-memory-builder/references/yaml-schemas.md
@@ -66,6 +66,39 @@ figures:
 
 **Required per figure:** `id`, `file`, `supports_claims` (may be `[]`).
 
+### `file:` sentinel values (v0.3.16+)
+
+For figures that have NO separable source file on disk, `file:`
+accepts these documented sentinel values instead of a real path:
+
+| Sentinel | Use when |
+|---|---|
+| `embedded-in-manuscript` | Figure is embedded directly inside the `.docx` / `.tex` / Word manuscript with no separable source file (typical for Word-based research workflows where figures are pasted or rendered inline). |
+| `embedded-in-supporting-information` | Same as above, but for figures in the SI / Appendix manuscript file. |
+| `embedded-in-presentation` | Figure originates in a `.pptx` deck (some workflows author in PowerPoint and export to manuscript). |
+
+Downstream consumers (`academic-writing-skills` figure-text consistency
+checks, future figure-archive tooling) treat sentinel values as
+"present in manuscript, no separable artifact to verify
+independently." This is a documented limitation, NOT a permanent
+solution — a future paper-memory-builder version may add a
+pre-processing step that extracts embedded figures to a
+`.paper/figures/` subdir, at which point the sentinel becomes a real
+path. Until then, the sentinel is the honest representation.
+
+Example:
+
+```yaml
+figures:
+  - id: "Fig2"
+    file: "embedded-in-manuscript"
+    panels: ["(a) baseline", "(b) intervention"]
+    key_numbers: ["10-year simulation", "50 runs"]
+    supports_claims: ["C1", "C4"]
+    caption_in_manuscript: >-
+      Figure 2. Yearly adaptation trajectories ...
+```
+
 ## See also
 
 - `revision_history_schema.md` — schema + append-only rules for `revision_history.yml`.

--- a/tests/test_handoff_gap_to_topic_design_helper.py
+++ b/tests/test_handoff_gap_to_topic_design_helper.py
@@ -387,6 +387,70 @@ def test_design_brief_template_has_placeholder_segments_field() -> None:
     )
 
 
+def test_paper_memory_yaml_schemas_documents_file_sentinel_values() -> None:
+    """v0.3.16 (F-cross2 fast-follow): figures.yml `file:` field has no
+    natural value when figures are embedded inside .docx with no
+    separable source file. v0.3.16 documents sentinel values
+    (`embedded-in-manuscript`, `embedded-in-supporting-information`,
+    `embedded-in-presentation`) in yaml-schemas.md so downstream
+    consumers (academic-writing-skills figure-text checks) know how
+    to interpret them.
+    """
+    schemas_doc = (
+        REPO_ROOT / "skills" / "paper-memory-builder" / "references" / "yaml-schemas.md"
+    )
+    assert schemas_doc.exists(), f"missing yaml-schemas.md: {schemas_doc}"
+    text = schemas_doc.read_text(encoding="utf-8")
+    # All three sentinels must be documented in the schema doc
+    for sentinel in (
+        "embedded-in-manuscript",
+        "embedded-in-supporting-information",
+        "embedded-in-presentation",
+    ):
+        assert sentinel in text, (
+            f"figures.yml `file:` sentinel `{sentinel}` not documented "
+            f"in yaml-schemas.md — F-cross2 ship contract broken"
+        )
+    # W1 hardening: verify the documentation table header is present,
+    # not just sentinel words floating in an example block (table could
+    # be deleted while example still references sentinels)
+    assert "| Sentinel | Use when |" in text, (
+        "yaml-schemas.md sentinel-values TABLE header missing — table "
+        "may have been removed while example YAML still references "
+        "sentinels (W1 from v0.3.16 code-reviewer)"
+    )
+
+
+def test_paper_memory_skill_md_documents_evidence_artifact_scanning() -> None:
+    """v0.3.16 (F-cross3 fast-follow): paper-memory-builder SKILL.md
+    Inputs section now has a "Scanning the paper repo for evidence
+    artifacts" sub-section that documents non-figure evidence types
+    (simulation CSVs, analysis scripts, drawio sources, reviewer-
+    response artifacts) and shows how to populate
+    claims[].evidence_artifacts with their paths.
+    """
+    skill_md = REPO_ROOT / "skills" / "paper-memory-builder" / "SKILL.md"
+    text = skill_md.read_text(encoding="utf-8")
+    inputs_section = _extract_section(text, "## Inputs")
+    assert "Scanning the paper repo" in inputs_section, (
+        "SKILL.md Inputs section missing `### Scanning the paper repo for "
+        "evidence artifacts` sub-section — F-cross3 ship contract broken"
+    )
+    # Must mention all 4 non-figure evidence types (W2 hardening:
+    # was "at least 3 of 4" — tightened to require all 4 so a future
+    # edit can't silently delete one type and still pass the test)
+    for artifact_type in (
+        "Simulation",
+        "Analysis scripts",
+        "Drawio",
+        "Reviewer-response",
+    ):
+        assert artifact_type in inputs_section, (
+            f"Scanning sub-section missing `{artifact_type}` — incomplete "
+            f"coverage of non-figure evidence artifact types"
+        )
+
+
 def test_design_helper_has_brief_to_docx_script_and_skill_md_section() -> None:
     """v0.3.14 (F4 fast-follow): research-design-helper ships
     `scripts/brief_to_docx.js` as the sister generator to


### PR DESCRIPTION
Two doc improvements surfaced by the Stage 7-8 dogfood (`~/.claude/audits/dogfood_runs/2026-05-23-paper-memory-academic-writing-stage-7-8/VERIFICATION.md`). Producer-side companion to academic-writing-skills PR #6 (v0.2.1, F-cross1).

## F-cross2 — `figures.yml` `file:` sentinel values

The schema requires `figures[].file` (required field), but real-world Word-based research workflows often have figures embedded directly inside `.docx` with no separable source file. `references/yaml-schemas.md` adds a new `### file: sentinel values (v0.3.16+)` section documenting 3 sentinels:

| Sentinel | Use case |
|---|---|
| `embedded-in-manuscript` | Embedded in `.docx`/`.tex` |
| `embedded-in-supporting-information` | Embedded in SI / Appendix |
| `embedded-in-presentation` | Originates in `.pptx` deck |

Documented limitation, NOT a permanent solution — future versions may add a pre-processing step that extracts embedded figures to `.paper/figures/`. Until then, sentinel is the honest representation.

## F-cross3 — SKILL.md "Scanning the paper repo for evidence artifacts"

The previous Inputs section only described figures + manifest files but real research repos contain many non-figure evidence artifacts. New sub-section documents 4 artifact types:

1. **Simulation/experiment outputs** (CSV, parquet, npz, h5, json)
2. **Analysis scripts** (py, R, jl, ipynb)
3. **Drawio/SVG framework diagrams**
4. **Reviewer-response artifacts**

Includes concrete YAML example mirroring the dogfood C8 chi-squared claim, showing CSV + script + manuscript-anchor as `evidence_artifacts`. Makes the audit trail end-to-end traceable: claim → manuscript sentence → figure/table → data file → analysis code.

## Cross-skill consistency with academic-writing-skills PR #6

academic-writing-skills v0.2.1 (PR #6, merged as `5a1cbe0`) ships the consumer-side schema-aware audit logic. This PR ships the producer-side doc improvements. Both are independent — the sentinel rule applies to `figures[].file` only (no claim-side impact); the new scanning sub-section is purely additive guidance for populating `claims[].evidence_artifacts`.

## Validation

| Check | Result |
|---|---|
| `pytest tests/test_handoff_gap_to_topic_design_helper.py tests/test_v068_3_version_sync.py -q` | **26/26** passed (was 24 → 26; added 2 new tests for F-cross2 + F-cross3) |
| `diff -rq skills/paper-memory-builder/ src/research_hub/skills_data/paper-memory-builder/` | clean |
| `git grep -nF "0.3.15"` outside CHANGELOG | 6 intentional `v0.3.15+` since-version markers (no stale current-version pointers) |
| code-reviewer subagent | APPROVE (after fix-cycle: W1 hardening — sentinel test now also asserts table-header presence; W2 hardening — artifact-type test now requires all 4 not 3) |

Pure additive: no schema fields removed, no enum tokens changed, no required-field additions.

## Next (queued, blocked by this PR merge)

- **Catalog 1.5.17**: bundle academic-writing-skills 0.2.1 + research-workspace 0.3.16 propagation in ai-research-skills marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)