### PR TITLE
feat(ezproxy): institutional PDF access — per-institution URL template + browser-captured cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
 ### Added
+- **EZproxy support for paywalled PDF downloads** (`ezproxy.py`, `cli.py`,
+  `zotero/pdf_attach.py`, `pyproject.toml`). Opt-in via
+  `cfg.ezproxy_url_template`. New
+  `research-hub ezproxy login` captures institutional SSO cookies via
+  Playwright; `paper attach-pdfs` then wraps publisher URLs through the
+  proxy and falls back to the direct URL on any proxy failure. Generic
+  per-institution template — any university with an EZproxy gateway can
+  configure it. Closes the IEEE/Wiley/Elsevier-via-paywall gap noted in
+  the README's Known limitations.
 - **`auto --year RANGE` flag** (`cli.py`, `auto.py`). The standalone
   `search --year` filter is now also exposed on the `auto` subcommand so
   users who want recent literature can write

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ which workaround to reach for.
 
 | Limitation | What's actually happening | What to do |
 |---|---|---|
-| **IEEE Xplore PDFs / URLs are blocked** by anti-bot | IEEE returns an *"Unable to Load Page"* HTML stub to both our URL pre-check AND NotebookLM's server-side fetcher. The bundle ladder flags these as `likely_error_page` and warns. | Either (a) download the PDF through your institutional access and drop it on the Zotero item / upload it in the NotebookLM web UI manually, or (b) skip the IEEE source — the abstract is still in Zotero and the Obsidian note. |
+| **IEEE Xplore PDFs / URLs are blocked** by anti-bot | IEEE returns an *"Unable to Load Page"* HTML stub to direct fetches. `paper attach-pdfs` can now route configured publisher PDF URLs through your institution's EZproxy and fall back to the direct URL if the proxy fails. | Configure `ezproxy_url_template`, run `research-hub ezproxy login` once, then re-run `paper attach-pdfs`. See [EZproxy PDF access](docs/ezproxy.md). Without EZproxy, manually attach the PDF through institutional access or skip the source. |
 | **NotebookLM session expires ~every 3.5h** | Google's short-lived `__Secure-1PSIDTS` / `PSIDRTS` cookies are not refreshable by background polling. `notebooklm keepalive` exists but cannot rotate them server-side. | Re-run `research-hub notebooklm login --auto-detect` when a run reports an auth failure — < 1 minute, no terminal interaction. |
 | **`--no-llm-fit-check` can't filter "wrong sub-topic, right field"** | The no-LLM BM25 gate is designed to catch *blatant cross-field contamination* (e.g. pure hydrology with zero AI in an LLM cluster). It cannot tell "AI-agents-in-general" from "AI-agents-in-water-resources" — both score similarly on a lexical-only metric, so the gate is recall-biased and keeps both. | For topic-specific subset filtering, use the **default** LLM-judge path (drop `--no-llm-fit-check`). The LLM-judge layer is what's designed to make semantic relevance calls. |
 | **Cluster-overview LLM auto-fill writes English headings even when the scaffold is Chinese** | `topic.py` writes Chinese section headings (`## 核心問題`, `## 範圍定義`, …) for the empty scaffold, but `apply_overview` re-renders the file with English headings (`## Core Question`, `## Scope`, …) when the LLM fills it in. | Cosmetic — content is correct. If you prefer Chinese headings on the filled overview, hand-curate the section names after the first auto-fill (the markers ensure subsequent runs preserve your edits). |
@@ -397,7 +397,7 @@ which workaround to reach for.
 
 ## Docs + Status + Dev
 
-Docs: [First 10 minutes](docs/first-10-minutes.md), [lazy mode](docs/lazy-mode.md), [dashboard walkthrough](docs/dashboard-walkthrough.md), [MCP tools](docs/mcp-tools.md), [AI host support matrix](docs/ai-host-support.md), [live smoke checklist](docs/live-smoke.md), [personas](docs/personas.md), [NotebookLM setup](docs/notebooklm.md), [import folder](docs/import-folder.md), [CLI reference](docs/cli-reference.md), [CHANGELOG](CHANGELOG.md).
+Docs: [First 10 minutes](docs/first-10-minutes.md), [lazy mode](docs/lazy-mode.md), [dashboard walkthrough](docs/dashboard-walkthrough.md), [MCP tools](docs/mcp-tools.md), [AI host support matrix](docs/ai-host-support.md), [live smoke checklist](docs/live-smoke.md), [personas](docs/personas.md), [NotebookLM setup](docs/notebooklm.md), [EZproxy PDF access](docs/ezproxy.md), [import folder](docs/import-folder.md), [CLI reference](docs/cli-reference.md), [CHANGELOG](CHANGELOG.md).
 
 Status:
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -13,6 +13,7 @@
 # against"; this file is the human-readable contract.
 networkx>=3.0,<4.0
 notebooklm-py>=0.4.1,<0.5.0
+httpx>=0.27,<1.0
 rookiepy>=0.1.0
 platformdirs>=4.0,<6.0
 pyzotero>=1.5.18,<2.0

--- a/docs/ezproxy.md
+++ b/docs/ezproxy.md
@@ -1,0 +1,30 @@
+# EZproxy PDF Access
+
+EZproxy support is opt-in and only affects `paper attach-pdfs`.
+
+1. Set your institution's URL template. It must contain `{encoded_url}`:
+
+   ```bash
+   research-hub config set ezproxy_url_template "https://login.example.edu/login?qurl={encoded_url}"
+   ```
+
+   If your library uses EZproxy, the template is usually visible after you
+   click a publisher link from the library portal. Replace the target article
+   URL with `{encoded_url}`.
+
+2. Run the browser login once:
+
+   ```bash
+   research-hub ezproxy login
+   ```
+
+3. Verify state:
+
+   ```bash
+   research-hub ezproxy status
+   ```
+
+4. Re-run `paper attach-pdfs`. Paywalled publisher PDF URLs now try the proxy
+   first and fall back to the direct URL on any proxy failure.
+
+Cookies usually last 1-4 weeks before your institution requires re-login.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "networkx>=3.0,<4.0",
     "notebooklm-py>=0.4.1,<0.5.0",
+    "httpx>=0.27,<1.0",
     "platformdirs>=4.0,<6.0",
     "pyzotero>=1.5.18,<2.0",
     "pyyaml>=6,<7",

--- a/src/research_hub/auto.py
+++ b/src/research_hub/auto.py
@@ -570,7 +570,7 @@ def _run_pdf_attach_step(
         if local_pdfs_dir is not None:
             local_pdfs_dir = local_pdfs_dir / "pdfs"
         results = attach_pdfs(web, actionable, rate_limit_rps=1.0,
-                               local_pdfs_dir=local_pdfs_dir)
+                               local_pdfs_dir=local_pdfs_dir, cfg=cfg)
         summary = results.summary
         ok, skip, fail = summary.ok, summary.skip, summary.fail
         _step_log(report, "pdf.attach", True, _elapsed(started, report),

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -181,6 +181,8 @@ def _config_encrypt_secrets() -> int:
 
 
 _ALLOWED_CONFIG_KEYS = frozenset({
+    "ezproxy_cookies_path",
+    "ezproxy_url_template",
     "unpaywall_email",
     "zotero.unpaywall_email",
     "persona",
@@ -1571,6 +1573,7 @@ def _paper_attach_pdfs(
         rate_limit_rps=rate_limit,
         keep_url_fallback=keep_url_fallback,
         max_pdf_size_mb=max_pdf_size_mb,
+        cfg=cfg,
     )
     manifest = Manifest(cfg.research_hub_dir / "manifest.jsonl")
     batch_label = _manifest_batch_label("pdf-attach")
@@ -5218,6 +5221,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Allow setting a key not in the allowlist (use for new fields)",
     )
 
+    ezproxy_parser = subparsers.add_parser(
+        "ezproxy",
+        help="Institutional EZproxy support for paywalled PDF downloads",
+    )
+    ezproxy_sub = ezproxy_parser.add_subparsers(dest="ezproxy_command", required=True)
+    ezproxy_login = ezproxy_sub.add_parser(
+        "login",
+        help="Open a browser, complete institutional SSO, save cookies",
+    )
+    ezproxy_login.add_argument(
+        "--sentinel-url",
+        default="https://ieeexplore.ieee.org/",
+        help="Publisher URL to load (proxied) so you can verify access before closing the window",
+    )
+    ezproxy_sub.add_parser("status", help="Show configured template + cookie file state")
+
     examples_parser = subparsers.add_parser(
         "examples",
         help="Browse and copy bundled cluster examples",
@@ -7392,7 +7411,7 @@ def _main_dispatch(args, parser) -> int:
 
     _warn_cli_deprecated_alias_from_args(args)
 
-    exempt_commands = {"init", "setup", "doctor", "install", "examples", "where", "config", "package-dxt", "describe", "context"}
+    exempt_commands = {"init", "setup", "doctor", "install", "examples", "where", "config", "ezproxy", "package-dxt", "describe", "context"}
 
     if args.command not in exempt_commands and get_config is require_config.__globals__["get_config"]:
         require_config()
@@ -7470,6 +7489,26 @@ def _main_dispatch(args, parser) -> int:
         if args.config_command == "set":
             return _config_set(args.key, args.value, force=getattr(args, "force", False))
         parser.error("config requires a subcommand")
+        return 2
+    if args.command == "ezproxy":
+        from research_hub.ezproxy import login as ezproxy_login
+        from research_hub.ezproxy import resolve_config
+
+        cfg = get_config()
+        ezcfg = resolve_config(cfg)
+        if args.ezproxy_command == "login":
+            return ezproxy_login(
+                ezcfg.cookies_path,
+                url_template=ezcfg.url_template,
+                sentinel_url=args.sentinel_url,
+            )
+        if args.ezproxy_command == "status":
+            print(f"ezproxy_url_template: {ezcfg.url_template or '(unset)'}")
+            print(f"cookies_path: {ezcfg.cookies_path}")
+            print(f"cookies file exists: {ezcfg.cookies_path.exists()}")
+            print(f"enabled: {ezcfg.enabled}")
+            return 0
+        parser.error("ezproxy requires a subcommand")
         return 2
     if args.command == "examples":
         from research_hub.examples import copy_example_as_cluster, list_examples, load_example

--- a/src/research_hub/config.py
+++ b/src/research_hub/config.py
@@ -107,6 +107,8 @@ class HubConfig:
         config_persona: str | None = None
         config_no_zotero: bool = False
         config_disable_pdf_fallback: bool = False
+        config_ezproxy_url_template: str | None = None
+        config_ezproxy_cookies_path: str | None = None
         config_unpaywall_email: str | None = None
         config_zotero_parent_collection: str | None = None
         config_llm_cli_adapters: dict = {}
@@ -132,6 +134,8 @@ class HubConfig:
             config_persona = data.get("persona")
             config_no_zotero = bool(data.get("no_zotero", False))
             config_disable_pdf_fallback = bool(data.get("disable_pdf_fallback", False))
+            config_ezproxy_url_template = data.get("ezproxy_url_template")
+            config_ezproxy_cookies_path = data.get("ezproxy_cookies_path")
             zotero = data.get("zotero", {})
             config_unpaywall_email = data.get("unpaywall_email")
             config_zotero_api_key = zotero.get("api_key")
@@ -208,6 +212,12 @@ class HubConfig:
         self.disable_pdf_fallback = config_disable_pdf_fallback or (
             os.environ.get("RESEARCH_HUB_DISABLE_PDF_FALLBACK", "").lower() in {"1", "true", "yes"}
         )
+        self.ezproxy_url_template = str(
+            config_ezproxy_url_template or os.environ.get("RESEARCH_HUB_EZPROXY_URL_TEMPLATE", "")
+        ).strip()
+        self.ezproxy_cookies_path = str(
+            config_ezproxy_cookies_path or os.environ.get("RESEARCH_HUB_EZPROXY_COOKIES_PATH", "")
+        ).strip()
         self.unpaywall_email = str(
             config_unpaywall_email or os.environ.get("UNPAYWALL_EMAIL", "")
         ).strip()

--- a/src/research_hub/ezproxy.py
+++ b/src/research_hub/ezproxy.py
@@ -1,0 +1,172 @@
+"""EZproxy support for institutional PDF access.
+
+Opt-in. Users set ``cfg.ezproxy_url_template`` (a Python format template
+like ``https://login.ezproxy.youruniversity.edu/login?qurl={encoded_url}``)
+and run ``research-hub ezproxy login`` once to capture cookies. After that,
+``paper attach-pdfs`` can wrap publisher URLs through the proxy, falling back
+to the original URL on any proxy failure.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+
+@dataclass
+class EZproxyConfig:
+    """Resolved EZproxy settings for a HubConfig-like object."""
+
+    url_template: str
+    cookies_path: Path
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.url_template) and self.cookies_path.exists()
+
+
+def resolve_config(cfg: Any) -> EZproxyConfig:
+    """Read EZproxy settings from a HubConfig-like object."""
+
+    try:
+        template = (getattr(cfg, "ezproxy_url_template", "") or "").strip()
+    except Exception:
+        template = ""
+    try:
+        raw_path = getattr(cfg, "ezproxy_cookies_path", "") or ""
+    except Exception:
+        raw_path = ""
+    try:
+        cookies_path = Path(raw_path).expanduser() if raw_path else None
+    except Exception:
+        cookies_path = None
+    if cookies_path is None:
+        try:
+            base = Path(getattr(cfg, "research_hub_dir", ".")).expanduser()
+        except Exception:
+            base = Path(".")
+        cookies_path = base / "ezproxy_cookies.json"
+    return EZproxyConfig(url_template=template, cookies_path=cookies_path)
+
+
+def wrap_url(original_url: str, template: str) -> str:
+    """Wrap an absolute publisher URL through an EZproxy template."""
+
+    try:
+        if not template or "{encoded_url}" not in template:
+            return original_url
+        return template.format(encoded_url=quote(original_url, safe=""))
+    except Exception:
+        return original_url
+
+
+def load_cookies(cookies_path: Path) -> dict[str, str]:
+    """Load Playwright storage-state cookies as a ``{name: value}`` dict."""
+
+    try:
+        if not cookies_path.exists():
+            return {}
+        import json
+
+        data = json.loads(cookies_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    cookies = data.get("cookies", []) if isinstance(data, dict) else []
+    out: dict[str, str] = {}
+    for cookie in cookies:
+        if not isinstance(cookie, dict):
+            continue
+        name = cookie.get("name")
+        value = cookie.get("value")
+        if isinstance(name, str) and isinstance(value, str):
+            out[name] = value
+    return out
+
+
+def login(
+    cookies_path: Path,
+    *,
+    url_template: str = "",
+    sentinel_url: str = "https://ieeexplore.ieee.org/",
+    profile_dir: Path | None = None,
+) -> int:
+    """Open a persistent browser context and save EZproxy cookies on close."""
+
+    try:
+        from playwright.sync_api import Error as PlaywrightError
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        print(
+            "  [ezproxy] Playwright is not installed; cannot open browser login.\n"
+            "            Install it with: pip install 'research-hub-pipeline[playwright]'",
+            file=sys.stderr,
+        )
+        return 1
+
+    from research_hub.notebooklm.auth import _playwright_event_loop
+    from research_hub.notebooklm.auth import _tighten_state_file_perms
+
+    cookies_path = Path(cookies_path).expanduser()
+    profile = Path(profile_dir).expanduser() if profile_dir is not None else cookies_path.parent / "ezproxy_profile"
+    try:
+        cookies_path.parent.mkdir(parents=True, exist_ok=True)
+        profile.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"  [ezproxy] cannot create browser profile dir: {exc}", file=sys.stderr)
+        return 1
+
+    homepage = wrap_url(sentinel_url, url_template) if url_template else sentinel_url
+    launch_kwargs = {
+        "user_data_dir": str(profile),
+        "headless": False,
+        "args": [
+            "--disable-blink-features=AutomationControlled",
+            "--password-store=basic",
+        ],
+        "ignore_default_args": ["--enable-automation"],
+    }
+
+    with _playwright_event_loop():
+        playwright = None
+        context = None
+        try:
+            playwright = sync_playwright().start()
+            context = playwright.chromium.launch_persistent_context(**launch_kwargs)
+            page = context.pages[0] if context.pages else context.new_page()
+            try:
+                page.goto(homepage, timeout=30_000)
+            except PlaywrightError:
+                pass
+            print(
+                "  [ezproxy] Browser opened. Complete institutional SSO, verify access,\n"
+                "            then close the browser window to save cookies.",
+            )
+            while True:
+                try:
+                    if not context.pages:
+                        break
+                except PlaywrightError:
+                    break
+                time.sleep(1.0)
+            context.storage_state(path=str(cookies_path))
+            _tighten_state_file_perms(cookies_path)
+            print(f"  [ezproxy] Saved cookies to {cookies_path}")
+            return 0
+        except Exception as exc:  # noqa: BLE001 - login must fail closed
+            print(f"  [ezproxy] login failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+            return 1
+        finally:
+            try:
+                if context is not None:
+                    context.close()
+            except Exception:
+                pass
+            try:
+                if playwright is not None:
+                    playwright.stop()
+            except Exception:
+                pass

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -1395,7 +1395,7 @@ def run_pipeline(
                 try:
                     items = [zot.item(key) for key in just_added_keys]
                     plans = plan_attach_for_items(items, unpaywall_email=oa_email)
-                    pdf_results = attach_pdfs(zot, plans, rate_limit_rps=2.0)
+                    pdf_results = attach_pdfs(zot, plans, rate_limit_rps=2.0, cfg=cfg)
                     slug_by_key = {
                         pp.get("zotero_key", ""): pp.get("slug", "")
                         for pp in papers_for_notes

--- a/src/research_hub/zotero/pdf_attach.py
+++ b/src/research_hub/zotero/pdf_attach.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
 import shutil
 import sys
@@ -13,6 +14,7 @@ from pathlib import Path
 from typing import Iterable, Optional
 from urllib.parse import urlparse
 
+import httpx
 import requests
 
 from research_hub.utils.doi import normalize_doi as _normalize_doi
@@ -22,6 +24,7 @@ UNPAYWALL_BASE = "https://api.unpaywall.org/v2"
 CROSSREF_BASE = "https://api.crossref.org/works"
 
 _HINT_SHOWN = False  # once-per-process flag for the unpaywall_email hint
+logger = logging.getLogger(__name__)
 
 
 def _reset_hint_state() -> None:
@@ -129,6 +132,13 @@ class _PdfDownloadResult:
     status: int | None = None
     reason: str | None = None
     bytes: int | None = None
+
+
+@dataclass(frozen=True)
+class _PdfBytesResult:
+    content: bytes | None
+    status: int | None = None
+    reason: str | None = None
 
 
 _LAST_DOWNLOAD_RESULTS: dict[str, _PdfDownloadResult] = {}
@@ -316,74 +326,124 @@ def _has_existing_pdf(zot, item_key: str) -> bool:
     return False
 
 
-def _download_pdf_to_temp(url: str, *, max_mb: int = 25) -> Path | None:
+def _download_pdf_to_temp(url: str, *, max_mb: int = 25, cfg=None) -> Path | None:
     """Download a PDF URL to a temp file and return the local path."""
 
-    result = _download_pdf_to_temp_result(url, max_mb=max_mb)
+    result = _download_pdf_to_temp_result(url, max_mb=max_mb, cfg=cfg)
     _LAST_DOWNLOAD_RESULTS[url] = result
     return result.path
 
 
-def _download_pdf_to_temp_result(url: str, *, max_mb: int = 25) -> _PdfDownloadResult:
+def _download_pdf_to_temp_result(url: str, *, max_mb: int = 25, cfg=None) -> _PdfDownloadResult:
     """Download a PDF URL and retain the reason when it cannot be saved."""
 
-    # v0.90.0 G1#5/#6 fix:
-    # - wrap requests.get(stream=True) in `with` so the connection is released
-    #   even when we early-return; pre-fix held connections until GC, which
-    #   starved the pool at N=1000 paper batches.
-    # - clean up partial temp files on write_bytes failure so a disk-full or
-    #   interrupted write doesn't leave 0-byte / partial .pdf cruft in
-    #   tempfile.gettempdir(). Happy-path cleanup is the caller's job
-    #   (see _upload_local_pdf call sites' try/finally local_path.unlink()).
+    result = _download_pdf_bytes_with_ezproxy_result(url, cfg=cfg, timeout=60, max_size_mb=max_mb)
+    if result.content is None:
+        return _PdfDownloadResult(None, status=result.status, reason=result.reason)
+    return _write_pdf_temp(url, result.content, status=result.status)
+
+
+# Dead `_download_pdf_with_ezproxy_fallback` removed (PR feedback): it was
+# a parallel-with-`_download_pdf_bytes_with_ezproxy_result` copy that the
+# production path never used. Tests are updated to exercise the live
+# `_download_pdf_bytes_with_ezproxy_result` directly.
+
+
+def _download_pdf_bytes_with_ezproxy_result(
+    url: str,
+    *,
+    cfg=None,
+    timeout: int = 60,
+    max_size_mb: int = 25,
+) -> _PdfBytesResult:
     parsed = urlparse(url)
     if parsed.netloc.endswith(".test") and parsed.path.lower().endswith(".pdf"):
         # Reserved .test URLs are used throughout the unit suite; keep them
         # offline while still exercising the imported_file upload path.
-        content = b"%PDF-1.4\n% research-hub test fixture\n"
-        digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
-        target = Path(tempfile.gettempdir()) / f"rh_pdf_{digest}.pdf"
+        return _PdfBytesResult(b"%PDF-1.4\n% research-hub test fixture\n")
+    if cfg is not None:
         try:
-            target.write_bytes(content)
-        except Exception:
-            _cleanup_partial_temp_pdf(target)
-            return _PdfDownloadResult(None, reason="network_error")
-        return _PdfDownloadResult(target, bytes=len(content))
+            from research_hub.ezproxy import load_cookies, resolve_config, wrap_url
+
+            ezcfg = resolve_config(cfg)
+            if ezcfg.enabled:
+                wrapped = wrap_url(url, ezcfg.url_template)
+                if wrapped != url:
+                    proxy_result = _download_via_httpx_result(
+                        wrapped,
+                        cookies=load_cookies(ezcfg.cookies_path),
+                        timeout=timeout,
+                        max_size_mb=max_size_mb,
+                    )
+                    if proxy_result.content is not None:
+                        return proxy_result
+                    logger.info(
+                        "ezproxy fetch failed (%s); falling back to direct URL",
+                        proxy_result.reason or proxy_result.status or "unknown",
+                    )
+        except Exception as exc:  # noqa: BLE001 - fallback must never fail hard
+            logger.info("ezproxy fetch failed (%s); falling back to direct URL", exc)
+    return _download_via_httpx_result(url, cookies={}, timeout=timeout, max_size_mb=max_size_mb)
+
+
+def _download_via_httpx(
+    url: str,
+    *,
+    cookies: dict[str, str] | None = None,
+    timeout: int = 60,
+    max_size_mb: int = 25,
+) -> bytes | None:
+    """Download and validate a PDF payload with httpx."""
+
+    return _download_via_httpx_result(
+        url,
+        cookies=cookies,
+        timeout=timeout,
+        max_size_mb=max_size_mb,
+    ).content
+
+
+def _download_via_httpx_result(
+    url: str,
+    *,
+    cookies: dict[str, str] | None = None,
+    timeout: int = 60,
+    max_size_mb: int = 25,
+) -> _PdfBytesResult:
     try:
-        response = requests.get(url, timeout=60, stream=True)
+        response = httpx.get(
+            url,
+            cookies=cookies or {},
+            follow_redirects=True,
+            timeout=timeout,
+        )
     except Exception:
-        return _PdfDownloadResult(None, reason="network_error")
-    # Always close the streaming response to release the connection
-    # back to the pool, regardless of which early-return branch fires.
-    # `with requests.get(...)` would be cleaner but fails with test
-    # mocks that don't implement __enter__/__exit__ — using a manual
-    # try/finally + .close() works with both real Response objects and
-    # Mock fakes.
+        return _PdfBytesResult(None, reason="network_error")
+    status = _response_status(response)
+    is_success = getattr(response, "is_success", getattr(response, "ok", False))
+    if not is_success:
+        return _PdfBytesResult(None, status=status, reason=_http_failure_reason(status))
     try:
-        status = _response_status(response)
-        if not response.ok:
-            return _PdfDownloadResult(None, status=status, reason=_http_failure_reason(status))
-        try:
-            content = response.content
-        except Exception:
-            return _PdfDownloadResult(None, status=status, reason="network_error")
-        if len(content) > max_mb * 1024 * 1024:
-            return _PdfDownloadResult(None, status=status, reason="pdf_invalid")
-        content_type = str((response.headers or {}).get("Content-Type", "") or "").lower()
-        if "pdf" not in content_type and not content.startswith(b"%PDF"):
-            return _PdfDownloadResult(None, status=status, reason="pdf_invalid")
-        digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
-        target = Path(tempfile.gettempdir()) / f"rh_pdf_{digest}.pdf"
-        try:
-            target.write_bytes(content)
-        except Exception:
-            _cleanup_partial_temp_pdf(target)
-            return _PdfDownloadResult(None, status=status, reason="network_error")
-        return _PdfDownloadResult(target, status=status, bytes=len(content))
-    finally:
-        try:
-            response.close()
-        except Exception:
-            pass
+        content = response.content
+    except Exception:
+        return _PdfBytesResult(None, status=status, reason="network_error")
+    if len(content) > max_size_mb * 1024 * 1024:
+        return _PdfBytesResult(None, status=status, reason="pdf_invalid")
+    content_type = str((response.headers or {}).get("Content-Type", "") or "").lower()
+    if not content_type.startswith("application/pdf") and not content.startswith(b"%PDF"):
+        return _PdfBytesResult(None, status=status, reason="pdf_invalid")
+    return _PdfBytesResult(content, status=status)
+
+
+def _write_pdf_temp(url: str, content: bytes, *, status: int | None = None) -> _PdfDownloadResult:
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+    target = Path(tempfile.gettempdir()) / f"rh_pdf_{digest}.pdf"
+    try:
+        target.write_bytes(content)
+    except Exception:
+        _cleanup_partial_temp_pdf(target)
+        return _PdfDownloadResult(None, status=status, reason="network_error")
+    return _PdfDownloadResult(target, status=status, bytes=len(content))
 
 
 def _cleanup_partial_temp_pdf(target: Path) -> None:
@@ -614,6 +674,7 @@ def attach_pdfs(
     keep_url_fallback: bool = False,
     max_pdf_size_mb: int = 25,
     local_pdfs_dir: Path | None = None,
+    cfg=None,
 ) -> dict[str, str]:
     """Attach PDFs as imported_file items, with optional imported_url fallback.
 
@@ -636,7 +697,7 @@ def attach_pdfs(
                 results[plan.item_key] = "skip:already-has-pdf"
                 entries.append(_entry(plan, "SKIP", report_source, reason="already_has_pdf"))
                 continue
-            local_path = _download_pdf_to_temp(plan.pdf_url, max_mb=max_pdf_size_mb)
+            local_path = _download_pdf_to_temp(plan.pdf_url, max_mb=max_pdf_size_mb, cfg=cfg)
             download_result = _LAST_DOWNLOAD_RESULTS.pop(plan.pdf_url, None)
             if local_path is None:
                 reason = _download_failure_reason(download_result, report_source)

--- a/tests/test_ezproxy.py
+++ b/tests/test_ezproxy.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from urllib.parse import quote
+
+from research_hub.ezproxy import EZproxyConfig, load_cookies, resolve_config, wrap_url
+from research_hub.zotero import pdf_attach
+
+
+def test_wrap_url_substitutes_encoded_url():
+    url = "https://ieeexplore.ieee.org/document/9"
+    template = "https://prox/login?qurl={encoded_url}"
+
+    assert wrap_url(url, template) == f"https://prox/login?qurl={quote(url, safe='')}"
+
+
+def test_wrap_url_empty_template_returns_original():
+    assert wrap_url("https://example.com/paper", "") == "https://example.com/paper"
+
+
+def test_wrap_url_missing_placeholder_returns_original():
+    assert wrap_url("https://example.com/paper", "https://prox/login") == "https://example.com/paper"
+
+
+def test_load_cookies_from_storage_state_json(tmp_path):
+    cookies_path = tmp_path / "state.json"
+    cookies_path.write_text(
+        json.dumps(
+            {
+                "cookies": [
+                    {"name": "ezproxy", "value": "abc", "domain": ".example.edu", "path": "/"},
+                    {"name": "session", "value": "xyz", "domain": ".example.edu", "path": "/"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert load_cookies(cookies_path) == {"ezproxy": "abc", "session": "xyz"}
+
+
+def test_load_cookies_missing_file_returns_empty(tmp_path):
+    assert load_cookies(tmp_path / "missing.json") == {}
+
+
+def test_load_cookies_bad_json_returns_empty(tmp_path):
+    cookies_path = tmp_path / "bad.json"
+    cookies_path.write_text("{not json", encoding="utf-8")
+
+    assert load_cookies(cookies_path) == {}
+
+
+def test_resolve_config_uses_defaults_when_fields_missing(tmp_path):
+    cfg = SimpleNamespace(research_hub_dir=tmp_path / ".research_hub")
+
+    ezcfg = resolve_config(cfg)
+
+    assert ezcfg.url_template == ""
+    assert ezcfg.cookies_path == tmp_path / ".research_hub" / "ezproxy_cookies.json"
+
+
+def test_enabled_requires_template_and_file(tmp_path):
+    cookies_path = tmp_path / "ezproxy_cookies.json"
+
+    assert not EZproxyConfig("", cookies_path).enabled
+    assert not EZproxyConfig("https://prox/login?qurl={encoded_url}", cookies_path).enabled
+
+    cookies_path.write_text('{"cookies": []}', encoding="utf-8")
+    assert EZproxyConfig("https://prox/login?qurl={encoded_url}", cookies_path).enabled
+
+
+def test_pdf_attach_falls_back_to_original_url_when_proxy_404s(tmp_path, monkeypatch):
+    """Exercises the LIVE `_download_pdf_bytes_with_ezproxy_result` path —
+    the one actually invoked by `_download_pdf_to_temp_result` in
+    production. Earlier draft of this test hit a duplicate
+    `_download_pdf_with_ezproxy_fallback` shim that was never wired in;
+    that shim was removed and this test now monkeypatches the live
+    result-returning helper instead."""
+    cookies_path = tmp_path / "ezproxy_cookies.json"
+    cookies_path.write_text('{"cookies": [{"name": "ez", "value": "cookie"}]}', encoding="utf-8")
+    cfg = SimpleNamespace(
+        ezproxy_url_template="https://prox/login?qurl={encoded_url}",
+        ezproxy_cookies_path=str(cookies_path),
+    )
+    calls: list[str] = []
+
+    def fake_download_result(url, *, cookies=None, timeout=60, max_size_mb=25):
+        calls.append(url)
+        # Live function name is _PdfBytesResult; importing locally to
+        # avoid coupling the test to the private dataclass at module top.
+        from research_hub.zotero.pdf_attach import _PdfBytesResult
+        if url.startswith("https://prox/"):
+            return _PdfBytesResult(None, status=404, reason="not_found_404")
+        return _PdfBytesResult(b"%PDF-1.4\nfixture\n", status=200)
+
+    monkeypatch.setattr(pdf_attach, "_download_via_httpx_result", fake_download_result)
+
+    result = pdf_attach._download_pdf_bytes_with_ezproxy_result(
+        "https://ieeexplore.ieee.org/document/9",
+        cfg=cfg,
+        timeout=60,
+        max_size_mb=25,
+    )
+
+    assert result.content == b"%PDF-1.4\nfixture\n"
+    assert calls == [
+        "https://prox/login?qurl=https%3A%2F%2Fieeexplore.ieee.org%2Fdocument%2F9",
+        "https://ieeexplore.ieee.org/document/9",
+    ]

--- a/tests/test_v075_pdf_attach.py
+++ b/tests/test_v075_pdf_attach.py
@@ -136,7 +136,8 @@ def test_run_pipeline_with_pdfs_invokes_attach_helpers(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         "research_hub.zotero.pdf_attach.attach_pdfs",
-        lambda zot, plans, rate_limit_rps=2.0: {"Z0": "ok"},
+        # accept cfg=cfg passed by pipeline.run_pipeline (EZproxy plumbing)
+        lambda zot, plans, rate_limit_rps=2.0, cfg=None: {"Z0": "ok"},
     )
 
     try:

--- a/tests/test_v080_pdf_imported_file.py
+++ b/tests/test_v080_pdf_imported_file.py
@@ -14,15 +14,23 @@ from research_hub.zotero.pdf_attach import (
 
 
 class _Resp:
-    def __init__(self, *, ok: bool = True, headers: dict | None = None, content: bytes = b"") -> None:
-        self.ok = ok
+    def __init__(
+        self,
+        *,
+        ok: bool = True,
+        headers: dict | None = None,
+        content: bytes = b"",
+        status_code: int = 200,
+    ) -> None:
+        self.is_success = ok
         self.headers = headers or {}
         self.content = content
+        self.status_code = status_code
 
 
 def test_download_pdf_to_temp_accepts_pdf_magic_bytes(monkeypatch):
     monkeypatch.setattr(
-        "research_hub.zotero.pdf_attach.requests.get",
+        "research_hub.zotero.pdf_attach.httpx.get",
         lambda *args, **kwargs: _Resp(
             headers={"Content-Type": "application/octet-stream"},
             content=b"%PDF-1.4\nfixture\n",
@@ -39,7 +47,7 @@ def test_download_pdf_to_temp_accepts_pdf_magic_bytes(monkeypatch):
 
 def test_download_pdf_to_temp_rejects_non_pdf_payload(monkeypatch):
     monkeypatch.setattr(
-        "research_hub.zotero.pdf_attach.requests.get",
+        "research_hub.zotero.pdf_attach.httpx.get",
         lambda *args, **kwargs: _Resp(
             headers={"Content-Type": "text/html"},
             content=b"<html>not a pdf</html>",

--- a/tests/test_v087_pdf_attach_reporting.py
+++ b/tests/test_v087_pdf_attach_reporting.py
@@ -4,7 +4,8 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import requests
+import httpx
+import requests  # noqa: F401 — kept for the Zenodo-skip test's monkeypatch target
 
 from research_hub.clusters import ClusterRegistry
 from research_hub.zotero.pdf_attach import (
@@ -73,14 +74,17 @@ def test_zenodo_doi_is_skip_not_fail(monkeypatch) -> None:
 
 
 def test_403_404_and_network_errors_are_distinct(monkeypatch) -> None:
+    # pdf_attach.py uses httpx.get (since the EZproxy refactor moved off
+    # `requests`). httpx's "did the request succeed" attribute is
+    # `is_success`, not `ok`.
     def fake_get(url: str, **kwargs):
         if "403" in url:
-            return SimpleNamespace(ok=False, status_code=403, headers={}, content=b"")
+            return SimpleNamespace(is_success=False, status_code=403, headers={}, content=b"")
         if "404" in url:
-            return SimpleNamespace(ok=False, status_code=404, headers={}, content=b"")
-        raise requests.RequestException("offline")
+            return SimpleNamespace(is_success=False, status_code=404, headers={}, content=b"")
+        raise httpx.RequestError("offline")
 
-    monkeypatch.setattr("research_hub.zotero.pdf_attach.requests.get", fake_get)
+    monkeypatch.setattr("research_hub.zotero.pdf_attach.httpx.get", fake_get)
     plans = [
         PdfAttachPlan("P403", "Forbidden", "10.1000/403", "", "https://files.example.com/403.pdf", "unpaywall"),
         PdfAttachPlan("P404", "Missing", "10.1000/404", "", "https://files.example.com/404.pdf", "crossref-link"),
@@ -166,7 +170,8 @@ def test_pipeline_appends_pdf_attach_summary_to_output_json(tmp_path, monkeypatc
     )
     monkeypatch.setattr(
         "research_hub.zotero.pdf_attach.attach_pdfs",
-        lambda zot, plans, rate_limit_rps=2.0: PdfAttachResults(
+        # accept cfg=cfg passed by pipeline.run_pipeline (EZproxy plumbing)
+        lambda zot, plans, rate_limit_rps=2.0, cfg=None: PdfAttachResults(
             {"Z0": "ok"},
             PdfAttachSummary(
                 [


### PR DESCRIPTION
Closes the IEEE / Wiley / Elsevier paywalled-PDF gap noted in `## Known limitations`. **Opt-in, generic, per-institution** — no hardcoded URLs.

## Architecture — 4 locked design choices

1. **Cookie source**: Playwright SSO + dump. `research-hub ezproxy login` opens a browser, user completes their institution's SSO once, cookies dumped to `~/.research_hub/ezproxy_cookies.json`. Mirrors `notebooklm/auth.py:_login_with_auto_detect` (reuses `_playwright_event_loop` + `_tighten_state_file_perms`).
2. **URL rewrite scope**: `paper attach-pdfs` only. Search/ingest untouched.
3. **Generic template**: `cfg.ezproxy_url_template` is a format string like `"https://login.ezproxy.youruniversity.edu/login?qurl={encoded_url}"`. Any institution with an EZproxy gateway can configure their own.
4. **Fail-safe**: proxy 4xx/5xx/network → automatic fallback to direct URL with empty cookies. Never raises.

## Files

| Status | File | Purpose |
|---|---|---|
| New | `src/research_hub/ezproxy.py` | `EZproxyConfig`, `resolve_config`, `wrap_url`, `load_cookies`, `login` |
| New | `tests/test_ezproxy.py` | 9 unit tests (`wrap_url` ×3, `load_cookies` ×3, `resolve_config`, `enabled` flag, full fallback) |
| New | `docs/ezproxy.md` | Institution-agnostic how-to |
| Mod | `src/research_hub/config.py` | `ezproxy_url_template` + `ezproxy_cookies_path` (default empty) |
| Mod | `src/research_hub/cli.py` | `ezproxy login` / `ezproxy status` subcommands |
| Mod | `src/research_hub/zotero/pdf_attach.py` | port `requests.get`→`httpx.get` for the PDF body; `_download_pdf_bytes_with_ezproxy_result` wraps proxy-then-direct |
| Mod | `src/research_hub/auto.py` + `pipeline.py` | 1-line each: `attach_pdfs(..., cfg=cfg)` so pdf_attach can read the ezproxy config |
| Mod | `pyproject.toml` + `constraints.txt` | declare `httpx>=0.27,<1.0` as direct dep (was transitive via notebooklm-py) |
| Mod | `README.md` | Known limitations IEEE row → points at `docs/ezproxy.md` |
| Mod | `CHANGELOG.md` | `[Unreleased] Added` entry |
| Mod | 3× test files | lambda mocks accept `cfg=None`, monkeypatch switches `requests.get` → `httpx.get` |

## Codex delegation + Claude review

Delegated to Codex via `codex-delegate` skill (brief: `.ai/codex_task_ezproxy_mvp.md`). Codex produced a working implementation on first pass; Claude ran `code-reviewer` subagent and fixed two issues:

- **Critical (C1)**: Removed a dead duplicate `_download_pdf_with_ezproxy_fallback` helper the test suite was exercising — production used `_download_pdf_bytes_with_ezproxy_result` instead. Test rewritten to monkeypatch the live path (`_download_via_httpx_result`) so fallback behaviour is genuinely covered.
- **Warning (W1)**: Removed Lehigh-specific URL from `ezproxy.py:4` docstring and `docs/ezproxy.md` "For Lehigh" block. This is a general-purpose PyPI package; institution-specific URLs in published source were inappropriate. Replaced with `login.ezproxy.youruniversity.edu` placeholder.

## Verification

- `pytest -k "pdf or pipeline or ezproxy or auto or cli"`: **651 passed, 7 skipped, 0 failed**
- `pytest tests/test_ezproxy.py`: 9 passed
- Smoke: `research-hub ezproxy status` returns resolved config without a real browser

## How a user enables it

```bash
research-hub config set ezproxy_url_template "https://login.ezproxy.youruniversity.edu/login?qurl={encoded_url}"
research-hub ezproxy login    # opens browser, SSO, cookies saved
research-hub ezproxy status   # verify enabled=True
research-hub paper attach-pdfs --cluster <slug> --apply   # paywalled PDFs now route through proxy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)