### PR TITLE
chore: add server.json for MCP Server Registry publication

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.WenyuChiou/research-hub",
+  "description": "Research workspace for Zotero + Obsidian + NotebookLM. Search, ingest, sync, verify briefs.",
+  "version": "0.91.1",
+  "repository": {
+    "url": "https://github.com/WenyuChiou/research-hub",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "research-hub-pipeline",
+      "version": "0.91.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why

The official Anthropic-adjacent MCP Server Registry at [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io) replaced the community-server list in [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) README. Publishing research-hub to that registry requires a `server.json` manifest in the repo root matching the [2025-12-11 schema](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json).

## What

Adds `server.json` declaring:

- **Namespace**: `io.github.WenyuChiou/research-hub` (GitHub-OAuth-verifiable)
- **Description**: trimmed to fit the registry's 100-char limit
- **Repository**: `https://github.com/WenyuChiou/research-hub` (source: github)
- **Package**: PyPI `research-hub-pipeline` v0.91.1, stdio transport (matches existing `research-hub serve` MCP mode)

## Validation

```
$ mcp-publisher validate
Validating against https://registry.modelcontextprotocol.io...
✅ server.json is valid
```

## Next steps after merge

```bash
mcp-publisher login github   # opens browser, OAuth device flow
mcp-publisher publish        # uploads server.json to registry
```

Verify post-publish:

```bash
curl 'https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.WenyuChiou/research-hub'
```

## Version bumps

When `research-hub-pipeline` releases a new PyPI version, update both `version` fields in `server.json` and re-run `mcp-publisher publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)