### PR TITLE
feat(auto): --year RANGE flag for recent-bias literature filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ UI scope is capped here by decision: the dashboard stays a thin
 status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
+### Added
+- **`auto --year RANGE` flag** (`cli.py`, `auto.py`). The standalone
+  `search --year` filter is now also exposed on the `auto` subcommand so
+  users who want recent literature can write
+  `auto "LLM × X" --year 2024-` directly instead of running a separate
+  search step. Same syntax as `search --year`: `2024-2025` (closed range),
+  `2024-` (from 2024), `-2024` (up to 2024). Wired end-to-end through
+  `_auto()` → `auto_pipeline(..., year_from, year_to)` → `_run_search()` →
+  `search_papers(year_from, year_to)`. Unset = no year filter, behaviour
+  unchanged.
+
 ### Changed
 - **LLM-judge fit-check uses a stricter rubric when the cluster topic is
   LLM-narrowed** (`fit_check.py`). For a cluster topic that explicitly

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -88,6 +88,10 @@ def auto_pipeline(
     with_summary: bool = False,
     peer_reviewed: bool = False,
     include_suspect_urls: bool = False,
+    # Year filter for the search step (parsed upstream from `--year RANGE`).
+    # None on either side = unbounded in that direction.
+    year_from: int | None = None,
+    year_to: int | None = None,
 ) -> AutoReport:
     """End-to-end ingest + optional NotebookLM publish.
 
@@ -188,6 +192,12 @@ def auto_pipeline(
                 f", exclude_types={','.join(exclude_types)}, "
                 f"min_confidence={min_confidence:g}"
             )
+        if year_from is not None or year_to is not None:
+            year_note = (
+                f"{year_from if year_from is not None else ''}-"
+                f"{year_to if year_to is not None else ''}"
+            )
+            filter_note += f", year={year_note}"
         plan_lines = [
             f"  search {topic!r} (max_papers={max_papers}, "
             f"backends={'+'.join(backends)}{filter_note})",
@@ -272,6 +282,10 @@ def auto_pipeline(
             search_kwargs["peer_reviewed"] = True
         if field is not None:
             search_kwargs["field"] = field
+        if year_from is not None:
+            search_kwargs["year_from"] = year_from
+        if year_to is not None:
+            search_kwargs["year_to"] = year_to
         papers = _run_search(topic, **search_kwargs)
         report.papers_ingested = len(papers)  # tentative
         _step_log(report, "search", True, _elapsed(started, report), f"{len(papers)} results", print_progress)
@@ -1286,9 +1300,11 @@ def _run_search(
     cluster_slug: str,
     field: Optional[str] = None,
     peer_reviewed: bool = False,
+    year_from: int | None = None,
+    year_to: int | None = None,
 ) -> list[dict]:
     """Run arxiv + semantic_scholar search, return papers_input dicts."""
-    from research_hub.search import search_papers       
+    from research_hub.search import search_papers
 
 
     # v0.49.4: search arxiv + semantic-scholar + openalex + crossref so the
@@ -1303,5 +1319,7 @@ def _run_search(
         exclude_types=exclude_types,
         min_confidence=min_confidence,
         limit=max_papers,
+        year_from=year_from,
+        year_to=year_to,
     )
     return _to_papers_input([asdict(r) for r in results], cluster_slug)

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -4943,6 +4943,9 @@ def _auto(
     with_summary: bool = False,
     peer_reviewed: bool = False,
     include_suspect_urls: bool = False,
+    # Year filter — parsed from `--year RANGE` upstream. None = no filter.
+    year_from: int | None = None,
+    year_to: int | None = None,
     emit_json: bool = False,
 ) -> int:
     from research_hub.auto import auto_pipeline
@@ -4999,6 +5002,10 @@ def _auto(
             auto_kwargs["with_pdfs"] = True
         if with_summary:
             auto_kwargs["with_summary"] = True
+        if year_from is not None:
+            auto_kwargs["year_from"] = year_from
+        if year_to is not None:
+            auto_kwargs["year_to"] = year_to
         report = auto_pipeline(**auto_kwargs)
     finally:
         if batch_label is not None:
@@ -5372,6 +5379,16 @@ def build_parser() -> argparse.ArgumentParser:
     auto_parser.add_argument("--cluster-name", default=None,
                              help="Display name for new cluster (default: title-case of topic)")
     auto_parser.add_argument("--max-papers", type=int, default=8)
+    auto_parser.add_argument(
+        "--year",
+        default=None,
+        metavar="RANGE",
+        help=(
+            "Year range filter for the search step, e.g. '2024-2025', "
+            "'2024-' (2024 and later), or '-2024' (up to 2024). Same syntax "
+            "as the standalone `search --year` flag. Unset = no year filter."
+        ),
+    )
     auto_parser.add_argument("--field", default=None,
                              choices=["cs", "bio", "med", "physics", "math", "social", "econ", "chem", "astro", "edu", "general"],
                              help="Field preset for backend selection")
@@ -7559,6 +7576,11 @@ def _main_dispatch(args, parser) -> int:
             # them to True here so an explicit --no-with-pdfs or
             # --no-with-summary is respected even under --full-auto.
             args.with_crystals = True
+        # Parse --year RANGE → (year_from, year_to). None on either side
+        # = unbounded; both None = no year filter applied.
+        year_from, year_to = (
+            _parse_year_range(args.year) if getattr(args, "year", None) else (None, None)
+        )
         return _auto(
             topic=args.topic,
             cluster_slug=args.cluster,
@@ -7582,6 +7604,8 @@ def _main_dispatch(args, parser) -> int:
             batch_label=args.batch_label,
             with_pdfs=args.with_pdfs,
             with_summary=args.with_summary,
+            year_from=year_from,
+            year_to=year_to,
             emit_json=args.json,
         )
     if args.command == "ingest":


### PR DESCRIPTION
The standalone `search --year` filter is already supported by `search_papers(year_from, year_to)` and tested via `test_discover` etc., but the `auto` subcommand had no way to pass it through. Users running `auto "LLM × X"` who wanted "2024+ only" had to drop down to a separate `search --year 2024- --to-papers-input` plus `ingest` flow, or eyeball-prune older results post-ingest.

## What changes

Expose the same `--year RANGE` syntax on `auto`:

| Syntax | Meaning |
|---|---|
| `--year 2024-2025` | Closed range |
| `--year 2024-` | From 2024 (no upper bound) |
| `--year -2024` | Up to 2024 (no lower bound) |
| (unset) | No year filter — behaviour unchanged |

## Wired end-to-end

```
cli.py argparse --year
  → _parse_year_range(args.year)
  → _auto(..., year_from, year_to)
  → auto_pipeline(..., year_from, year_to)
  → _run_search(..., year_from, year_to)
  → search_papers(..., year_from, year_to)
```

The dry-run plan-printer surfaces the filter as `year=2024-` next to the existing `max_papers/backends` line so users can confirm the filter applies before a real run.

## Smoke verification

```
$ research-hub auto "test topic" --max-papers 5 --year 2024- --dry-run
[OK] cluster        would create: test-topic
Dry-run plan:
  search 'test topic' (max_papers=5, backends=arxiv+semantic-scholar+openalex+crossref, year=2024-)
  fit-check via LLM judge (claude, threshold=4)
  ingest into cluster test-topic
  ...
```

## Verification

`pytest -k "auto or cli"`: **440 passed, 7 skipped, 0 failed**.

## Project-level vs personal config

This is a project-level capability (every `auto` user can pass `--year`), not personal config. Sister to PRs #90 / #103 / #104 / #106 in the "make auto's defaults give precise, recent, LLM-specific clusters" arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)