### PR TITLE
feat(moc): per-cluster sub-MOC for two-level hub-and-spoke graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@ graph rebuild (link out to the real tools instead)._
   are passed AND that the UA looks like a real browser.
 
 ### Added
+- **Two-level hub-and-spoke MOC graph (per-cluster sub-MOC)**
+  (`vault/hub_overview.py`). Every LLM/water cluster now links to BOTH a
+  parent MOC (e.g. `LLM-Agents`) AND a per-cluster sub-MOC derived from
+  the slug's distinctive tail (e.g. `LLM-Agents-Flood`,
+  `LLM-Agents-ConsumerBehavior`, `Water-Resources-DataPipeline`). Without
+  the sub-MOC, every LLM cluster collapsed onto a single `LLM-Agents`
+  node in Obsidian graph view; with it, each cluster has a distinct
+  sub-hub between the parent and the paper notes — the cross-cluster
+  centre stays, but each topic gets its own visible centre too. Two
+  parser fixes along the way: hyphenated slug tokens like
+  `large-language-models-consumer-behavior` now correctly match
+  `"large language model"` substring (haystack normalised
+  `-`/`_` → space), and generic possessive prefixes (`my`, `our`,
+  `new`, `old`) are stripped so `my-cluster` produces `Cluster` not
+  `MyCluster`. Existing clusters need
+  `research-hub vault rebuild-overviews` to backfill sub-MOC links into
+  legacy paper-note frontmatter; new ingests get them automatically.
 - **EZproxy support for paywalled PDF downloads** (`ezproxy.py`, `cli.py`,
   `zotero/pdf_attach.py`, `pyproject.toml`). Opt-in via
   `cfg.ezproxy_url_template`. New

--- a/src/research_hub/vault/hub_overview.py
+++ b/src/research_hub/vault/hub_overview.py
@@ -485,20 +485,97 @@ def populate_all_mocs(cfg) -> list[tuple[str, Path]]:
     return written
 
 
+# Tokens dropped when deriving a per-cluster sub-MOC. These appear in
+# almost every LLM/water cluster slug and so are useless for
+# distinguishing one cluster from another. The remaining tokens identify
+# what makes THIS cluster different — that's the sub-MOC name.
+_SUB_MOC_STOPWORDS = frozenset({
+    # LLM-family tokens (kept as the parent MOC's identity)
+    "llm", "llms", "large", "language", "model", "models",
+    "agent", "agents", "ai", "generative", "chatgpt", "gpt",
+    # Water-family tokens
+    "water", "flood", "hydro", "hydrology", "hydrological", "rainfall",
+    "river", "drainage", "drought", "sociohydrology", "stormwater",
+    "reservoir",
+    # Connectors / qualifiers / generic possessives
+    "and", "or", "for", "in", "of", "the", "to", "a", "an", "on",
+    "with", "as", "by", "via", "based", "using", "study", "studies",
+    "system", "systems", "research", "review",
+    "my", "our", "new", "old",
+})
+
+
+def _sub_moc_token_from_slug(cluster_slug: str) -> str:
+    """Return a 1-2-word PascalCase tag identifying what this cluster is
+    ABOUT, after stripping LLM/water/connector stopwords.
+
+    Used to build a per-cluster sub-MOC name like `LLM-Agents-Flood` or
+    `LLM-Agents-ConsumerBehavior` that lives BETWEEN the parent MOC
+    (`LLM-Agents`) and the individual papers in the Obsidian graph. The
+    parent MOC is still there — clusters in the same parent family
+    cluster around it — but each cluster now also has its own visible
+    sub-hub.
+
+    Examples:
+      generative-ai-chatgpt-llm-agents-flood
+        → after stopwords: [] (all tokens are stopwords) — falls back
+          to the last meaningful slug token: ``Flood`` (kept because
+          it's in the water-family stopword list but ALSO the cluster's
+          distinguishing topic, so we prefer it over an empty result)
+      large-language-models-consumer-behavior
+        → after stopwords: [consumer, behavior] → ``ConsumerBehavior``
+      generative-ai-large-language-models-coupled-human-nature
+        → after stopwords: [coupled, human, nature] → ``HumanNature``
+        (last 2)
+    """
+    parts = [p for p in re.split(r"[-_]", str(cluster_slug or "").lower()) if p]
+    distinctive = [p for p in parts if p not in _SUB_MOC_STOPWORDS]
+    if not distinctive:
+        # All tokens are stopwords (very LLM/water-heavy slug). Fall back
+        # to the LAST original token so the sub-MOC isn't empty — it's
+        # better to risk a slightly-redundant "LLM-Agents-Flood" than to
+        # collapse every flood cluster onto the parent MOC alone.
+        distinctive = parts[-1:] if parts else []
+    if not distinctive:
+        return ""
+    # Take the LAST 1-2 distinctive tokens — usually the more specific
+    # ones (e.g. "consumer behavior", "human nature", "ecological
+    # coupling") rather than the first ones (which tend to be broader
+    # qualifiers).
+    pick = distinctive[-2:] if len(distinctive) >= 2 else distinctive[:1]
+    return "".join(t.capitalize() for t in pick)
+
+
 def derive_moc_links(
     cluster_slug: str,
     cluster_queries: list[str] | None = None,
     moc_links: list[str] | None = None,
 ) -> list[str]:
-    """Return v0.87 default MOC names for a cluster."""
+    """Return v0.87 default MOC names for a cluster.
+
+    Two-level hub-and-spoke: each LLM/water cluster gets BOTH a parent
+    MOC (e.g. ``LLM-Agents``) and a per-cluster sub-MOC (e.g.
+    ``LLM-Agents-ConsumerBehavior``). In Obsidian graph view this gives
+    you the cross-cluster centre (LLM-Agents) AND a distinct visible
+    sub-hub per topic, instead of every LLM cluster collapsing onto a
+    single shared LLM-Agents node.
+    """
 
     links: list[str] = []
     for name in moc_links or []:
         _append_unique(links, str(name).strip())
     text_parts = [cluster_slug, *(cluster_queries or [])]
+    # Normalise hyphens/underscores to spaces so multi-word triggers like
+    # "large language model" match slug tokens "large-language-models" too.
+    # Without this, `large-language-models-consumer-behavior` failed to link
+    # to the LLM-Agents MOC because the substring check never fired.
     haystack = " ".join(str(part) for part in text_parts if part).lower()
+    haystack = haystack.replace("-", " ").replace("_", " ")
+    sub_tag = _sub_moc_token_from_slug(cluster_slug)
     if "llm" in haystack or "large language model" in haystack or "agent" in haystack:
         _append_unique(links, "LLM-Agents")
+        if sub_tag:
+            _append_unique(links, f"LLM-Agents-{sub_tag}")
     # v0.88.5: broaden water-resources heuristic so flood / hydrology /
     # drainage / river / drought / rainfall clusters also link to the
     # Water-Resources MOC. Without this, a "ml-flood-forecasting" cluster
@@ -509,6 +586,8 @@ def derive_moc_links(
     )
     if any(kw in haystack for kw in water_keywords):
         _append_unique(links, "Water-Resources")
+        if sub_tag:
+            _append_unique(links, f"Water-Resources-{sub_tag}")
     return links
 
 

--- a/tests/test_moc.py
+++ b/tests/test_moc.py
@@ -26,32 +26,96 @@ def test_ensure_moc_is_idempotent(tmp_path):
 
 
 def test_moc_links_from_llm_and_water_slugs():
-    assert derive_moc_links("human-water-llm") == ["LLM-Agents", "Water-Resources"]
-    assert derive_moc_links("flood-water-supply") == ["Water-Resources"]
-    assert derive_moc_links("social-llm-agents") == ["LLM-Agents"]
+    """Each LLM/water cluster gets BOTH a parent MOC (`LLM-Agents`,
+    `Water-Resources`) and a per-cluster sub-MOC (e.g.
+    `LLM-Agents-Human`). Two-level hub-and-spoke graph view."""
+    assert derive_moc_links("human-water-llm") == [
+        "LLM-Agents", "LLM-Agents-Human",
+        "Water-Resources", "Water-Resources-Human",
+    ]
+    assert derive_moc_links("flood-water-supply") == [
+        "Water-Resources", "Water-Resources-Supply",
+    ]
+    assert derive_moc_links("social-llm-agents") == [
+        "LLM-Agents", "LLM-Agents-Social",
+    ]
 
 
 def test_moc_links_v0885_broader_water_keywords():
     """v0.88.5: clusters about flood / hydrology / rainfall / drought etc.
-    should also surface the Water-Resources MOC. Previously only the
-    literal substring `water` triggered the mapping."""
-    assert derive_moc_links("ml-flood-forecasting") == ["Water-Resources"]
-    assert derive_moc_links("hydrology-data-pipeline") == ["Water-Resources"]
-    assert derive_moc_links("rainfall-radar-deep-learning") == ["Water-Resources"]
-    assert derive_moc_links("drought-monitoring") == ["Water-Resources"]
-    assert derive_moc_links("urban-stormwater-modeling") == ["Water-Resources"]
-    assert derive_moc_links("reservoir-operation-rl") == ["Water-Resources"]
-    # query text also counts, not just slug
+    surface Water-Resources. Each also gets a per-cluster sub-MOC."""
+    assert derive_moc_links("ml-flood-forecasting") == [
+        "Water-Resources", "Water-Resources-MlForecasting",
+    ]
+    assert derive_moc_links("hydrology-data-pipeline") == [
+        "Water-Resources", "Water-Resources-DataPipeline",
+    ]
+    assert derive_moc_links("rainfall-radar-deep-learning") == [
+        "Water-Resources", "Water-Resources-DeepLearning",
+    ]
+    assert derive_moc_links("drought-monitoring") == [
+        "Water-Resources", "Water-Resources-Monitoring",
+    ]
+    assert derive_moc_links("urban-stormwater-modeling") == [
+        "Water-Resources", "Water-Resources-UrbanModeling",
+    ]
+    assert derive_moc_links("reservoir-operation-rl") == [
+        "Water-Resources", "Water-Resources-OperationRl",
+    ]
+    # query text triggers Water-Resources; sub-MOC is derived from SLUG only
+    # (so `smart-cities` slug + `drainage` query → Water-Resources-SmartCities)
     assert derive_moc_links(
         "smart-cities", cluster_queries=["urban drainage simulation"]
-    ) == ["Water-Resources"]
+    ) == ["Water-Resources", "Water-Resources-SmartCities"]
 
 
 def test_moc_links_v0885_agent_keyword_for_llm_agents():
-    """v0.88.5: `agent` as a standalone keyword also routes to LLM-Agents.
-    A cluster about `multi-agent-systems` should pick up the MOC even if
-    no literal `llm` token appears."""
+    """v0.88.5: `agent` as a standalone keyword routes to LLM-Agents."""
     assert "LLM-Agents" in derive_moc_links("multi-agent-systems")
     assert "LLM-Agents" in derive_moc_links(
         "social-simulation", cluster_queries=["generative agent persona modelling"]
     )
+
+
+def test_sub_moc_per_cluster_creates_visible_sub_hub():
+    """Two-level hub-and-spoke: parent MOC + per-cluster sub-MOC.
+
+    Without this, every LLM cluster collapses onto the single `LLM-Agents`
+    MOC in Obsidian graph view; with it, each cluster has a distinct
+    sub-hub node BETWEEN the parent and the paper notes."""
+    # Realistic slugs from production clusters
+    flood = derive_moc_links("generative-ai-chatgpt-llm-agents-flood")
+    assert flood == ["LLM-Agents", "LLM-Agents-Flood",
+                     "Water-Resources", "Water-Resources-Flood"]
+
+    consumer = derive_moc_links("large-language-models-consumer-behavior")
+    assert consumer == ["LLM-Agents", "LLM-Agents-ConsumerBehavior"]
+
+    human_nature = derive_moc_links(
+        "generative-ai-large-language-models-coupled-human-nature-systems"
+    )
+    # last 2 distinctive (post-stopword: coupled, human, nature) = HumanNature
+    assert human_nature == ["LLM-Agents", "LLM-Agents-HumanNature"]
+
+
+def test_sub_moc_fallback_when_all_tokens_are_stopwords():
+    """If every slug token is a stopword (very LLM/water-heavy slug),
+    fall back to the LAST original token so the sub-MOC isn't empty.
+    Better to have `LLM-Agents-Llms` than to collapse the cluster onto
+    the parent MOC alone."""
+    assert derive_moc_links("llm-agents-llms") == [
+        "LLM-Agents", "LLM-Agents-Llms",
+    ]
+
+
+def test_sub_moc_explicit_moc_links_pass_through_untouched():
+    """Existing `cluster.moc_links` (set by hand in clusters.yaml) flow
+    through unchanged — sub-MOC derivation only adds, never strips."""
+    out = derive_moc_links(
+        "my-cluster",
+        moc_links=["MyCustomMOC"],
+        cluster_queries=["large language model X"],
+    )
+    assert "MyCustomMOC" in out
+    assert "LLM-Agents" in out
+    assert "LLM-Agents-Cluster" in out  # sub from slug "my-cluster" (last non-stopword)


### PR DESCRIPTION
## Summary

- Adds a per-cluster sub-MOC layer to the Obsidian MOC system. Every LLM/water cluster now emits BOTH the parent MOC (`LLM-Agents` / `Water-Resources`) AND a per-cluster sub-MOC derived from the slug's distinctive tail (e.g. `LLM-Agents-Flood`, `LLM-Agents-ConsumerBehavior`, `Water-Resources-DataPipeline`).
- Fixes two latent parsing bugs in `derive_moc_links`: hyphenated slug tokens like `large-language-models-consumer-behavior` failed to trigger the `"large language model"` substring match (haystack now normalises `-`/`_` → space), and generic possessive prefixes (`my`, `our`, `new`, `old`) are now stripped so `my-cluster` → `Cluster`, not `MyCluster`.
- 6 new/updated tests in `tests/test_moc.py`. 8/8 MOC tests pass; wider regression `pytest -k "moc or hub_overview or vault"` clean (118 passed, 8 skipped, 1 xfailed).

## Why

User reported (with screenshot) that Obsidian graph view showed only the single `LLM-Agents` central node — every cluster collapsed onto it, no per-topic structure visible. Explicit request: *"我是希望一樣有中心點 但是還有每個主題還有自己的sub center 這樣"* — keep the cross-cluster centre, but each topic should also have its own visible sub-centre. Two-level hub-and-spoke restores the structure: parent centre → per-topic sub-centre → paper notes.

## Design notes

- `_SUB_MOC_STOPWORDS` strips LLM-family + water-family tokens (already represented in the parent MOC's identity) + connectors + generic possessives.
- `_sub_moc_token_from_slug()` returns last 1-2 distinctive tokens, PascalCased. All-stopword slugs fall back to the last original token so `llm-agents-llms` still gets `Llms` instead of collapsing onto the parent alone.
- Sub-tag is derived from SLUG only, not `cluster_queries` — so `smart-cities` + query `"urban drainage"` → `Water-Resources-SmartCities`, not `Water-Resources-Drainage`.

## Migration

Existing paper notes' `## Hub` frontmatter still references only the parent MOC. After merging:

```bash
research-hub vault rebuild-overviews
```

backfills sub-MOC links into the existing paper notes. New ingests get them automatically.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/test_moc.py -q` → 8 passed
- [x] `PYTHONPATH=src python -m pytest -k "moc or hub_overview or vault" -q --timeout=120` → 118 passed
- [ ] After merge: maintainer runs `research-hub vault rebuild-overviews` on `~/knowledge-base` and visually confirms in Obsidian graph view that each cluster has its own sub-hub node connected to the parent MOC

🤖 Generated with [Claude Code](https://claude.com/claude-code)