### PR TITLE
fix(pdf-attach): send browser UA so MDPI/Frontiers/Springer/IEEE stop returning 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ UI scope is capped here by decision: the dashboard stays a thin
 status-mirror + palette + onboarding demo; no 3-pane / citation-
 graph rebuild (link out to the real tools instead)._
 
+### Fixed
+- **PDF attach 0% regression from PR #108's requests → httpx port**
+  (`zotero/pdf_attach.py`). The `requests` → `httpx` migration in PR #108
+  used `httpx.get()` without overriding the default User-Agent
+  (`python-httpx/<ver>`). MDPI, Frontiers, Springer-pdfdirect, IEEE, and
+  other publishers' bot filters block that UA and return 403. Production
+  E2E coverage crashed: a flood cluster got 0/15 OA PDFs attached, the
+  Human-Nature cluster got 0/30. New `_PDF_DOWNLOAD_HEADERS` constant
+  sends a real Chrome-on-Windows UA + `Accept: application/pdf,...` so
+  the publishers' filters let the download through. Live verification:
+  `_download_via_httpx_result(<Springer pdfdirect URL>)` now returns
+  status 200 + a 1.6 MB PDF (was 403 / 406 bytes of HTML). Regression
+  test in `tests/test_v080_pdf_imported_file.py` pins both that headers
+  are passed AND that the UA looks like a real browser.
+
 ### Added
 - **EZproxy support for paywalled PDF downloads** (`ezproxy.py`, `cli.py`,
   `zotero/pdf_attach.py`, `pyproject.toml`). Opt-in via

--- a/src/research_hub/zotero/pdf_attach.py
+++ b/src/research_hub/zotero/pdf_attach.py
@@ -23,6 +23,24 @@ OPENALEX_BASE = "https://api.openalex.org/works/doi"
 UNPAYWALL_BASE = "https://api.unpaywall.org/v2"
 CROSSREF_BASE = "https://api.crossref.org/works"
 
+# Browser-mimicking headers for publisher PDF downloads. Required because
+# `httpx`'s default UA (`python-httpx/<ver>`) is blocked by MDPI, Frontiers,
+# Springer-pdfdirect, IEEE, and others; the PR #108 requests→httpx port
+# regressed PDF coverage to 0% on master until this header set was added.
+# Chrome on Windows is the safest masquerade — it's the modal real-user UA
+# publishers' bot filters expect. Accept covers the PDF redirect-to-HTML
+# error pages too (so bot filters that bounce on "Accept: */*" let us
+# through).
+_PDF_DOWNLOAD_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/131.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/pdf,application/octet-stream,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
 _HINT_SHOWN = False  # once-per-process flag for the unpaywall_email hint
 logger = logging.getLogger(__name__)
 
@@ -416,6 +434,14 @@ def _download_via_httpx_result(
             cookies=cookies or {},
             follow_redirects=True,
             timeout=timeout,
+            # Browser-mimicking headers. The PR #108 requests→httpx port
+            # accidentally regressed PDF coverage to 0% on master because
+            # httpx's default UA ("python-httpx/0.28.1") gets blocked by
+            # MDPI, Frontiers, Springer-pdfdirect, IEEE, and other
+            # publishers that previously let requests' UA through (or
+            # that newly tightened in 2026). A real Chrome UA + Accept
+            # header pair restores the pre-#108 success rate.
+            headers=_PDF_DOWNLOAD_HEADERS,
         )
     except Exception:
         return _PdfBytesResult(None, reason="network_error")

--- a/tests/test_v080_pdf_imported_file.py
+++ b/tests/test_v080_pdf_imported_file.py
@@ -45,6 +45,36 @@ def test_download_pdf_to_temp_accepts_pdf_magic_bytes(monkeypatch):
     path.unlink()
 
 
+def test_download_pdf_to_temp_sends_browser_useragent_header(monkeypatch):
+    """Regression: PR #108 ported `requests.get` → `httpx.get` for the PDF
+    body download. httpx's default `User-Agent: python-httpx/<ver>` is
+    blocked by MDPI, Frontiers, Springer-pdfdirect, IEEE, etc. — coverage
+    crashed to 0/30 on production E2E. The fix is to send a real Chrome
+    User-Agent. This test pins both that headers are passed AND that the
+    UA looks like Chrome on Windows."""
+    captured: dict = {}
+
+    def fake_get(url, *args, **kwargs):
+        captured["url"] = url
+        captured["headers"] = kwargs.get("headers", {})
+        return _Resp(headers={"Content-Type": "application/pdf"}, content=b"%PDF-1.4\nfx\n")
+
+    monkeypatch.setattr("research_hub.zotero.pdf_attach.httpx.get", fake_get)
+
+    path = _download_pdf_to_temp("https://www.mdpi.com/2673-2688/7/1/14/pdf")
+    assert path is not None
+    path.unlink()
+
+    headers = captured["headers"]
+    assert "User-Agent" in headers, "PDF download must send a User-Agent header"
+    ua = headers["User-Agent"]
+    assert "Mozilla" in ua and "Chrome" in ua, (
+        f"User-Agent must masquerade as a real Chrome browser; got {ua!r}. "
+        "Default python-httpx/<ver> is blocked by MDPI/Frontiers/Springer/IEEE."
+    )
+    assert "Accept" in headers and "pdf" in headers["Accept"].lower()
+
+
 def test_download_pdf_to_temp_rejects_non_pdf_payload(monkeypatch):
     monkeypatch.setattr(
         "research_hub.zotero.pdf_attach.httpx.get",


### PR DESCRIPTION
## Bug

PR #108's `requests` → `httpx` port for the PDF download body used `httpx.get()` without overriding the default User-Agent (`python-httpx/<ver>`). MDPI, Frontiers, Springer-pdfdirect, IEEE, and other publishers' bot filters block that UA with **403 + 406-byte HTML stub**.

Production impact (post-#108 master):
- **"LLM × flood forecasting"** cluster: 0/15 OA PDFs attached
- **"LLM × Human-Nature systems"** cluster (today's E2E test): **0/30** OA PDFs attached

## Diagnosis

Monkeypatch-driven UA swap on a Springer pdfdirect URL:

| UA | Status | Bytes |
|---|---|---|
| `python-httpx/0.28.1` (default) | 403 | 406 (HTML error) |
| `Mozilla/5.0 ... Chrome/131.0.0.0 ...` | **200** | **1,695,467 (real PDF)** |

Same pattern for MDPI/Frontiers — default httpx UA blocked, Chrome UA passes.

## Fix

New module-level `_PDF_DOWNLOAD_HEADERS` constant in `zotero/pdf_attach.py`, passed to `_download_via_httpx_result`'s `httpx.get()`:

```python
_PDF_DOWNLOAD_HEADERS = {
    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                  "AppleWebKit/537.36 (KHTML, like Gecko) "
                  "Chrome/131.0.0.0 Safari/537.36",
    "Accept": "application/pdf,application/octet-stream,*/*;q=0.8",
    "Accept-Language": "en-US,en;q=0.9",
}
```

The `Accept` header is required too — some publishers' bot filters bounce on `Accept: */*` even with a browser UA.

## Verification

- **Live**: `_download_via_httpx_result("https://link.springer.com/content/pdf/10.1007/s00146-026-03070-1.pdf")` returns status 200 + 1.6 MB PDF (was 403 / 406 bytes pre-fix).
- **Test**: new `test_download_pdf_to_temp_sends_browser_useragent_header` pins both that headers reach `httpx.get()` AND that the UA contains "Mozilla" + "Chrome". A future refactor that drops the UA (or reverts to `python-httpx/*`) fails this test loudly.
- `pytest -k "pdf_attach or pdf_imported or ezproxy"`: 29 passed, 0 failed.

## Sister to

- PR #108 (requests → httpx port) — caused the regression
- PR #90 (`--with-pdfs` default ON) — the user-facing promise this PR restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)