### PR TITLE
feat(moc): explicit sub-MOC override via cluster.moc_links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,30 @@ graph rebuild (link out to the real tools instead)._
   are passed AND that the UA looks like a real browser.
 
 ### Added
+- **Explicit sub-MOC override via `cluster.moc_links`**
+  (`vault/hub_overview.py`, `pipeline.py`,
+  `vault/hub_backlink_migrate.py`, `cli.py`). When a cluster's
+  `moc_links` field contains a name with a family prefix
+  (`LLM-Agents-*` or `Water-Resources-*`), the auto-derived slug-based
+  sub-MOC for THAT family is now suppressed — the user-provided name
+  wins instead of being appended alongside. Use case: slug
+  `generative-ai-large-language-models-coupled` auto-derives
+  `LLM-Agents-Coupled`, but the topic is really Human-Nature Systems;
+  setting `moc_links: [LLM-Agents-HumanNature]` in `clusters.yaml` now
+  yields `[LLM-Agents-HumanNature, LLM-Agents]` instead of also
+  tacking on `LLM-Agents-Coupled`. Each family is independent: an
+  `LLM-Agents-*` override does NOT suppress the Water-Resources auto
+  sub-MOC, and vice-versa. Names that do NOT match a family prefix
+  (e.g. `MyCustomMOC`) still pass through additively, as before.
+  The override propagates through ALL `derive_moc_links` call sites
+  — the cluster `00_overview.md`, MOC pages, `_HOME.md` rendering,
+  per-paper `## Hub` section at ingest time (P1 fix: previously
+  `pipeline._render_obsidian_note` did NOT pass `cluster.moc_links`,
+  so the overview/MOC honoured the override while every paper
+  wikilinked to the slug-derived sub-MOC), and `hub-backlink-migrate`
+  backfills. Regression test
+  `test_explicit_override_propagates_to_paper_note_hub_section`
+  pins the pipeline call-site fix.
 - **Two-level hub-and-spoke MOC graph (per-cluster sub-MOC)**
   (`vault/hub_overview.py`). Every LLM/water cluster now links to BOTH a
   parent MOC (e.g. `LLM-Agents`) AND a per-cluster sub-MOC derived from

--- a/src/research_hub/cli.py
+++ b/src/research_hub/cli.py
@@ -3772,13 +3772,23 @@ def _vault_hub_backlink_migrate(
     """Backfill ## Hub backlink section into existing paper notes (v0.88 §5)."""
     from collections import Counter
 
+    from research_hub.clusters import ClusterRegistry
     from research_hub.vault.hub_backlink_migrate import migrate_all
 
     cfg = get_config()
+    # Pre-build cluster_slug -> moc_links map so backfill honours explicit
+    # `LLM-Agents-*` / `Water-Resources-*` overrides set in clusters.yaml.
+    registry = ClusterRegistry(cfg.clusters_file)
+    cluster_moc_links_map = {
+        (c.slug or "").strip(): list(getattr(c, "moc_links", []) or [])
+        for c in registry.list()
+        if (c.slug or "").strip()
+    }
     results = migrate_all(
         Path(cfg.root),
         cluster_slug_filter=cluster_slug,
         dry_run=dry_run,
+        cluster_moc_links_map=cluster_moc_links_map,
     )
     counts = Counter(r.action for r in results)
     if emit_json:

--- a/src/research_hub/pipeline.py
+++ b/src/research_hub/pipeline.py
@@ -661,6 +661,7 @@ def _render_obsidian_note(
     query: str | None,
     *,
     fit_warning: bool = False,
+    cluster_moc_links: list[str] | None = None,
 ) -> str:
     # Build authors_str from either authors_str field, list of strings,
     # or list of {creatorType, firstName, lastName} dicts (Zotero format).
@@ -695,11 +696,18 @@ def _render_obsidian_note(
     cluster_queries_for_note = [_query_for_paper(pp, query)] if cluster_slug else []
     # v0.88 #5: derive MOC backlinks at note-creation time so every paper
     # gets a `## Hub` section linking up to its cluster overview + MOCs.
+    # Pass cluster.moc_links so explicit `LLM-Agents-*` / `Water-Resources-*`
+    # overrides set in clusters.yaml take effect HERE too — without this,
+    # the paper note's `## Hub` would still emit the auto-derived sub-MOC
+    # while the cluster `00_overview.md` (which DOES pass moc_links via
+    # `_sync_hub_overview`) shows the override. End state: overview wikilink
+    # and paper-note wikilink disagree.
     moc_links_for_note: list[str] = []
     if cluster_slug:
         moc_links_for_note = derive_moc_links(
             cluster_slug,
             cluster_queries=cluster_queries_for_note,
+            moc_links=list(cluster_moc_links or []),
         )
     content = make_raw_md(
         item_data,
@@ -1321,6 +1329,11 @@ def run_pipeline(
                         cluster_slug,
                         query,
                         fit_warning=bool(pp.get("_fit_warning")),
+                        cluster_moc_links=(
+                            list(getattr(cluster_obj, "moc_links", []) or [])
+                            if cluster_obj
+                            else None
+                        ),
                     ),
                     encoding="utf-8",
                 )

--- a/src/research_hub/vault/hub_backlink_migrate.py
+++ b/src/research_hub/vault/hub_backlink_migrate.py
@@ -59,8 +59,19 @@ def _build_hub_section(cluster_slug: str, moc_links: list[str]) -> str:
     return "\n## Hub\n\n" + "\n".join(lines) + "\n"
 
 
-def migrate_one_note(path: Path) -> HubMigrationResult:
-    """Inject `## Hub` section into one paper note. Idempotent."""
+def migrate_one_note(
+    path: Path,
+    *,
+    cluster_moc_links_map: dict[str, list[str]] | None = None,
+) -> HubMigrationResult:
+    """Inject `## Hub` section into one paper note. Idempotent.
+
+    ``cluster_moc_links_map`` lets the caller pre-load each cluster's
+    explicit `moc_links` (from `clusters.yaml`) so the auto-derived
+    sub-MOC suppression rule in `derive_moc_links` actually fires for
+    backfilled notes. Without this map, the generated `## Hub` block
+    would emit the slug-derived sub-MOC instead of the user override.
+    """
     try:
         text = path.read_text(encoding="utf-8")
     except OSError:
@@ -77,7 +88,8 @@ def migrate_one_note(path: Path) -> HubMigrationResult:
     if _HUB_SECTION_RE.search(text):
         return HubMigrationResult(path=path, action="already_present")
 
-    moc_links = derive_moc_links(cluster_slug)
+    explicit_moc_links = list((cluster_moc_links_map or {}).get(cluster_slug, []))
+    moc_links = derive_moc_links(cluster_slug, moc_links=explicit_moc_links)
     hub_section = _build_hub_section(cluster_slug, moc_links)
 
     # Find injection point: before any of the user-facing sections, after
@@ -107,8 +119,15 @@ def migrate_all(
     *,
     cluster_slug_filter: str | None = None,
     dry_run: bool = False,
+    cluster_moc_links_map: dict[str, list[str]] | None = None,
 ) -> list[HubMigrationResult]:
-    """Walk raw/*/*.md and ensure each has a `## Hub` section."""
+    """Walk raw/*/*.md and ensure each has a `## Hub` section.
+
+    ``cluster_moc_links_map`` is forwarded to `migrate_one_note` so
+    explicit `LLM-Agents-*` / `Water-Resources-*` overrides set in
+    `clusters.yaml` are honoured during backfill. Callers (CLI) should
+    pre-build this map by walking ClusterRegistry once.
+    """
     raw_root = vault_root / "raw"
     if not raw_root.exists():
         return []
@@ -133,5 +152,10 @@ def migrate_all(
                 continue
             results.append(HubMigrationResult(path=note, action="added"))
         else:
-            results.append(migrate_one_note(note))
+            results.append(
+                migrate_one_note(
+                    note,
+                    cluster_moc_links_map=cluster_moc_links_map,
+                )
+            )
     return results

--- a/src/research_hub/vault/hub_overview.py
+++ b/src/research_hub/vault/hub_overview.py
@@ -198,7 +198,11 @@ def populate_home(cfg) -> Path:
         _name = (cluster.name or _slug).strip()
         _paper_count = _count_papers(vault_root, _slug)
         _cluster_queries = [str(getattr(cluster, "first_query", "") or "")]
-        _moc_links = derive_moc_links(_slug, cluster_queries=_cluster_queries)
+        _moc_links = derive_moc_links(
+            _slug,
+            cluster_queries=_cluster_queries,
+            moc_links=list(getattr(cluster, "moc_links", []) or []),
+        )
         _moc_tail = ""
         if _moc_links:
             _moc_wikilinks = " / ".join(f"[[{m}]]" for m in _moc_links)
@@ -559,11 +563,33 @@ def derive_moc_links(
     you the cross-cluster centre (LLM-Agents) AND a distinct visible
     sub-hub per topic, instead of every LLM cluster collapsing onto a
     single shared LLM-Agents node.
+
+    Explicit override: if ``moc_links`` contains a name starting with
+    ``LLM-Agents-`` (resp. ``Water-Resources-``), the auto-derived
+    sub-MOC for that family is suppressed. The user-provided name wins
+    and replaces the slug-derived one, so e.g. setting
+    ``moc_links: [LLM-Agents-HumanNature]`` for a slug like
+    ``generative-ai-large-language-models-coupled`` yields
+    ``[LLM-Agents-HumanNature, LLM-Agents]`` instead of also tacking
+    on the slug-default ``LLM-Agents-Coupled``.
     """
 
     links: list[str] = []
+    explicit_names: list[str] = []
     for name in moc_links or []:
-        _append_unique(links, str(name).strip())
+        clean = str(name).strip()
+        if clean:
+            explicit_names.append(clean)
+            _append_unique(links, clean)
+    # Suppress auto sub-MOC for any family the user has already
+    # explicitly overridden (matches the family's parent name + `-`).
+    has_explicit_llm_sub = any(
+        n.startswith("LLM-Agents-") for n in explicit_names
+    )
+    has_explicit_water_sub = any(
+        n.startswith("Water-Resources-") for n in explicit_names
+    )
+
     text_parts = [cluster_slug, *(cluster_queries or [])]
     # Normalise hyphens/underscores to spaces so multi-word triggers like
     # "large language model" match slug tokens "large-language-models" too.
@@ -574,7 +600,7 @@ def derive_moc_links(
     sub_tag = _sub_moc_token_from_slug(cluster_slug)
     if "llm" in haystack or "large language model" in haystack or "agent" in haystack:
         _append_unique(links, "LLM-Agents")
-        if sub_tag:
+        if sub_tag and not has_explicit_llm_sub:
             _append_unique(links, f"LLM-Agents-{sub_tag}")
     # v0.88.5: broaden water-resources heuristic so flood / hydrology /
     # drainage / river / drought / rainfall clusters also link to the
@@ -586,7 +612,7 @@ def derive_moc_links(
     )
     if any(kw in haystack for kw in water_keywords):
         _append_unique(links, "Water-Resources")
-        if sub_tag:
+        if sub_tag and not has_explicit_water_sub:
             _append_unique(links, f"Water-Resources-{sub_tag}")
     return links
 

--- a/tests/test_moc.py
+++ b/tests/test_moc.py
@@ -110,7 +110,13 @@ def test_sub_moc_fallback_when_all_tokens_are_stopwords():
 
 def test_sub_moc_explicit_moc_links_pass_through_untouched():
     """Existing `cluster.moc_links` (set by hand in clusters.yaml) flow
-    through unchanged — sub-MOC derivation only adds, never strips."""
+    through unchanged — sub-MOC derivation only adds, never strips.
+
+    Caveat: an explicit name that does NOT match a family prefix
+    (`LLM-Agents-*` / `Water-Resources-*`) is treated as an unrelated
+    extra MOC; the family's auto sub-MOC still gets added. See
+    `test_explicit_sub_moc_suppresses_auto_for_same_family` for the
+    suppression rule when the prefix DOES match."""
     out = derive_moc_links(
         "my-cluster",
         moc_links=["MyCustomMOC"],
@@ -119,3 +125,88 @@ def test_sub_moc_explicit_moc_links_pass_through_untouched():
     assert "MyCustomMOC" in out
     assert "LLM-Agents" in out
     assert "LLM-Agents-Cluster" in out  # sub from slug "my-cluster" (last non-stopword)
+
+
+def test_explicit_sub_moc_suppresses_auto_for_same_family():
+    """When `cluster.moc_links` contains a name with the parent's
+    prefix (`LLM-Agents-*`), the auto-derived slug-based sub-MOC for
+    that family is SUPPRESSED. The user-provided name wins.
+
+    Use case: slug like `generative-ai-large-language-models-coupled`
+    auto-derives `LLM-Agents-Coupled`, but the actual topic is
+    Human-Nature Systems. User sets
+    `moc_links: [LLM-Agents-HumanNature]` in clusters.yaml; result
+    should be the user's choice + parent, NOT both."""
+    out = derive_moc_links(
+        "generative-ai-large-language-models-coupled",
+        moc_links=["LLM-Agents-HumanNature"],
+    )
+    assert out == ["LLM-Agents-HumanNature", "LLM-Agents"]
+    # Slug-derived `LLM-Agents-Coupled` must NOT appear.
+    assert "LLM-Agents-Coupled" not in out
+
+
+def test_explicit_water_sub_moc_suppresses_auto_for_same_family():
+    """Same suppression rule for the Water-Resources family."""
+    out = derive_moc_links(
+        "ml-flood-forecasting",
+        moc_links=["Water-Resources-Floods"],
+    )
+    assert out == ["Water-Resources-Floods", "Water-Resources"]
+    assert "Water-Resources-MlForecasting" not in out
+
+
+def test_explicit_override_only_suppresses_matching_family():
+    """An explicit `LLM-Agents-*` override should NOT suppress the
+    auto water sub-MOC, and vice-versa. Each family is independent."""
+    # Slug triggers BOTH families; user overrides only LLM.
+    out = derive_moc_links(
+        "human-water-llm",
+        moc_links=["LLM-Agents-Custom"],
+    )
+    # LLM family: user override wins, no auto sub.
+    assert "LLM-Agents-Custom" in out
+    assert "LLM-Agents-Human" not in out
+    # Water family: auto sub-MOC still derived.
+    assert "Water-Resources" in out
+    assert "Water-Resources-Human" in out
+
+
+def test_explicit_override_propagates_to_paper_note_hub_section(tmp_path):
+    """Regression: the per-paper Obsidian-note `## Hub` block (written
+    by `pipeline._render_obsidian_note`) MUST also honour
+    `cluster.moc_links`. Before this test existed, the pipeline call
+    site at `pipeline.py:700` only passed `cluster_slug` +
+    `cluster_queries` — the override took effect on the cluster
+    `00_overview.md` and MOC pages but NOT on the paper notes, so the
+    overview said `LLM-Agents-HumanNature` while every paper wikilinked
+    to `LLM-Agents-Coupled`. This test pins the fix."""
+    from research_hub.pipeline import _render_obsidian_note
+
+    pp = {
+        "title": "Test paper on coupled human-nature systems",
+        "authors": ["Doe, J."],
+        "year": "2026",
+        "journal": "Nat. HumanNature",
+        "doi": "10.1234/test",
+        "abstract": "Coupled human-nature systems are studied with LLMs.",
+        "slug": "doe2026-test-paper",
+        "tags": [],
+        "summary": "",
+        "key_findings": [],
+        "methodology": "",
+        "relevance": "",
+    }
+    out = _render_obsidian_note(
+        pp,
+        collection_name="generative-ai-large-language-models-coupled",
+        cluster_slug="generative-ai-large-language-models-coupled",
+        query="LLM human-nature systems",
+        cluster_moc_links=["LLM-Agents-HumanNature"],
+    )
+    # The override should be wikilinked from the `## Hub` block.
+    assert "[[LLM-Agents-HumanNature]]" in out
+    # The slug-derived auto sub-MOC must NOT appear.
+    assert "[[LLM-Agents-Coupled]]" not in out
+    # Parent MOC still present.
+    assert "[[LLM-Agents]]" in out


### PR DESCRIPTION
## Summary

- Lets the user override the auto-derived sub-MOC by setting `moc_links: [LLM-Agents-HumanNature]` (or any `LLM-Agents-*` / `Water-Resources-*` prefix) in `clusters.yaml`. When the prefix matches a family, the slug-derived sub-MOC for THAT family is suppressed; the user's name wins.
- Threads `cluster.moc_links` through all 7 effective `derive_moc_links` call sites — the previous PR (#110) honoured it only on cluster `00_overview.md`, MOC pages, and NLM brief mirrors, leaving paper notes / `_HOME.md` / backfill emitting the slug default. End state without this PR: overview wikilink and paper-note wikilink disagree.
- New regression test `test_explicit_override_propagates_to_paper_note_hub_section` pins the pipeline call-site fix (the load-bearing one — fires on every paper during ingest).

## Why this is two PRs

PR #110 shipped the two-level hub-and-spoke (parent + auto sub-MOC). Reviewing it against a real vault surfaced that `LLM-Agents-Coupled` was a vague name for a Human-Nature Systems cluster (the slug truncated mid-concept). This PR adds the override knob without changing the auto-derivation behaviour for clusters that don't set `moc_links`.

## Use case (from clusters.yaml)

```yaml
- slug: generative-ai-large-language-models-coupled
  moc_links: [LLM-Agents-HumanNature]   # override the vague auto-derived `LLM-Agents-Coupled`
```

Result: `derive_moc_links` returns `[LLM-Agents-HumanNature, LLM-Agents]`. Without the override it would return `[LLM-Agents, LLM-Agents-Coupled]`. Each family is independent — a user can override `LLM-Agents-*` while leaving the Water-Resources auto sub-MOC intact.

## Call sites audit

All 7 effective `derive_moc_links` callers now pass `moc_links`:

| Caller | Status |
|---|---|
| `notebooklm/download.py:36` (mirror_brief) | pre-existing |
| `pipeline.py:707` (_render_obsidian_note) | **NEW** |
| `pipeline.py:1567` (_sync_hub_overview) | pre-existing |
| `vault/hub_overview.py:201` (populate_home) | **NEW** |
| `vault/hub_overview.py:477` (populate_all_mocs) | pre-existing |
| `vault/hub_overview.py:669` (populate_all_overviews) | pre-existing |
| `vault/hub_backlink_migrate.py:92` (migrate_one_note) | **NEW** |

## API compat

- `migrate_one_note(path)` keeps working — new `cluster_moc_links_map` kwarg is keyword-only with `None` default
- `migrate_all(...)` same — new kwarg additive
- `_render_obsidian_note(...)` same — new `cluster_moc_links` kwarg additive

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/test_moc.py -q` → 12 passed
- [x] `PYTHONPATH=src python -m pytest -k 'moc or hub_overview or hub_backlink or pipeline or render_obsidian' -q --timeout=120` → 165 passed, 7 skipped
- [x] code-review skill: pass 1 → REQUEST CHANGES (P1 caught the missing pipeline call site), pass 2 → APPROVE / HIGH confidence
- [ ] CI matrix green on this PR

## Files

- `src/research_hub/vault/hub_overview.py` (+28) — core override logic + populate_home fix
- `src/research_hub/pipeline.py` (+13) — paper-note `## Hub` generation now honours override
- `src/research_hub/vault/hub_backlink_migrate.py` (+24/-2) — backfill honours override via map kwarg
- `src/research_hub/cli.py` (+10) — handler pre-builds the slug→moc_links map from ClusterRegistry
- `tests/test_moc.py` (+90/-2) — 4 new tests (3 override semantics + 1 pipeline regression)
- `CHANGELOG.md` (+24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)