### PR TITLE
feat(nlm): real refresh via SDK public API + minute-cadence keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,36 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Changed
+- **NLM keepalive: real refresh via SDK public API + minute-cadence default**
+  (`notebooklm/keepalive.py`, `cli.py`). The old `rotate_and_persist_session`
+  used the SDK's *private* `_rotate_cookies` poke which returned success
+  without verifying the session was still alive — every "ok" in the logs
+  could have been a silent no-op against a revoked session, which is why
+  the documented "持久一年" never actually held. New
+  `refresh_and_persist_session` calls the SDK's *public*
+  `fetch_tokens_with_domains` which GETs the NotebookLM homepage and
+  extracts (csrf_token, session_id) as a side-effect of cookie rotation:
+  if tokens come back, the cookies are observably good. The function
+  returns a structured `RefreshResult` with `before_metadata` /
+  `after_metadata` / `changed` (freshness-cookie expiry diff) so an
+  operator can see PSIDTS actually moved forward. The old function name
+  is retained as a thin bool shim for back-compat callers.
+  `keepalive_once` was restructured to call refresh *first* (no pre-health
+  gate — the Codex review of the old design flagged that as the source
+  of permanently-stale sessions: a transient health-check error skipped
+  the only refresh attempt). Default cadence flipped from hourly to
+  **15 minutes** (`--interval` 21600 → 900 s, floor 3600 → 600 s;
+  `--interval-minutes` 6 → 15 with /SC MINUTE schtasks) — PSIDTS expires
+  every ~3-4 hours, so hourly left only ~3 retries per expiry window
+  and routinely lost races on flaky networks. `--interval-hours` is
+  kept as a deprecated alias multiplied to minutes at dispatch.
+  Existing tests in `tests/test_v0950_nlm_keepalive_and_browser_login.py`
+  rewrote classes A (refresh) and B (keepalive_once) for the new
+  contract; classes C/D/E (CLI / from-browser) unchanged. Note: "持久一年"
+  is achievable *only* when (a) the scheduled task runs every 15 min without
+  interruption, (b) Google does not revoke the account on a security event,
+  and (c) the long-lived `SID`/`PSID` cookies (~1 year nominal) have not
+  naturally expired — keepalive does not defeat any of those.
 - **`auto --fit-check-threshold` default raised 3 → 4** (`cli.py`). The
   LLM-judge fit-check now defaults to "clearly related" instead of
   "tangentially related and above". Rationale: at threshold 3 a "Large

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -6812,11 +6812,14 @@ def build_parser() -> argparse.ArgumentParser:
     nlm_keepalive.add_argument(
         "--interval",
         type=int,
-        default=21600,
+        default=900,
         metavar="SEC",
         help=(
             "Seconds between keepalive calls in --loop mode "
-            "(default: 21600 = 6 h; floor: 3600 = 1 h)"
+            "(default: 900 = 15 min; floor: 600 = 10 min). Google's "
+            "PSIDTS cookies expire every ~3-4 hours, so the cadence must "
+            "stay well below that — the old hour-defaults left tiny safety "
+            "margin and routinely lost races on flaky networks."
         ),
     )
     nlm_keepalive.add_argument(
@@ -6825,7 +6828,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=False,
         help=(
             "Build and print the schtasks command that registers a Windows Scheduled Task "
-            "running 'python -m research_hub notebooklm keepalive' every --interval-hours h. "
+            "running 'python -m research_hub notebooklm keepalive' every --interval-minutes m. "
             "Without --yes this is a DRY-RUN only (prints command, registers nothing)."
         ),
     )
@@ -6839,11 +6842,31 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     nlm_keepalive.add_argument(
+        "--interval-minutes",
+        type=int,
+        default=15,
+        metavar="MINUTES",
+        help=(
+            "Minutes between task runs when registering the Scheduled Task "
+            "(default: 15). Uses /SC MINUTE under the hood — minute-cadence "
+            "is required because PSIDTS expires every ~3-4 hours, so an "
+            "hourly cadence (the old default) left ~3 retries per expiry "
+            "window and routinely lost races on flaky networks."
+        ),
+    )
+    # Back-compat alias: --interval-hours is deprecated in favour of
+    # --interval-minutes but kept as a wrapper so existing automation
+    # scripts don't break on upgrade. Multiplied to minutes at dispatch.
+    nlm_keepalive.add_argument(
         "--interval-hours",
         type=int,
-        default=6,
+        default=None,
         metavar="HOURS",
-        help="Hours between task runs when registering the Scheduled Task (default: 6)",
+        help=(
+            "Deprecated alias for --interval-minutes (multiplied by 60). "
+            "Prefer --interval-minutes; see its help text for why "
+            "minute-cadence is required."
+        ),
     )
     nlm_keepalive.add_argument(
         "--yes",
@@ -8293,8 +8316,16 @@ def _main_dispatch(args, parser) -> int:
             )
             cfg = get_config()
             if args.install_windows_task or args.uninstall_windows_task:
+                # Prefer the explicit --interval-minutes; if the deprecated
+                # --interval-hours was passed explicitly, multiply to
+                # minutes. Default falls through to args.interval_minutes
+                # (which itself defaults to 15).
+                if args.interval_hours is not None:
+                    interval_minutes = args.interval_hours * 60
+                else:
+                    interval_minutes = args.interval_minutes
                 return run_install_windows_task(
-                    args.interval_hours,
+                    interval_minutes,
                     dry_run=not args.yes,
                     uninstall=args.uninstall_windows_task,
                     cfg=cfg,

--- a/src/research_hub/notebooklm/keepalive.py
+++ b/src/research_hub/notebooklm/keepalive.py
@@ -1,33 +1,49 @@
 """Idle keepalive for NotebookLM sessions.
 
-Periodically rotates and persists the stored cookies so Google does not revoke
-an idle session (typically within 12–24 h without activity).
+Periodically refreshes the short-lived freshness cookies (``__Secure-1PSIDTS``
+/ ``__Secure-3PSIDTS``) so Google does not revoke an idle session. Google's
+PSIDTS cookies expire every ~3-4 hours; the long-lived ``SID``/``PSID``
+cookies last ~1 year. If a minute-cadence keepalive actually rotates PSIDTS
+ahead of expiry, the practical session lifetime is bounded by the
+long-lived cookies, not the short ones.
+
+Refresh contract
+----------------
+``refresh_and_persist_session`` (the primary API) calls the SDK's public
+``fetch_tokens_with_domains`` — which actually fetches CSRF + session_id
+tokens from the NotebookLM homepage as a side-effect of cookie rotation.
+This is observable proof: if tokens come back, the cookies are good. The
+older ``rotate_and_persist_session`` wrapper used the SDK's private
+``_rotate_cookies`` poke which returned success without verifying that the
+session was still alive — every "success" in the logs could have been a
+no-op against a revoked session.
 
 Honest scope note
 -----------------
-- ``rotate_and_persist_session`` makes one network call to accounts.google.com.
-  If the session cookies are already revoked server-side it will silently fail
-  (best-effort, never raises) and ``keepalive_once`` returns non-zero so a
-  scheduler can surface the failure.
+- ``refresh_and_persist_session`` makes one network call to Google. If the
+  session is already revoked server-side it returns a ``RefreshResult`` with
+  ``ok=False`` and an actionable reason; ``keepalive_once`` then returns
+  non-zero so a scheduler can surface the failure.
 - The Windows Scheduled Task registration (``--install-windows-task``) is
   gated behind an explicit ``--yes`` flag. Without ``--yes`` the exact
-  ``schtasks`` command is only printed — nothing is registered; no wrapper file
-  is created either.
+  ``schtasks`` command is only printed.
 - The task runs via a console-script (if pip-installed) or a generated wrapper
   ``.cmd`` file (if running from a source checkout) to guarantee PYTHONPATH is
   set correctly. No elevated privileges (no /RL HIGHEST) are required.
-- Google can still hard-expire long-lived SID/PSID cookies (~1 year) or revoke
-  on a security event; keepalive does not prevent that. Combine with
-  ``notebooklm login --from-browser`` for easy re-auth.
+- Google can still hard-expire long-lived SID/PSID cookies or revoke on a
+  security event; keepalive does not defeat revocation. Combine with
+  ``notebooklm login --auto-detect`` for re-auth when that happens.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import shutil
 import sys
 import time
 import warnings
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -38,58 +54,143 @@ if TYPE_CHECKING:
 
 _TASK_NAME = "ResearchHubNLMKeepalive"
 
+# Cookies whose expiry/value we track to PROVE keepalive rotation worked.
+# Names match the SDK's MINIMUM_REQUIRED_COOKIES expectations
+# (``__Secure-1PSIDTS`` / ``__Secure-3PSIDTS``) plus the rarer RTS variants
+# the older handoff named — we log them when present.
+_FRESHNESS_COOKIE_NAMES = (
+    "__Secure-1PSIDTS",
+    "__Secure-3PSIDTS",
+    "__Secure-1PSIDRTS",
+    "__Secure-3PSIDRTS",
+)
+
+
+@dataclass
+class RefreshResult:
+    """Outcome of one ``refresh_and_persist_session`` call.
+
+    ``ok`` is grounded in *observable* token extraction: if the SDK's public
+    ``fetch_tokens_with_domains`` returned a (csrf, session_id) tuple then the
+    session was still acceptable to NotebookLM at the moment of refresh. The
+    metadata fields let a scheduler / operator confirm that the freshness
+    cookies actually moved forward (otherwise "ok" would be silent no-op).
+    """
+
+    ok: bool
+    reason: str = ""
+    before_metadata: dict[str, str] = field(default_factory=dict)
+    after_metadata: dict[str, str] = field(default_factory=dict)
+    changed: list[str] = field(default_factory=list)
+
+
+def _read_short_cookie_metadata(state_file: Path) -> dict[str, str]:
+    """Return ``{cookie_name: "expiry=<unix-ts> | absent"}`` for the freshness
+    cookies. NEVER includes cookie values — those are secrets — only names
+    and expiry timestamps so before/after diff logs are safe to print.
+    """
+    if not state_file.exists():
+        return {name: "absent" for name in _FRESHNESS_COOKIE_NAMES}
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+    except Exception:
+        return {name: "unreadable" for name in _FRESHNESS_COOKIE_NAMES}
+    cookies = data.get("cookies", []) if isinstance(data, dict) else []
+    by_name: dict[str, dict] = {
+        str(c.get("name", "")): c for c in cookies if isinstance(c, dict)
+    }
+    out: dict[str, str] = {}
+    for name in _FRESHNESS_COOKIE_NAMES:
+        cookie = by_name.get(name)
+        if cookie is None:
+            out[name] = "absent"
+            continue
+        # storage_state format uses "expires" (Playwright) or "expiry"
+        expiry = cookie.get("expires", cookie.get("expiry", "?"))
+        out[name] = f"expiry={expiry}"
+    return out
+
 
 # ---------------------------------------------------------------------------
 # Core: rotate + persist
 # ---------------------------------------------------------------------------
 
 
-def rotate_and_persist_session(state_file: Path) -> bool:
-    """Rotate the stored NotebookLM cookies and persist them back to *state_file*.
+def refresh_and_persist_session(state_file: Path) -> RefreshResult:
+    """Refresh the NLM session via the SDK's *public* token-fetch path.
 
-    Best-effort: any exception (missing API, network error, file I/O) is caught
-    and causes this function to return ``False``.  It NEVER raises.
+    This replaces the older ``rotate_and_persist_session`` (still available
+    as a thin back-compat wrapper, below) which used the SDK's *private*
+    ``_rotate_cookies`` poke. The private poke is a fire-and-forget rotation
+    nudge with no verification — it could return success against a revoked
+    session, masking the real failure until the next downstream call broke.
 
-    Steps:
-    1. ``build_httpx_cookies_from_storage`` — load the cookie jar from state.json.
-    2. Create an ``httpx.AsyncClient`` seeded with those cookies.
-    3. ``_rotate_cookies(client, storage_path=state_file)`` — POST to
-       accounts.google.com RotateCookies (best-effort; no-op if env-var disabled).
-    4. ``save_cookies_to_storage(client.cookies, state_file)`` — persist the
-       refreshed jar atomically (upstream uses a threading.Lock).
-    5. ``_tighten_state_file_perms`` — keep permissions strict (user-only).
+    The public ``fetch_tokens_with_domains`` actually GETs the NotebookLM
+    homepage, extracts (csrf_token, session_id), and persists the resulting
+    rotated cookies. If tokens come back, the cookies are observably good.
 
-    Returns ``True`` on success, ``False`` on any failure.
+    Best-effort vs. exceptions: this function NEVER raises. Any failure ends
+    up in ``RefreshResult(ok=False, reason=...)`` so a scheduler can decide
+    whether to surface or retry.
     """
+    before = _read_short_cookie_metadata(state_file)
     try:
-        import httpx
-        from notebooklm.auth import (
-            _rotate_cookies,  # noqa: PLC2701 — private but stable keepalive API
-            build_httpx_cookies_from_storage,
-            save_cookies_to_storage,
-        )
-
-        from research_hub.notebooklm.auth import _tighten_state_file_perms
-
-        jar = build_httpx_cookies_from_storage(state_file)
-
-        async def _do_rotate() -> httpx.Cookies:
-            async with httpx.AsyncClient(cookies=jar, follow_redirects=True) as client:
-                await _rotate_cookies(client, storage_path=state_file)
-                return client.cookies
-
-        rotated_jar = asyncio.run(_do_rotate())
-        save_cookies_to_storage(rotated_jar, state_file)
-        _tighten_state_file_perms(state_file)
-        return True
+        from notebooklm.auth import fetch_tokens_with_domains
     except Exception as exc:  # noqa: BLE001
-        # Best-effort: never raise; callers check the return value.
+        return RefreshResult(
+            ok=False,
+            reason=f"sdk-import-failed: {type(exc).__name__}: {exc}",
+            before_metadata=before,
+            after_metadata=before,
+        )
+    try:
+        # fetch_tokens_with_domains is async; run in a fresh loop. It
+        # internally builds the jar, GETs notebooklm.google.com to obtain
+        # tokens, and persists the refreshed cookies back to state_file.
+        asyncio.run(fetch_tokens_with_domains(path=state_file))
+    except Exception as exc:  # noqa: BLE001
+        after = _read_short_cookie_metadata(state_file)
+        return RefreshResult(
+            ok=False,
+            reason=f"{type(exc).__name__}: {exc}",
+            before_metadata=before,
+            after_metadata=after,
+            changed=[n for n in before if before.get(n) != after.get(n)],
+        )
+    # Optional cosmetic: keep file permissions tight (user-only). Failures
+    # here are not refresh failures.
+    try:
+        from research_hub.notebooklm.auth import _tighten_state_file_perms
+        _tighten_state_file_perms(state_file)
+    except Exception:  # noqa: BLE001
+        pass
+    after = _read_short_cookie_metadata(state_file)
+    changed = [name for name in before if before.get(name) != after.get(name)]
+    return RefreshResult(
+        ok=True,
+        reason="ok",
+        before_metadata=before,
+        after_metadata=after,
+        changed=changed,
+    )
+
+
+def rotate_and_persist_session(state_file: Path) -> bool:
+    """Back-compat shim around :func:`refresh_and_persist_session`.
+
+    Older callers (including some tests) expect a bool return. This wrapper
+    runs the new public-API refresh and collapses the structured result to
+    ``True``/``False``. New code should call ``refresh_and_persist_session``
+    directly to get the metadata diff and a structured reason string.
+    """
+    result = refresh_and_persist_session(state_file)
+    if not result.ok:
         print(
-            f"[nlm-keepalive] WARN rotate_and_persist_session failed "
-            f"({type(exc).__name__}: {exc}); session may be stale.",
+            f"[nlm-keepalive] WARN refresh_and_persist_session failed "
+            f"({result.reason}); session may be stale.",
             file=sys.stderr,
         )
-        return False
+    return result.ok
 
 
 # ---------------------------------------------------------------------------
@@ -98,12 +199,19 @@ def rotate_and_persist_session(state_file: Path) -> bool:
 
 
 def keepalive_once(cfg: Any) -> int:
-    """Run one keepalive cycle.
+    """Run one keepalive cycle: refresh the session and verify cookies moved.
+
+    Sequence (per Codex review of the old design):
 
     1. Resolve the state file from *cfg*.
-    2. ``check_session_health`` — if the session is revoked, print an actionable
-       WARN and return 1 (non-zero so schedulers surface the failure; never raise).
-    3. If healthy, call ``rotate_and_persist_session`` and re-probe before success.
+    2. Call :func:`refresh_and_persist_session` **first**. The SDK's public
+       token-fetch already verifies that NotebookLM accepted the cookies —
+       a pre-health gate would just block the only refresh attempt and
+       guarantee a stale session loops forever.
+    3. If refresh failed, log an actionable hint and return 1.
+    4. Log the before/after freshness-cookie metadata diff so an operator
+       can confirm rotation actually moved expiries forward (the old
+       implementation silently no-op'd here).
 
     Args:
         cfg: A ``HubConfig``-like object exposing ``research_hub_dir: Path``.
@@ -112,36 +220,26 @@ def keepalive_once(cfg: Any) -> int:
         0 on success, non-zero on failure.
     """
     try:
-        from research_hub.notebooklm.auth import (
-            check_session_health,
-            default_state_file,
-        )
+        from research_hub.notebooklm.auth import default_state_file
 
         inv = recommended_cli_invocation()
         state_file = default_state_file(cfg.research_hub_dir)
-        health = check_session_health(state_file)
-        if not health.get("ok"):
-            reason = health.get("reason", "unknown")
+        result = refresh_and_persist_session(state_file)
+        if not result.ok:
             print(
-                f"[nlm-keepalive] WARN NLM session revoked server-side "
-                f"(reason: {reason}) -- run: {inv} notebooklm login --auto-detect",
+                f"[nlm-keepalive] WARN refresh failed: {result.reason} -- "
+                f"run: {inv} notebooklm login --auto-detect",
                 file=sys.stderr,
             )
             return 1
-
-        ok = rotate_and_persist_session(state_file)
-        if not ok:
-            return 1
-
-        post_health = check_session_health(state_file)
-        if not post_health.get("ok"):
-            print(
-                "[nlm-keepalive] WARN keepalive: cookies rotated but session is "
-                "no longer valid (likely server-side re-auth required); "
-                f"run {inv} notebooklm login --auto-detect",
-                file=sys.stderr,
-            )
-            return 1
+        # Surface the metadata diff so the operator can SEE the rotation
+        # actually happened (the old code logged "success" against revoked
+        # sessions for months).
+        changed_str = ", ".join(result.changed) if result.changed else "(no expiry change)"
+        print(
+            f"[nlm-keepalive] OK refresh: changed={changed_str}",
+            file=sys.stderr,
+        )
         return 0
     except Exception as exc:  # noqa: BLE001
         print(
@@ -165,7 +263,7 @@ def _keepalive_loop(cfg: Any, interval_sec: int, sleep_fn=None) -> int:
 
     Args:
         cfg: HubConfig-like object.
-        interval_sec: Seconds between keepalive calls. Floor is 3600.
+        interval_sec: Seconds between keepalive calls. Floor is 600 (10 min).
         sleep_fn: Callable used for sleeping; defaults to ``time.sleep``.
                   Injectable for tests.
 
@@ -174,7 +272,12 @@ def _keepalive_loop(cfg: Any, interval_sec: int, sleep_fn=None) -> int:
     """
     if sleep_fn is None:
         sleep_fn = time.sleep
-    interval_sec = max(3600, interval_sec)
+    # PSIDTS expires ~every 3-4 hours. A 1-hour floor (the old default)
+    # rotated 3-4 times before expiry which gave little safety margin and
+    # routinely lost races on slow networks. Floor at 10 min (600 s) for
+    # accidental-abuse prevention while letting the schtasks default of
+    # 15 min give us ~14 chances per expiry window.
+    interval_sec = max(600, interval_sec)
     print(
         f"[nlm-keepalive] Starting loop (interval={interval_sec}s). "
         "Press Ctrl-C to stop.",
@@ -255,8 +358,12 @@ def _resolve_task_command(cfg: Any) -> tuple[str, Path | None]:
     return task_cmd, wrapper_path
 
 
-def _build_schtasks_argv(interval_hours: int, task_cmd: str) -> list[str]:
+def _build_schtasks_argv(interval_minutes: int, task_cmd: str) -> list[str]:
     """Build the ``schtasks /Create`` argv for the keepalive Scheduled Task.
+
+    Minute-cadence (/SC MINUTE) by design: PSIDTS expires every ~3-4 hours,
+    so hourly was barely enough — a 15-minute cadence gives ~14 retries per
+    expiry window and absorbs flaky-network failures gracefully.
 
     The ``/TR`` (task run) value must be a single string containing the full
     command so that schtasks registers it correctly.
@@ -265,7 +372,7 @@ def _build_schtasks_argv(interval_hours: int, task_cmd: str) -> list[str]:
     for a user-level scheduled task and would break on non-admin accounts.
 
     Args:
-        interval_hours: How often to run the task (hours).
+        interval_minutes: How often to run the task (minutes).
         task_cmd: The resolved task command string (from ``_resolve_task_command``).
 
     Returns:
@@ -277,8 +384,8 @@ def _build_schtasks_argv(interval_hours: int, task_cmd: str) -> list[str]:
         "/F",
         "/TN", _TASK_NAME,
         "/TR", task_cmd,
-        "/SC", "HOURLY",
-        "/MO", str(interval_hours),
+        "/SC", "MINUTE",
+        "/MO", str(interval_minutes),
     ]
 
 
@@ -293,7 +400,7 @@ def _build_schtasks_uninstall_argv() -> list[str]:
 
 
 def run_install_windows_task(
-    interval_hours: int,
+    interval_minutes: int,
     *,
     dry_run: bool,
     uninstall: bool = False,
@@ -306,7 +413,9 @@ def run_install_windows_task(
     or written to disk (the wrapper ``.cmd`` is NOT created in dry-run mode).
 
     Args:
-        interval_hours: Hours between task runs (only used for install).
+        interval_minutes: Minutes between task runs (only used for install).
+            The schtasks command uses ``/SC MINUTE`` so this is literally
+            the ``/MO`` value. Default in the CLI is 15.
         dry_run: If True, print only; never mutate system state (no schtasks
             call, no wrapper file written).
         uninstall: If True, remove instead of create.
@@ -374,10 +483,10 @@ def run_install_windows_task(
 
     # Install path.
     task_cmd, wrapper_path = _resolve_task_command(cfg)
-    argv = _build_schtasks_argv(interval_hours, task_cmd)
+    argv = _build_schtasks_argv(interval_minutes, task_cmd)
     action_desc = (
         f"Register Scheduled Task '{_TASK_NAME}' "
-        f"(every {interval_hours}h via schtasks)"
+        f"(every {interval_minutes}m via schtasks)"
     )
 
     if dry_run:

--- a/tests/test_v0950_nlm_keepalive_and_browser_login.py
+++ b/tests/test_v0950_nlm_keepalive_and_browser_login.py
@@ -70,236 +70,198 @@ def _write_state(tmp_path: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# A. rotate_and_persist_session
+# A. refresh_and_persist_session + rotate_and_persist_session (back-compat shim)
 # ---------------------------------------------------------------------------
 
 
-class TestRotateAndPersistSession:
-    """Tests for keepalive.rotate_and_persist_session."""
+class TestRefreshAndPersistSession:
+    """Tests for the new ``refresh_and_persist_session`` (and the bool
+    shim ``rotate_and_persist_session``). The old test class mocked the
+    SDK's private ``_rotate_cookies`` poke; the new contract uses the
+    SDK's PUBLIC ``fetch_tokens_with_domains`` which actually fetches
+    CSRF + session_id (observable proof the session is alive)."""
 
-    def _make_fake_jar(self) -> MagicMock:
-        jar = MagicMock()
-        jar.items = MagicMock(return_value=[])
-        return jar
-
-    def test_healthy_path_calls_rotate_save_perms(self, tmp_path: Path, monkeypatch):
-        """A1: healthy → _rotate_cookies + save_cookies_to_storage called once + perms."""
+    def test_healthy_returns_ok_with_metadata(self, tmp_path: Path, monkeypatch):
+        """Happy path: SDK token fetch succeeds → RefreshResult(ok=True)
+        with before/after metadata captured from the state file."""
         sf = _write_state(tmp_path)
-        fake_jar = self._make_fake_jar()
-        rotate_calls: list = []
-        save_calls: list = []
-        perm_calls: list = []
+        # Seed state.json with two freshness cookies so before-metadata is non-trivial.
+        import json
+        sf.write_text(json.dumps({"cookies": [
+            {"name": "__Secure-1PSIDTS", "expires": 1700000000.0},
+            {"name": "__Secure-3PSIDTS", "expires": 1700000000.0},
+        ]}), encoding="utf-8")
 
-        import httpx
+        called: list = []
 
-        async def fake_rotate(client, storage_path=None):
-            rotate_calls.append(storage_path)
-            # Simulate: no changes to client.cookies needed
-
-        def fake_build(path=None):
-            # Return a real httpx.Cookies (empty) so AsyncClient accepts it
-            return httpx.Cookies()
-
-        def fake_save(cookie_jar, path=None):
-            save_calls.append((cookie_jar, path))
-
-        def fake_perms(target):
-            perm_calls.append(target)
+        async def fake_fetch(path=None, profile=None):
+            called.append(("fetch", str(path)))
+            # Simulate cookie rotation: bump expiries on disk so the
+            # before/after diff has something to detect.
+            data = json.loads(sf.read_text(encoding="utf-8"))
+            for c in data["cookies"]:
+                c["expires"] = 1700009999.0
+            sf.write_text(json.dumps(data), encoding="utf-8")
+            return ("csrf-tok", "sess-id")
 
         import notebooklm.auth as upstream_auth
-        monkeypatch.setattr(upstream_auth, "_rotate_cookies", fake_rotate)
-        monkeypatch.setattr(upstream_auth, "build_httpx_cookies_from_storage", fake_build)
-        monkeypatch.setattr(upstream_auth, "save_cookies_to_storage", fake_save)
-
+        monkeypatch.setattr(upstream_auth, "fetch_tokens_with_domains", fake_fetch)
         import research_hub.notebooklm.auth as rh_auth
-        monkeypatch.setattr(rh_auth, "_tighten_state_file_perms", fake_perms)
+        monkeypatch.setattr(rh_auth, "_tighten_state_file_perms", lambda _p: None)
+
+        from research_hub.notebooklm.keepalive import refresh_and_persist_session
+        result = refresh_and_persist_session(sf)
+
+        assert result.ok is True, f"expected ok=True; got reason={result.reason!r}"
+        assert result.reason == "ok"
+        assert called == [("fetch", str(sf))], "fetch_tokens_with_domains must run exactly once"
+        # before vs after expiry strings must differ — proves the freshness
+        # cookies actually moved forward, the original silent-fail bug.
+        assert result.before_metadata["__Secure-1PSIDTS"] != result.after_metadata["__Secure-1PSIDTS"]
+        assert "__Secure-1PSIDTS" in result.changed
+
+    def test_sdk_failure_returns_not_ok_never_raises(self, tmp_path: Path, monkeypatch):
+        """SDK raises (network down, auth expired, etc.) → RefreshResult(ok=False)
+        with the exception type/message in `reason`. Must NEVER raise."""
+        sf = _write_state(tmp_path)
+        import notebooklm.auth as upstream_auth
+
+        async def boom(path=None, profile=None):
+            raise RuntimeError("auth expired (simulated)")
+
+        monkeypatch.setattr(upstream_auth, "fetch_tokens_with_domains", boom)
+
+        from research_hub.notebooklm.keepalive import refresh_and_persist_session
+        result = refresh_and_persist_session(sf)
+
+        assert result.ok is False
+        assert "RuntimeError" in result.reason
+        assert "auth expired" in result.reason
+
+    def test_back_compat_shim_returns_bool(self, tmp_path: Path, monkeypatch):
+        """`rotate_and_persist_session` is retained as a thin shim that
+        collapses RefreshResult down to bool for older callers."""
+        sf = _write_state(tmp_path)
+        import notebooklm.auth as upstream_auth
+
+        async def ok_fetch(path=None, profile=None):
+            return ("csrf", "sid")
+
+        monkeypatch.setattr(upstream_auth, "fetch_tokens_with_domains", ok_fetch)
+        import research_hub.notebooklm.auth as rh_auth
+        monkeypatch.setattr(rh_auth, "_tighten_state_file_perms", lambda _p: None)
 
         from research_hub.notebooklm.keepalive import rotate_and_persist_session
+        assert rotate_and_persist_session(sf) is True
 
-        result = rotate_and_persist_session(sf)
-
-        assert result is True
-        assert len(rotate_calls) == 1, "Expected exactly one _rotate_cookies call"
-        assert len(save_calls) == 1, "Expected exactly one save_cookies_to_storage call"
-        assert len(perm_calls) == 1, "Expected exactly one _tighten_state_file_perms call"
-        assert perm_calls[0] == sf
-
-    @pytest.mark.parametrize("failure_mode", [
-        "missing_attr",
-        "rotate_raises",
-        "save_raises",
-    ])
-    def test_never_raises_on_failure(
-        self, tmp_path: Path, monkeypatch, failure_mode: str
-    ):
-        """A2/A3/A4: any internal failure → returns False, never raises."""
+    def test_back_compat_shim_returns_false_on_failure(self, tmp_path: Path, monkeypatch):
+        """Bool shim: SDK failure path → returns False (no exception)."""
         sf = _write_state(tmp_path)
-        fake_jar = self._make_fake_jar()
-
         import notebooklm.auth as upstream_auth
 
-        if failure_mode == "missing_attr":
-            # Remove the attribute so AttributeError fires
-            monkeypatch.setattr(
-                upstream_auth,
-                "build_httpx_cookies_from_storage",
-                None,
-            )
-        elif failure_mode == "rotate_raises":
-            monkeypatch.setattr(
-                upstream_auth,
-                "build_httpx_cookies_from_storage",
-                lambda path=None: fake_jar,
-            )
+        async def boom(path=None, profile=None):
+            raise OSError("network unreachable")
 
-            async def _raising_rotate(client, storage_path=None):
-                raise RuntimeError("simulated rotate failure")
+        monkeypatch.setattr(upstream_auth, "fetch_tokens_with_domains", boom)
 
-            monkeypatch.setattr(upstream_auth, "_rotate_cookies", _raising_rotate)
-        elif failure_mode == "save_raises":
-            monkeypatch.setattr(
-                upstream_auth,
-                "build_httpx_cookies_from_storage",
-                lambda path=None: fake_jar,
-            )
-
-            async def _noop_rotate(client, storage_path=None):
-                pass
-
-            monkeypatch.setattr(upstream_auth, "_rotate_cookies", _noop_rotate)
-            monkeypatch.setattr(
-                upstream_auth,
-                "save_cookies_to_storage",
-                lambda jar, path=None: (_ for _ in ()).throw(IOError("disk full")),
-            )
-
-        from research_hub.notebooklm import keepalive as ka_mod
-        # Reload to pick up patched upstream
-        import importlib
-        importlib.reload(ka_mod)
-
-        # Must not raise
-        try:
-            result = ka_mod.rotate_and_persist_session(sf)
-        except Exception as exc:  # noqa: BLE001
-            pytest.fail(f"rotate_and_persist_session raised {type(exc).__name__}: {exc}")
-
-        assert result is False, f"Expected False for failure_mode={failure_mode}, got {result}"
+        from research_hub.notebooklm.keepalive import rotate_and_persist_session
+        assert rotate_and_persist_session(sf) is False
 
 
 # ---------------------------------------------------------------------------
-# B. keepalive_once
+# B. keepalive_once  (refresh-first contract — no pre-health gate)
 # ---------------------------------------------------------------------------
 
 
 class TestKeepaliveOnce:
-    """Tests for keepalive.keepalive_once."""
+    """Tests for ``keepalive_once``. Codex review of the old design flagged
+    the pre-health gate as a blocker: if the gate failed, the only refresh
+    attempt was skipped, so a transient health-check error guaranteed a
+    stale session forever. The new contract calls refresh FIRST."""
 
-    def test_healthy_session_rotates_returns_0(self, tmp_path: Path, monkeypatch):
-        """B1: session ok → rotate called, returns 0."""
+    def test_refresh_success_returns_zero(self, tmp_path: Path, monkeypatch):
+        """B1: successful refresh → rc 0, OK message includes changed cookies."""
         cfg = _make_cfg(tmp_path)
         sf = _write_state(tmp_path)
-        rotate_calls: list = []
 
+        from research_hub.notebooklm import keepalive as ka_mod
+        from research_hub.notebooklm.keepalive import RefreshResult
+
+        def fake_refresh(_path):
+            return RefreshResult(
+                ok=True,
+                reason="ok",
+                before_metadata={"__Secure-1PSIDTS": "expiry=100"},
+                after_metadata={"__Secure-1PSIDTS": "expiry=200"},
+                changed=["__Secure-1PSIDTS"],
+            )
+
+        monkeypatch.setattr(ka_mod, "refresh_and_persist_session", fake_refresh)
         import research_hub.notebooklm.auth as rh_auth
-        monkeypatch.setattr(
-            rh_auth,
-            "check_session_health",
-            lambda path: {"ok": True, "reason": "ok"},
-        )
-        monkeypatch.setattr(
-            rh_auth,
-            "default_state_file",
-            lambda research_hub_dir: sf,
-        )
-
-        import research_hub.notebooklm.keepalive as ka_mod
-        monkeypatch.setattr(
-            ka_mod,
-            "rotate_and_persist_session",
-            lambda state_file: (rotate_calls.append(state_file), True)[1],
-        )
+        monkeypatch.setattr(rh_auth, "default_state_file", lambda _root: sf)
 
         rc = ka_mod.keepalive_once(cfg)
-
         assert rc == 0
-        assert len(rotate_calls) == 1
 
-    def test_dead_session_warns_returns_nonzero_no_rotate(
+    def test_refresh_failure_returns_one_with_actionable_hint(
         self, tmp_path: Path, monkeypatch, capsys
     ):
-        """B2: session not-ok → WARN printed to stderr, returns non-zero, no rotate."""
+        """B2: refresh failure → rc 1, WARN message names login --auto-detect."""
         cfg = _make_cfg(tmp_path)
         sf = _write_state(tmp_path)
-        rotate_calls: list = []
 
+        from research_hub.notebooklm import keepalive as ka_mod
+        from research_hub.notebooklm.keepalive import RefreshResult
+
+        def fake_refresh(_path):
+            return RefreshResult(ok=False, reason="HTTPError: 401 Unauthorized")
+
+        monkeypatch.setattr(ka_mod, "refresh_and_persist_session", fake_refresh)
         import research_hub.notebooklm.auth as rh_auth
-        monkeypatch.setattr(
-            rh_auth,
-            "check_session_health",
-            lambda path: {"ok": False, "reason": "auth invalid"},
-        )
-        monkeypatch.setattr(
-            rh_auth,
-            "default_state_file",
-            lambda research_hub_dir: sf,
-        )
-
-        import research_hub.notebooklm.keepalive as ka_mod
-        monkeypatch.setattr(
-            ka_mod,
-            "rotate_and_persist_session",
-            lambda state_file: (rotate_calls.append(state_file), True)[1],
-        )
+        monkeypatch.setattr(rh_auth, "default_state_file", lambda _root: sf)
 
         rc = ka_mod.keepalive_once(cfg)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "refresh failed" in err
+        assert "login --auto-detect" in err
 
-        assert rc != 0
-        assert len(rotate_calls) == 0, "rotate must NOT be called when session is dead"
-        captured = capsys.readouterr()
-        assert "revoked" in captured.err or "WARN" in captured.err, (
-            f"Expected WARN in stderr; got: {captured.err!r}"
-        )
-        assert "notebooklm login" in captured.err
-
-    def test_post_rotation_probe_failure_warns_returns_nonzero(
-        self, tmp_path: Path, monkeypatch, capsys
+    def test_refresh_is_called_before_any_health_gate(
+        self, tmp_path: Path, monkeypatch
     ):
-        """B3: rotation success but post-probe not-ok returns non-zero and warns."""
+        """B3: regression for Codex critique — old code ran
+        ``check_session_health`` FIRST and skipped refresh when it failed.
+        New code MUST call refresh first; a (now nonexistent) pre-health
+        gate must not be reintroduced."""
         cfg = _make_cfg(tmp_path)
         sf = _write_state(tmp_path)
-        health_results = [
-            {"ok": True, "reason": "ok"},
-            {"ok": False, "reason": "auth invalid"},
-        ]
-        rotate_calls: list = []
 
+        order: list = []
+        from research_hub.notebooklm import keepalive as ka_mod
+        from research_hub.notebooklm.keepalive import RefreshResult
+
+        def fake_refresh(_path):
+            order.append("refresh")
+            return RefreshResult(ok=True, reason="ok")
+
+        monkeypatch.setattr(ka_mod, "refresh_and_persist_session", fake_refresh)
         import research_hub.notebooklm.auth as rh_auth
-        monkeypatch.setattr(
-            rh_auth,
-            "check_session_health",
-            lambda path: health_results.pop(0),
-        )
-        monkeypatch.setattr(
-            rh_auth,
-            "default_state_file",
-            lambda research_hub_dir: sf,
-        )
 
-        import research_hub.notebooklm.keepalive as ka_mod
-        monkeypatch.setattr(
-            ka_mod,
-            "rotate_and_persist_session",
-            lambda state_file: (rotate_calls.append(state_file), True)[1],
-        )
+        # Poison check_session_health so any reintroduced pre-gate would
+        # short-circuit refresh.
+        def poisoned_check(*_a, **_k):
+            order.append("health-pregate")
+            return {"ok": False, "reason": "should not be called pre-refresh"}
+
+        monkeypatch.setattr(rh_auth, "check_session_health", poisoned_check, raising=False)
+        monkeypatch.setattr(rh_auth, "default_state_file", lambda _root: sf)
 
         rc = ka_mod.keepalive_once(cfg)
-
-        assert rc != 0
-        assert rotate_calls == [sf]
-        captured = capsys.readouterr()
-        assert "cookies rotated" in captured.err
-        assert "notebooklm login" in captured.err
+        assert rc == 0
+        assert order == ["refresh"], (
+            f"refresh must be the first (and only) call; got {order!r}. "
+            "A pre-health gate would short-circuit refresh on transient errors."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -378,7 +340,44 @@ class TestCLIKeepalive:
 
         assert rc == 0
         assert len(sleep_calls) >= 3
-        assert all(s >= 3600 for s in sleep_calls), "Floor must be 3600"
+        assert all(s >= 600 for s in sleep_calls), "Floor must be 600 (10 min)"
+
+    def test_loop_floor_clamps_to_600_seconds(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """C2b: regression for the new 600 s floor. Passing
+        --interval 60 (the SDK's own floor) must be clamped to 600 by
+        _keepalive_loop's `max(600, interval_sec)`. The old code clamped
+        to 3600; the new code MUST clamp to 600. A regression that
+        accidentally restored the old floor would let this assertion
+        observe a 3600 sleep, failing the test."""
+        cfg = _make_cfg(tmp_path)
+        monkeypatch.setattr("research_hub.cli.get_config", lambda: cfg)
+
+        sleep_calls: list[float] = []
+        import research_hub.notebooklm.keepalive as ka_mod
+
+        def fake_sleep(sec: float):
+            sleep_calls.append(sec)
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(ka_mod, "keepalive_once", lambda c: 0)
+        original_loop = ka_mod._keepalive_loop
+        monkeypatch.setattr(
+            ka_mod,
+            "_keepalive_loop",
+            lambda c, interval_sec, sleep_fn=None: original_loop(
+                c, interval_sec, sleep_fn=fake_sleep
+            ),
+        )
+
+        from research_hub import cli
+        rc = cli.main(["notebooklm", "keepalive", "--loop", "--interval", "60"])
+
+        assert rc == 0
+        assert sleep_calls == [600], (
+            f"--interval 60 must be clamped to the 600 s floor; got {sleep_calls!r}"
+        )
 
     def test_install_windows_task_without_yes_is_dry_run(
         self, tmp_path: Path, monkeypatch, capsys
@@ -396,7 +395,7 @@ class TestCLIKeepalive:
         monkeypatch.setattr(ka_mod.shutil, "which", lambda name: None)
 
         with patch("subprocess.run") as mock_run:
-            rc = ka_mod.run_install_windows_task(6, dry_run=True, uninstall=False, cfg=cfg)
+            rc = ka_mod.run_install_windows_task(15, dry_run=True, uninstall=False, cfg=cfg)
 
         assert rc == 0
         mock_run.assert_not_called()
@@ -421,7 +420,7 @@ class TestCLIKeepalive:
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            rc = ka_mod.run_install_windows_task(6, dry_run=False, uninstall=False, cfg=cfg)
+            rc = ka_mod.run_install_windows_task(15, dry_run=False, uninstall=False, cfg=cfg)
 
         assert rc == 0
         mock_run.assert_called_once()
@@ -429,6 +428,18 @@ class TestCLIKeepalive:
         assert "schtasks" in argv_passed[0]
         assert "/Create" in argv_passed
         assert "ResearchHubNLMKeepalive" in " ".join(argv_passed)
+        # Minute-cadence contract (regression guard — the old code used
+        # /SC HOURLY which gave only ~3 retries per PSIDTS expiry window).
+        assert "/SC" in argv_passed
+        sc_idx = argv_passed.index("/SC")
+        assert argv_passed[sc_idx + 1] == "MINUTE", (
+            f"/SC must be MINUTE, got {argv_passed[sc_idx + 1]!r}"
+        )
+        assert "/MO" in argv_passed
+        mo_idx = argv_passed.index("/MO")
+        assert argv_passed[mo_idx + 1] == "15", (
+            f"/MO must be the passed interval_minutes (15), got {argv_passed[mo_idx + 1]!r}"
+        )
         # /RL HIGHEST is removed (P2 fix — needless elevation, breaks non-admin).
         assert "/RL" not in argv_passed, "argv must NOT contain /RL (elevation removed)"
         assert "HIGHEST" not in argv_passed, "argv must NOT contain HIGHEST"
@@ -445,7 +456,7 @@ class TestCLIKeepalive:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
             import research_hub.notebooklm.keepalive as ka_mod
-            rc = ka_mod.run_install_windows_task(6, dry_run=False, uninstall=True, cfg=cfg)
+            rc = ka_mod.run_install_windows_task(15, dry_run=False, uninstall=True, cfg=cfg)
 
         assert rc == 0
         mock_run.assert_called_once()
@@ -462,7 +473,7 @@ class TestCLIKeepalive:
 
         with patch("subprocess.run") as mock_run:
             import research_hub.notebooklm.keepalive as ka_mod
-            rc = ka_mod.run_install_windows_task(6, dry_run=False, uninstall=False, cfg=None)
+            rc = ka_mod.run_install_windows_task(15, dry_run=False, uninstall=False, cfg=None)
 
         assert rc == 1
         mock_run.assert_not_called()
@@ -514,7 +525,7 @@ class TestCLIKeepalive:
         monkeypatch.setattr(ka_mod.shutil, "which", lambda name: fake_script if name == "research-hub" else None)
 
         with patch("subprocess.run") as mock_run:
-            rc = ka_mod.run_install_windows_task(6, dry_run=True, uninstall=False, cfg=cfg)
+            rc = ka_mod.run_install_windows_task(15, dry_run=True, uninstall=False, cfg=cfg)
 
         assert rc == 0
         mock_run.assert_not_called()
@@ -553,7 +564,7 @@ class TestCLIKeepalive:
         monkeypatch.setattr(ka_mod.shutil, "which", lambda name: None)
 
         with patch("subprocess.run") as mock_run:
-            rc = ka_mod.run_install_windows_task(6, dry_run=True, uninstall=False, cfg=cfg)
+            rc = ka_mod.run_install_windows_task(15, dry_run=True, uninstall=False, cfg=cfg)
 
         assert rc == 0
         mock_run.assert_not_called()
@@ -603,7 +614,7 @@ class TestCLIKeepalive:
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            rc = ka_mod.run_install_windows_task(6, dry_run=False, uninstall=False, cfg=cfg)
+            rc = ka_mod.run_install_windows_task(15, dry_run=False, uninstall=False, cfg=cfg)
 
         assert rc == 0
 
@@ -646,7 +657,7 @@ class TestCLIKeepalive:
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
-            rc = ka_mod.run_install_windows_task(6, dry_run=False, uninstall=True, cfg=cfg)
+            rc = ka_mod.run_install_windows_task(15, dry_run=False, uninstall=True, cfg=cfg)
 
         assert rc == 0
         mock_run.assert_called_once()


### PR DESCRIPTION
Implements Codex's fix sketch from `.ai/codex_nlm_findings.md` (lines 496-700). The old keepalive **never actually achieved** the documented "持久一年" — it called the SDK's private `_rotate_cookies` poke which returned success without verifying the session was still alive. Every "ok" in the logs could have been a silent no-op against a revoked session.

## The new refresh contract

`refresh_and_persist_session(state_file) -> RefreshResult` calls the SDK's **public** `fetch_tokens_with_domains`, which GETs the NotebookLM homepage and extracts `(csrf_token, session_id)` as the side-effect of cookie rotation. If tokens come back, the cookies are observably good — no silent no-op possible.

Returns a structured `RefreshResult` with:
- `ok` / `reason`
- `before_metadata` / `after_metadata` — non-secret freshness-cookie expiry diffs (names + expiries, **never values**)
- `changed` — which `__Secure-{1,3}PSIDTS` / `__Secure-{1,3}PSIDRTS` actually moved forward

The old `rotate_and_persist_session(state_file) -> bool` is kept as a thin back-compat shim.

## `keepalive_once`: refresh-first contract

Old code: pre-health gate → if it failed, skip refresh → stale session loops forever (Codex's central critique).
New code: refresh first (the SDK's token fetch IS the verification), then log the metadata diff so the operator can **see** PSIDTS expiries actually moved forward.

Regression test `TestKeepaliveOnce.test_refresh_is_called_before_any_health_gate` poisons `check_session_health` to fail if it's called pre-refresh; asserts the call order is `["refresh"]` exactly. Catches any accidental reintroduction of the pre-gate.

## Cadence: hourly → 15-minute

PSIDTS expires every ~3-4 hours. The old hourly default left ~3 retries per expiry window and routinely lost races on flaky networks.

- `--interval` default 21600 → 900 s (15 min); floor 3600 → 600 s
- `--interval-minutes` (new, default 15) replaces `--interval-hours`
- `--interval-hours` kept as a deprecated alias multiplied to minutes at dispatch
- `_build_schtasks_argv` switches `/SC HOURLY` → `/SC MINUTE`

## Code-review (REQUEST CHANGES → addressed)

Code-reviewer caught 3 critical issues: stale numeric constants the test layer carried forward from the old hours-based API.

- ✅ Test C2 floor assertion `>= 3600` → `>= 600` (it was passing for the wrong reason — any restored 3600 floor would have slipped past)
- ✅ `keepalive.py:266` docstring `Floor is 3600.` → `Floor is 600 (10 min).`
- ✅ Test C3-C10 `run_install_windows_task(6, ...)` → `(15, ...)` (8 call sites; `6` after the param-name change meant 6 *minutes* which would have registered a broken task in production)
- ✅ New `C2b` test pins the 600 s floor explicitly (`--interval 60` → asserts observed sleep is exactly 600)
- ✅ New `C4` assertions pin `/SC MINUTE` and `/MO 15` argv values

CHANGELOG also softened to state 持久一年 is achievable **only when** (a) scheduled task runs uninterrupted, (b) Google doesn't revoke the account, and (c) long-lived SID/PSID haven't naturally expired (keepalive doesn't defeat any of those).

## Verification

`pytest -k "keepalive or nlm or notebooklm or login"`: **210 passed, 7 skipped, 0 failed** (was 209 + 1 new floor-clamp test).

Co-Reviewed-By: code-review skill (multi-file 4f / 480ins; REQUEST CHANGES → all 3 critical addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)