### PR TITLE
feat(auto): --with-summary ON by default + marker-fix v2 (populate_overview overwrite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Changed
+- **`auto --with-summary` is now ON by default** (`cli.py`). After ingest, the
+  per-paper Key Findings / Methodology / Relevance sections are filled via the
+  detected LLM CLI (claude / codex / gemini) on every run; previously the
+  `--with-summary` flag had to be opted in explicitly. The flag uses
+  `argparse.BooleanOptionalAction`, so `--no-with-summary` is the new opt-out.
+  `--full-auto` no longer needs to re-set `--with-summary` and was simplified
+  accordingly, which incidentally lets `--full-auto --no-with-summary` respect
+  the opt-out (silently overridden before). Python API
+  `auto_pipeline(..., with_summary=False)` deliberately stays opt-in (mirrors
+  the `--with-pdfs` PR #90 split) so programmatic callers don't fire 20+ LLM
+  CLI invocations per run silently.
+
 - **`auto --with-pdfs` is now ON by default** (`cli.py`, `auto.py`). The `auto`
   subcommand attaches open-access PDFs from arXiv/OpenAlex/Unpaywall/Crossref
   to the ingested Zotero items as part of every run; previously `--with-pdfs`
@@ -39,6 +51,27 @@ graph rebuild (link out to the real tools instead)._
   overridden before). The `ingest` and `run` subcommands stay opt-in
   (`--with-pdfs` only) — they are lower-level entry points where an explicit
   flag still makes sense.
+
+### Fixed
+- **Cluster overview LLM auto-fill now fires after `populate_overview` runs
+  too** (`cluster_overview.py`). PR #91 fixed `_CHINESE_TEMPLATE_MARKER` to
+  match the Chinese scaffold (`一到兩句話...`) but in the real `auto` flow,
+  `populate_overview` (`vault/hub_overview.py`) runs BEFORE `apply_overview`
+  and overwrites the TL;DR with the cluster's topic-string fallback (`"LLM
+  for flood forecasting..."`). The Chinese marker then no longer matches and
+  `apply_overview` silently classified the topic string as "hand-curated",
+  skipping LLM enrichment. Net effect: every `auto`-fresh cluster still
+  ended with an empty TL;DR / Core Question / Scope. The scaffold check is
+  now `_is_scaffold_tldr(text, cluster_query, cluster_slug)` which also
+  recognises:
+    * the English fallback `"No cluster summary available yet."` (from
+      `_render_tldr`)
+    * exact match against the cluster's `first_query` (the topic-string
+      fallback `_overview_tldr` writes when there's no NLM brief yet)
+    * exact match (case-insensitive) against the slug humanised (the
+      last-resort fallback in `_overview_tldr`)
+  Two regression tests pin the new branches.
+
 
 ### Added
 - **`brief_to_docx.js` ships inside `skills/research-design-helper/scripts/`**

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -5391,18 +5391,23 @@ def build_parser() -> argparse.ArgumentParser:
                              help="Also generate crystals via detected LLM CLI")
     auto_parser.add_argument(
         "--with-summary",
-        action="store_true",
-        help="Run `summarize --apply` after ingest to fill per-paper Key Findings / Methodology / Relevance",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Run `summarize --apply` after ingest to fill per-paper "
+            "Key Findings / Methodology / Relevance (default: on). Use "
+            "--no-with-summary to skip per-paper summarization."
+        ),
     )
     auto_parser.add_argument(
         "--full-auto",
         action="store_true",
         help=(
-            "Enable --with-summary --with-crystals (--with-pdfs is already "
-            "on by default; use --no-with-pdfs to disable PDFs). "
-            "NotebookLM upload also stays ON by default — pair with "
-            "--no-nlm if you want fully local automation without the "
-            "browser step (NLM upload uses patchright + Google login)."
+            "Enable --with-crystals (--with-pdfs and --with-summary are "
+            "already on by default; use --no-with-pdfs / --no-with-summary "
+            "to disable them). NotebookLM upload also stays ON by default — "
+            "pair with --no-nlm if you want fully local automation without "
+            "the browser step (NLM upload uses patchright + Google login)."
         ),
     )
     auto_parser.add_argument(
@@ -7517,11 +7522,10 @@ def _main_dispatch(args, parser) -> int:
         return 0
     if args.command == "auto":
         if args.full_auto:
-            # --with-pdfs is on by default since the BooleanOptionalAction
-            # flip; we intentionally do NOT force args.with_pdfs = True here
-            # so an explicit --no-with-pdfs (args.with_pdfs == False) is
-            # respected even under --full-auto.
-            args.with_summary = True
+            # --with-pdfs and --with-summary are on by default since the
+            # BooleanOptionalAction flips; we intentionally do NOT force
+            # them to True here so an explicit --no-with-pdfs or
+            # --no-with-summary is respected even under --full-auto.
             args.with_crystals = True
         return _auto(
             topic=args.topic,

--- a/src/research_hub/cluster_overview.py
+++ b/src/research_hub/cluster_overview.py
@@ -30,6 +30,43 @@ from research_hub.summarize import _read_cluster_papers_with_abstracts
 # LLM enrichment.
 _CHINESE_TEMPLATE_MARKER = "一到兩句話"
 
+# Other scaffold sentinels written by `vault/hub_overview.py:_render_tldr`
+# when `populate_overview` runs BEFORE this `apply_overview` step in the
+# `auto` flow. populate_overview overwrites the Chinese scaffold with one
+# of these fallbacks, so the Chinese marker alone is not enough — without
+# these we'd silently classify a populate_overview-mangled scaffold as
+# "hand-curated" and never call the LLM.
+_ENGLISH_FALLBACK_TLDR = "No cluster summary available yet."
+
+
+def _is_scaffold_tldr(text: str, cluster_query: str, cluster_slug: str) -> bool:
+    """Return True if the TL;DR is still scaffold content, not user-curated.
+
+    Recognises:
+      * empty string
+      * the Chinese scaffold from topic.py (`一到兩句話...`)
+      * the English fallback string from `_render_tldr` when
+        `_overview_tldr` returns nothing usable
+      * an exact match against the cluster's query string (the most common
+        populate_overview fallback — `_overview_tldr` returns the query
+        when no NLM brief is available)
+      * an exact match (case-insensitive) against the slug humanised — the
+        last-resort fallback in `_overview_tldr`
+    """
+    text = (text or "").strip()
+    if not text:
+        return True
+    if text.startswith(_CHINESE_TEMPLATE_MARKER):
+        return True
+    if text == _ENGLISH_FALLBACK_TLDR:
+        return True
+    if cluster_query and text.strip() == cluster_query.strip():
+        return True
+    slug_humanised = cluster_slug.replace("-", " ").strip()
+    if slug_humanised and text.lower() == slug_humanised.lower():
+        return True
+    return False
+
 
 @dataclass
 class ClusterOverview:
@@ -315,7 +352,21 @@ def apply_overview(cfg, cluster_slug, payload, *, force: bool = False) -> Overvi
             frontmatter = existing_frontmatter
             title = _extract_title_from_frontmatter(existing_frontmatter, title_default)
         existing_tldr = _extract_tldr_text(existing_text)
-        if existing_tldr and not existing_tldr.startswith(_CHINESE_TEMPLATE_MARKER) and not force:
+        # Look up the cluster's query so the topic-string fallback that
+        # `populate_overview` writes can be recognised as scaffold (PR #91
+        # was half-fix — see _is_scaffold_tldr docstring).
+        try:
+            from research_hub.clusters import ClusterRegistry
+            _reg = ClusterRegistry(getattr(cfg, "clusters_file", Path(cfg.research_hub_dir) / "clusters.yaml"))
+            _cluster_obj = _reg.get(cluster_slug)
+            # NOTE: the Cluster dataclass field is `first_query`, NOT `query`
+            # — `create(query=...)` stores it as `first_query`. Reading the
+            # wrong attribute returns "" silently and the topic-string
+            # scaffold check below never fires.
+            _cluster_query = (getattr(_cluster_obj, "first_query", "") or "") if _cluster_obj else ""
+        except Exception:
+            _cluster_query = ""
+        if existing_tldr and not _is_scaffold_tldr(existing_tldr, _cluster_query, cluster_slug) and not force:
             # v0.88.9: this is a deliberate idempotent skip protecting
             # the user's hand-curated TL;DR. Report ``ok=True``,
             # ``skipped=True`` so the auto step can render it as a

--- a/tests/test_v071_cluster_overview.py
+++ b/tests/test_v071_cluster_overview.py
@@ -187,6 +187,84 @@ def test_apply_overview_treats_chinese_scaffold_placeholder_as_untouched(cfg):
     assert result.skipped is False
 
 
+def test_apply_overview_treats_populate_overview_topic_string_as_scaffold(tmp_path):
+    """Regression: PR #91 was half-fix. In the real `auto` flow,
+    `populate_overview` (vault/hub_overview.py) runs BEFORE
+    `apply_overview` (cluster_overview.py) and overwrites the Chinese
+    scaffold TL;DR with the cluster's topic-string fallback ("LLM for
+    flood forecasting..."). The marker `一到兩句話` then no longer
+    matches, so `apply_overview` silently classified the topic string as
+    "hand-curated" and never called the LLM. This test pins the
+    extended scaffold check that recognises the topic-string fallback
+    too."""
+    from research_hub.clusters import ClusterRegistry
+    raw = tmp_path / "raw" / "test-cluster"
+    raw.mkdir(parents=True)
+    hub_dir = tmp_path / "hub" / "test-cluster"
+    hub_dir.mkdir(parents=True)
+    research_hub_dir = tmp_path / ".research_hub"
+    research_hub_dir.mkdir()
+    clusters_file = research_hub_dir / "clusters.yaml"
+    _write_paper_md(
+        raw / "paper-one.md",
+        "Paper One",
+        "Multi-agent coordination under flood response.",
+        year=2024,
+    )
+    ClusterRegistry(clusters_file).create(
+        query="LLM for flood forecasting, warning, and decision-making",
+        name="LLM Flood Cluster",
+        slug="test-cluster",
+    )
+    cfg = SimpleNamespace(
+        raw=tmp_path / "raw",
+        hub=tmp_path / "hub",
+        research_hub_dir=research_hub_dir,
+        clusters_file=clusters_file,
+    )
+    overview_path = hub_dir / "00_overview.md"
+    # Simulate post-populate_overview state: TL;DR = the topic string,
+    # no Chinese marker.
+    overview_path.write_text(
+        "---\ntype: topic-overview\ncluster: test-cluster\n---\n\n"
+        "# Test Cluster\n\n## TL;DR\n\n"
+        "> [!abstract]\n"
+        "> LLM for flood forecasting, warning, and decision-making\n"
+        "^tldr\n",
+        encoding="utf-8",
+    )
+
+    result = apply_overview(cfg, "test-cluster", _valid_payload(), force=False)
+
+    # populate_overview's topic-string fallback is scaffold, NOT user content.
+    assert result.written is True, (
+        "topic-string fallback (populate_overview's output) must be recognised "
+        "as scaffold; if this fails, _is_scaffold_tldr's cluster-query branch "
+        "is broken — the LLM auto-fill won't fire in real `auto` runs"
+    )
+    assert result.skipped is False
+
+
+def test_apply_overview_treats_english_no_summary_fallback_as_scaffold(cfg):
+    """Regression: the other populate_overview fallback is the literal
+    string "No cluster summary available yet." (rendered by
+    `_render_tldr` when `_overview_tldr` returns an empty string). Must
+    also be recognised as scaffold."""
+    overview_path = cfg.hub / "test-cluster" / "00_overview.md"
+    overview_path.write_text(
+        "---\ntype: topic-overview\ncluster: test-cluster\n---\n\n"
+        "# Test Cluster\n\n## TL;DR\n\n"
+        "> [!abstract]\n"
+        "> No cluster summary available yet.\n"
+        "^tldr\n",
+        encoding="utf-8",
+    )
+
+    result = apply_overview(cfg, "test-cluster", _valid_payload(), force=False)
+    assert result.written is True
+    assert result.skipped is False
+
+
 def test_apply_overview_refuses_to_overwrite_filled_overview_without_force(cfg):
     overview_path = cfg.hub / "test-cluster" / "00_overview.md"
     overview_path.write_text(


### PR DESCRIPTION
Two `auto`-polish items uncovered while running an E2E on a fresh "LLM × flood forecasting" cluster on master, after PR #88/#90/#91 landed.

## (A) Marker fix v2 — cluster overview LLM auto-fill still wasn't firing

**Bug:** PR #91 fixed `_CHINESE_TEMPLATE_MARKER` to match the Chinese scaffold that `topic.py` writes (`一到兩句話...`). But in the real `auto` flow, `populate_overview` (`vault/hub_overview.py`) runs **before** `apply_overview` and **overwrites the TL;DR** with the cluster's topic-string fallback (the cluster's `first_query`, e.g. `"LLM for flood forecasting, warning, and decision-making"`). The Chinese marker then no longer matches → `apply_overview` silently classifies the topic string as "hand-curated" → LLM never called → every `auto`-fresh cluster still ends with an empty TL;DR / Core Question / Scope.

**Fix:** new helper `_is_scaffold_tldr(text, cluster_query, cluster_slug)` recognises:
- empty text
- the Chinese scaffold prefix `一到兩句話` (PR #91's check, preserved)
- the English fallback `"No cluster summary available yet."` (from `_render_tldr`)
- exact match against the cluster's `first_query` (topic-string fallback from `_overview_tldr`)
- exact match (case-insensitive) against the slug humanised (last-resort fallback)

**Subtle gotcha discovered while writing the regression test:** `ClusterRegistry.create(query=...)` stores its argument as `Cluster.first_query`, NOT `Cluster.query`. My first attempt at this fix read the non-existent `.query` attribute and silently got "" — bug only surfaced when the new test registered a real cluster.

Two regression tests added:
- `test_apply_overview_treats_populate_overview_topic_string_as_scaffold`
- `test_apply_overview_treats_english_no_summary_fallback_as_scaffold`

## (B) `--with-summary` now ON by default

Per-paper Key Findings / Methodology / Relevance via the detected LLM CLI is what makes the Obsidian notes useful for deep reading. Default-off was friction; default-on matches the expectation.

Mirrors PR #90's `--with-pdfs` split (avoids the CI regression I caused once):
- **CLI default:** `True` via `argparse.BooleanOptionalAction`; `--no-with-summary` is the opt-out.
- **`auto_pipeline()` Python API default:** stays `False` so programmatic callers (tests, library users) don't fire 20+ LLM CLI invocations per run silently.
- **`--full-auto`** no longer re-sets `--with-summary` (now redundant); `--full-auto --no-with-summary` is therefore respected.

## Verification

- `pytest -k "overview or auto or cli or summary"`: **543 passed, 7 skipped, 0 failed**
- `tests/test_v071_cluster_overview.py` + `tests/test_hub_overview.py`: **20 passed** (was 18 + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)