### PR TITLE
fix(subprocess): errors=replace on 6 locale-emitting subprocess reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,30 @@ out to the real tools instead)._
   troubleshooting + meta. No content removed; pure reorder + 2 new
   navigational sections (Quick start ~10 lines, Contents ~20 lines).
 
+### Fixed
+
+- **Subprocess reads now degrade gracefully on a stray byte instead of
+  crashing the reader thread.** Six diagnostic/system-tool subprocess
+  calls used `text=True` with no `errors=` handler: `doctor.py` (the
+  `wmic` / `ps` chrome-process lookup), `security/__init__.py` (the
+  `icacls` ACL reset / grant / verify calls), `dashboard/executor.py`
+  (the command runner's `subprocess.run` + `Popen` paths), and
+  `defuddle_extract.py` (had `encoding="utf-8"` but no `errors=`). Under
+  Python's UTF-8 mode (`PYTHONUTF8=1`), reading a Windows tool that emits
+  cp950/Big5 raised `UnicodeDecodeError: ... byte 0xa4` and killed the
+  `subprocess` reader thread (10 tracebacks polluted `doctor` output;
+  the affected lookup silently returned nothing). Added
+  `errors="replace"` to all six — the codec is **unchanged** (these
+  tools legitimately emit locale-encoded output, so forcing utf-8 would
+  mangle them), only a bad byte now becomes a replacement char rather
+  than a crash. The user-facing LLM-output reads (`llm_cli.py`,
+  `paper_summarize.py`) were already protected with
+  `encoding="utf-8", errors="replace"`. Verified: `doctor` under
+  `PYTHONUTF8=1` goes from 10 `UnicodeDecodeError`s to 0; the
+  executor / doctor / security / defuddle suites stay green (141
+  passed). Surfaced during a live literature-search dogfood of the
+  ai-research-skills audit follow-up.
+
 ## [1.0.0] - 2026-05-26
 
 First stable release. 129 commits since v0.91.1 (95 features +

--- a/src/research_hub/dashboard/executor.py
+++ b/src/research_hub/dashboard/executor.py
@@ -332,6 +332,7 @@ def execute_action(
                     args,
                     capture_output=True,
                     text=True,
+                    errors="replace",
                     timeout=timeout,
                     shell=False,
                 )
@@ -362,6 +363,7 @@ def execute_action(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                errors="replace",
                 shell=False,
             )
             stdout, stderr = proc.communicate(timeout=timeout)

--- a/src/research_hub/defuddle_extract.py
+++ b/src/research_hub/defuddle_extract.py
@@ -47,6 +47,7 @@ def extract_url_via_defuddle(
             capture_output=True,
             text=True,
             encoding="utf-8",
+            errors="replace",
             timeout=timeout_sec,
             check=False,
         )

--- a/src/research_hub/doctor.py
+++ b/src/research_hub/doctor.py
@@ -740,13 +740,13 @@ def check_nlm_chrome_orphans() -> CheckResult:
             # as "could not check" rather than FAIL.
             proc = subprocess.run(
                 ["wmic", "process", "where", "name='chrome.exe'", "get", "ProcessId,CommandLine", "/format:csv"],
-                capture_output=True, text=True, timeout=8, check=False,
+                capture_output=True, text=True, errors="replace", timeout=8, check=False,
             )
             cmdline_lookups = proc.stdout.splitlines() if proc.returncode == 0 else []
         else:
             proc = subprocess.run(
                 ["ps", "-eo", "pid,command"],
-                capture_output=True, text=True, timeout=8, check=False,
+                capture_output=True, text=True, errors="replace", timeout=8, check=False,
             )
             cmdline_lookups = proc.stdout.splitlines() if proc.returncode == 0 else []
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):

--- a/src/research_hub/security/__init__.py
+++ b/src/research_hub/security/__init__.py
@@ -196,6 +196,7 @@ def _restrict_windows_acl(path: Path, *, mode: int = 0o600) -> None:
                 _acl_reset_argv(path, is_dir=is_dir),
                 capture_output=True,
                 text=True,
+                errors="replace",
                 timeout=30,
             )
         except Exception:  # noqa: BLE001 - best-effort rollback
@@ -215,12 +216,14 @@ def _restrict_windows_acl(path: Path, *, mode: int = 0o600) -> None:
             _acl_grant_argv(path, principal, is_dir=is_dir),
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=10,
         )
         verify = subprocess.run(
             ["icacls", str(path)],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=10,
         )
         if result.returncode != 0 or not _acl_grant_present(


### PR DESCRIPTION
## What

Six diagnostic/system-tool subprocess calls used `text=True` with no `errors=` handler, so a single undecodable byte crashed the subprocess reader thread:

- `doctor.py` — `wmic` / `ps` chrome-process lookup (2 sites)
- `security/__init__.py` — `icacls` ACL reset / grant / verify (3 sites)
- `dashboard/executor.py` — command runner `subprocess.run` + `Popen` (2 sites)
- `defuddle_extract.py` — had `encoding="utf-8"` but no `errors=` (1 site)

## Why

Under Python UTF-8 mode (`PYTHONUTF8=1`), reading a Windows tool that emits cp950/Big5 raised `UnicodeDecodeError: ... byte 0xa4` and killed the reader thread — `doctor` spewed 10 tracebacks and the lookup silently returned nothing. Surfaced during a live literature-search dogfood (ai-research-skills audit follow-up).

## Fix

Add `errors="replace"` to all six. **The codec is unchanged** — these tools legitimately emit locale-encoded output, so forcing `encoding="utf-8"` would mangle them; only an *undecodable* byte now becomes `U+FFFD` instead of a crash. For a correct-locale user, behavior is byte-identical. The genuinely user-facing reads (LLM output in `llm_cli.py` / `paper_summarize.py`) were already protected with `encoding="utf-8", errors="replace"`.

### Security note
`security/__init__.py` is security-sensitive. Verified a replacement char in `icacls` output **cannot** fake the `name:(` ACE pattern that `_acl_grant_present` checks (`:`/`(` are illegal in Windows filenames, and `U+FFFD` can't synthesize them) — worst case it reads as *not-granted* and falls to the secure `_fail_open` rollback. ACL logic / argv untouched.

## Verification

- `doctor` under `PYTHONUTF8=1`: **10 UnicodeDecodeError → 0**
- `pytest -k "doctor or security or executor or defuddle"` → **141 passed, 9 skipped**
- Reviewer (code-review skill): **APPROVE 6/6** — AST scan confirms 0 unprotected `text=True` subprocess reads remain.

## Scope

`src/` only — no `skills/` touch, no version bump. Lands under `[Unreleased]` for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)