### PR TITLE
docs: add OpenWiki wiki (first generation)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- OPENWIKI:START -->
+
+## OpenWiki
+
+This repository uses OpenWiki for recurring code documentation. Start with `openwiki/quickstart.md`, then follow its links to architecture, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
+
+<!-- OPENWIKI:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+<!-- OPENWIKI:START -->
+
+## OpenWiki
+
+This repository uses OpenWiki for recurring code documentation. Start with `openwiki/quickstart.md`, then follow its links to architecture, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
+
+<!-- OPENWIKI:END -->

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,0 +1,6 @@
+{
+  "updatedAt": "2026-07-21T07:44:19.000Z",
+  "command": "init",
+  "gitHead": "efd87bd26ab1009b21ba91d32b18d28ccbd9732c",
+  "model": "claude-fable-5 (manual bootstrap; engine pending)"
+}

--- a/openwiki/architecture/ingest-pipeline.md
+++ b/openwiki/architecture/ingest-pipeline.md
@@ -1,0 +1,106 @@
+# Ingest pipeline architecture
+
+The ingest pipeline turns a topic string (or an explicit `papers_input.json`) into: Zotero items in a cluster collection, one Obsidian markdown note per paper, refreshed hub navigation pages, and — optionally — a NotebookLM notebook with a generated brief. Two modules own the flow:
+
+1. `src/research_hub/auto.py` — `auto_pipeline()`, the end-to-end orchestrator behind `python -m research_hub auto "<topic>"` ("lazy mode"): cluster create-or-get → search → fit-check → ingest → post-ingest enrichment → NotebookLM.
+2. `src/research_hub/pipeline.py` — `run_pipeline()`, the ingest core behind `python -m research_hub ingest`: input validation → authenticity gate → dedup → Zotero writes → Obsidian notes → hub overview sync. `auto_pipeline` calls it as step 5.
+
+The same ingest core is also reachable through the MCP server (`mcp_server.py`), the REST API (`api/v1.py`, `post_auto` / `post_search`), and the dashboard's action executor — all four surfaces converge on `auto_pipeline` / `run_pipeline`, so guards that live there (the append/force guard, the fail-closed relevance gate) protect every caller, not just the CLI.
+
+## Stage 1 — Discovery
+
+Discovery lives in `src/research_hub/search/` behind `search_papers()` in `search/fallback.py`. Backends are pluggable classes (`arxiv_backend.py`, `semantic_scholar.py`, `openalex.py`, `crossref.py`, `pubmed.py`, `dblp.py`, `biorxiv.py`, `chemrxiv.py`, `nasa_ads.py`, `repec.py`, `ssrn_backend.py`, `eric.py`, `cinii.py`, `kci.py`, `google_scholar_backend.py`, `websearch.py`), fanned out per query and merged with ranking in `_rank.py`.
+
+- The default backend set is `DEFAULT_BACKENDS = ("openalex", "arxiv", "semantic-scholar", "crossref", "dblp")` so one rate-limited backend cannot sink a run.
+- `--field` selects a preset from `FIELD_PRESETS` (e.g. `bio`/`med` add PubMed and bioRxiv, `econ`/`social` add RePEc and SSRN, `astro` adds NASA ADS); `REGION_PRESETS` covers `jp`/`kr`/`cjk` via CiNii and KCI.
+- `--peer-reviewed` excludes gray document types (`GRAY_DOC_TYPES`: preprints, reports, datasets, ...) and applies a minimum-confidence floor.
+
+`auto.py:_run_search()` wraps `search_papers()` and converts results into papers-input dicts via `discover._to_papers_input()`. `discover.py` also implements the separate staged, human-in-the-loop `discover` flow (state machine `new → scored_pending → done` persisted under `.research_hub/discover/<cluster>/`), which stages candidates and an AI scoring prompt instead of ingesting immediately.
+
+Between search and ingest, `auto_pipeline` runs a **fail-closed relevance fit-check**: an LLM CLI detected on PATH (`llm_cli.detect_llm_cli`) judges each candidate against the cluster definition; papers scoring below the threshold (default 3) are quarantined, never written. If no judge CLI is on PATH, the run aborts *before* the search step with explicit alternatives (`--no-fit-check`, or `--no-llm-fit-check` for rule-based term-overlap filtering) rather than silently ingesting unjudged papers.
+
+## Stage 2 — Zotero save: the local-API / Web-API boundary
+
+All Zotero traffic goes through `src/research_hub/zotero/client.py`, which defines the key boundary:
+
+- **Local API** — Zotero desktop's HTTP endpoint at `http://localhost:23119/api` (`LOCAL_API_BASE`, probed by `check_local_api()`). Fast, no network round-trip, **read-only**.
+- **Web API** — `api.zotero.org` via pyzotero, authenticated with `ZOTERO_API_KEY` / `ZOTERO_LIBRARY_ID` (resolution order in `_load_credentials()`: env vars → `~/.claude/.env` → research-hub `config.json` → the legacy standalone zotero-skills config). **All writes go here** — the local API does not support writes.
+
+Two client shapes implement the split:
+
+- `get_client()` returns a plain pyzotero **Web API** client. This is what `run_pipeline` uses for ingest, since ingest is write-heavy (item creation, tags, notes, collections).
+- `ZoteroDualClient` tries the **local API first for reads** (verifying with a real request at construction) and transparently falls back to the Web API when Zotero desktop is not running or the connection drops mid-run (`_read()` flips `local_available` on connection errors). Writes always route to `self.web`, with `create_items` chunked 50 at a time. The read-heavy surfaces use it: `cli_zotero`, `cli_citations`, `cli_clusters`, and `clusters.py` collection management.
+
+Inside `run_pipeline`, `write_papers_to_zotero()` builds one pyzotero item template per paper (type inferred by `_zotero_item_type`, DOI-prefix venue overrides applied via `zotero/doi_overrides.py`), tags it with hub-namespace tags (`_compose_hub_tags`), routes it to the cluster's collection plus a per-batch subcollection, and flushes in batches of `ZOTERO_BATCH_SIZE = 50`. `_flush_batch` handles partial batch responses carefully: items absent from both the `successful` and `failed` buckets are retried **individually** so each paper gets its own key — never borrowing another paper's key (the STAB-1 rule against silently cross-linking distinct papers onto one item). Each created item also gets an HTML child note (`add_note` / `_build_note_html`).
+
+Setting `RESEARCH_HUB_NO_ZOTERO=1` skips Zotero entirely ("data analyst mode": Obsidian + NotebookLM only), with a loud stderr warning that the cluster's Zotero collection will not receive the papers.
+
+## Stage 3 — Obsidian note generation
+
+After Zotero writes (and DOI/arXiv verification when `--verify` is passed; `auto` runs with `verify=False`), `run_pipeline` writes one markdown note per paper to `raw/<cluster-slug>/<paper-slug>.md` via `_render_obsidian_note()`, then:
+
+- registers the note in the **dedup index** (`DedupHit(source="obsidian", ...)`),
+- updates cluster wikilinks (`update_cluster_links`),
+- appends a `manifest.jsonl` entry (`action="new"`, with DOI, title, Zotero key, batch label).
+
+The manifest (`manifest.py`, at `.research_hub/manifest.jsonl`) is the append-only audit log of every ingest decision — actions include `new`, `dup-obsidian`, `ingest-reuse-zotero`, `quarantine`, `pdf-attach`, and `error`.
+
+## Stage 4 — Hub index rebuild
+
+Navigation artifacts are refreshed twice, at two granularities:
+
+- Per ingest, `run_pipeline._sync_hub_overview()` derives MOC links for the cluster (`derive_moc_links` / `ensure_moc`) and rewrites the cluster's `00_overview.md` (`populate_overview` in `vault/hub_overview.py`), then `_refresh_cluster_base()` regenerates the cluster's Obsidian `.base` view.
+- Per `auto` run (when at least one note was written), `auto_pipeline` calls `vault/hub_overview.populate_all_overviews()` to refresh the vault-wide layer: `_HOME.md`, every `hub/_moc/*.md` body, and every cluster's overview. This is best-effort — a render failure logs a warning without sinking the ingest.
+
+## Stage 5 — NotebookLM upload
+
+The NotebookLM leg (skippable with `--no-nlm`) lives in `src/research_hub/notebooklm/` and runs four sub-steps, mirroring the connector Protocol:
+
+1. **Bundle** (`bundle.py:bundle_cluster`) — walk the cluster's notes, pick per-paper sources (a matched local PDF by DOI or Author_Year filename, else a quality-screened URL, else abstract text) into a bundle report.
+2. **Upload** (`upload.py:upload_cluster`) — find-or-create a notebook named after the cluster and upload each source; suspect URLs (error-page titles, dataset DOIs) are screened out unless `--include-suspect-urls`.
+3. **Generate** (`upload.py:generate_artifact`) — trigger brief generation.
+4. **Download** (`upload.py:download_briefing_for_cluster`) — save the brief under the vault's artifacts.
+
+Transport is **not** ad-hoc browser automation: `notebooklm/client.py` is a thin synchronous adapter over the async `notebooklm-py` upstream client, doing authenticated RPC calls from a stored browser-session state file (`auth.py`, `state.json` under the research-hub dir; obtained via `notebooklm login`). `auto_pipeline` runs a session-health preflight first and, if the session is invalid, defers the whole NLM leg with a `notebooklm login --auto-detect` hint. NotebookLM failures are always **deferred, not fatal** (`report.nlm_deferred = True`, `report.ok` stays `True`): the papers are already in the vault, so the run reports success with a retry path — unlike search or ingest failures, which stop the run.
+
+## Idempotency and dedup
+
+Dedup is layered; each layer catches a different duplicate class (all in `pipeline.py` + `dedup.py`):
+
+- **Persistent dedup index** (`.research_hub/dedup_index.json`, `DedupIndex`) keys hits by normalized DOI *and* normalized title (titles only when >15 normalized chars, to avoid false merges), with sources `obsidian` and `zotero`. It is rebuilt from the vault + Zotero when empty.
+- **In-batch dedup** collapses two search backends returning the same paper under different DOIs (journal DOI vs preprint DOI) before Zotero creation, keeping the first occurrence — otherwise both would get Zotero items and their notes would collide on one filename slug.
+- **Obsidian hit** → skip, but only when the note file *actually exists* (a stale index entry pointing at a deleted note must not block re-ingest); the existing note gets the new cluster query appended and links updated (`action="dup-obsidian"`).
+- **Zotero hit** → the paper is *not* skipped: the existing item is reused (moved into the cluster collection, missing hub tags and child note added, no duplicate item created) and the paper continues to Obsidian-note creation with the reused key (`action="ingest-reuse-zotero"`).
+- **Library-wide `check_duplicate`** against Zotero itself, relaxable with `--allow-library-duplicates`.
+
+Other idempotency points: `auto` refuses to ingest into a cluster that already has notes unless `--append` (add) or `--force` (which really overwrites — it clears `raw/<slug>/*.md` first, scoped to Obsidian only, never deleting Zotero items or NotebookLM sources); PDF attach silently skips items that already have a PDF; the cluster-overview autofill skips when a hand-curated TL;DR exists; NotebookLM upload reuses an existing notebook with the same cluster name. Concurrency: each `auto` run writes its candidate list to a per-run path (`.runs/<slug>-<pid>/papers_input.json`) threaded into `run_pipeline`, so concurrent runs cannot clobber each other through the shared default `papers_input.json`.
+
+Before any write, every candidate also passes the **authenticity gate** (`authenticity.py:verify_authenticity`): layered checks (L0 input sanity, L1 DOI registration — with transient resolver failures marked `L1-deferred` and retryable rather than rejected, L3 metadata integrity, L4 relevance fit-check) quarantine failures with a manifest entry instead of writing them. If every candidate is quarantined, `auto` reports the ingest step as a failure with honest counts — it never prints "OK, N papers" for an empty vault.
+
+## Package boundaries
+
+- `search/` — discovery only. Consumes a query, produces ranked `SearchResult`s; knows nothing about Zotero or the vault.
+- `zotero/` — the Zotero seam. `client.py` (credentials, local/Web split, dual client), `pdf_attach.py` (open-access PDF lookup via OpenAlex/Unpaywall/arXiv/Crossref and attachment upload), `doi_overrides.py`, `fetch.py`, `enrich.py`, `gc.py`.
+- `notebooklm/` — the NotebookLM implementation (`auth.py`, `bundle.py`, `upload.py`, `download.py`, `client.py` over `notebooklm-py`).
+- `connectors/` — the *abstraction* over external publish targets: a `Connector` Protocol with `bundle → upload → generate(brief) → download` and typed report dataclasses. `_notebooklm_adapter.py` wraps the existing NotebookLM code without modifying it; `null.py` is the no-op reference implementation for tests and dry runs. New destinations implement the Protocol rather than being wired into `auto.py`.
+- `api/` — REST surface (`v1.py` request handlers such as `post_auto` / `post_search` / `get_cluster_quarantine`, `jobs.py` for async job tracking). Thin: validates request bodies and delegates to the same orchestration functions.
+- `dashboard/` — local HTML dashboard (`http_server.py`, `render.py`, `sections.py`, `executor.py` for action buttons). Reads vault state and *triggers* pipeline runs; owns no ingest logic.
+- `vault/` — Obsidian-side operations: hub overview/MOC/home rendering, cleanup, gc, sync, repair.
+
+Data handoffs are plain dicts and files: search results → papers-input dicts (`discover._to_papers_input`) → per-run `papers_input.json` → `run_pipeline` → notes in `raw/<slug>/` + `manifest.jsonl` + `dedup_index.json` + `logs/pipeline_output.json` → NotebookLM bundle dir → brief artifact.
+
+## End-to-end walkthrough: `python -m research_hub auto "battery degradation modeling"`
+
+Grounded in `auto.py:auto_pipeline()` (dispatched from `cli_pipeline.py:_auto`):
+
+1. **Cluster** — slugify the topic; create the cluster in `ClusterRegistry` if missing, refresh the vault graph config, and auto-create + bind a Zotero collection (probing for an existing collection by name first, and best-effort nesting it under the configured parent collection so ingest has a target without a manual `clusters bind`).
+2. **Guard** — if the cluster already has notes in `raw/<slug>/` and neither `append` nor `force` was passed, abort fail-closed. `--dry-run` prints the full step plan here and exits.
+3. **Judge preflight** — if the LLM fit-check is on but no judge CLI is on PATH, abort *before* searching (see Stage 1).
+4. **Search** — `_run_search` fans out over the resolved backends with `max_papers` (default 8), year and peer-review filters; zero results or a search exception stops the run.
+5. **Fit-check** — LLM-judge (or term-overlap) scores each candidate; low scorers are quarantined.
+6. **Ingest** — survivors are written to the per-run `papers_input.json` and `run_pipeline` executes Stages 2–4 above (authenticity gate → dedup → Zotero batches → notes → cluster overview). Afterwards `auto` recounts `raw/<slug>/*.md` so the reported ingest count reflects what actually reached the vault, cleans up the per-run dir, and refreshes vault-wide navigation.
+7. **Enrichment (best-effort)** — `--with-summary` fills both note-summary layers (`## Summary` one-liner plus Key Findings / Methodology / Relevance) via the detected LLM CLI; the cluster overview is auto-filled; `--with-pdfs` attaches open-access PDFs to the just-created Zotero items.
+8. **NotebookLM** — session preflight, then bundle → upload → generate brief → download brief; any failure is deferred with a retry hint.
+9. **Report** — an `AutoReport` (per-step results, counts, notebook URL, brief path) is returned; the CLI prints a Next Steps banner and, with `--json`, emits the report as JSON.
+
+For per-flag detail see [docs/cli-reference.md](../../docs/cli-reference.md) and [docs/lazy-mode.md](../../docs/lazy-mode.md); NotebookLM setup lives in [docs/notebooklm.md](../../docs/notebooklm.md). Related pages: [CLI module map](../cli/modules.md), [vault maintenance](../operations/vault-maintenance.md).

--- a/openwiki/cli/modules.md
+++ b/openwiki/cli/modules.md
@@ -1,0 +1,79 @@
+# CLI module map
+
+The `research_hub` CLI is a single argparse program with one entry point (`src/research_hub/cli.py`) and eleven extracted `cli_*` domain modules. The canonical invocation is `python -m research_hub <command> ...` (an installed `research-hub` console script behaves identically); prefixing `PYTHONPATH=src` is the dev/pytest variant for running against a checkout. The full flag-by-flag command reference lives in [docs/cli-reference.md](../../docs/cli-reference.md) — this page maps commands to source files so agents know where to read and where to edit.
+
+## How dispatch works
+
+`cli.py` owns the entire argparse surface and the routing; the `cli_*` modules own handler bodies only:
+
+- `build_parser()` in `cli.py` registers **every** subparser (~167 `add_parser` calls). No `cli_*` module registers its own arguments — if you are looking for a flag definition, it is in `cli.py`.
+- `main()` parses argv, then `_main_dispatch(args, parser)` routes on `args.command` through a flat `if args.command == ...` chain and calls a handler function, most of which are imported from the `cli_*` modules (import blocks at the top of `cli.py`).
+- A bare `python -m research_hub` with no subcommand prints help and exits 0 *before* any config probing, so fresh installs without a `config.json` see the command list instead of a config error.
+- Config gating: every command except the exempt set `{init, setup, doctor, install, examples, where, config, ezproxy, package-dxt, describe, context}` triggers `require_config()` before its handler runs.
+- Dependency injection: the `cli_*` modules bind `get_config` / `ClusterRegistry` at import time, so `cli.py` re-assigns lambdas into each module (and `_sync_cli_dependencies()` repeats this at the top of `_main_dispatch`) so that test patches of `research_hub.cli.get_config` propagate into the extracted handlers. When extracting a new module, add a sync line there.
+- Errors: `main()` catches `ResearchHubError`; with `--json` it emits a structured `{"ok": false, "error": ...}` payload and returns 1, otherwise it re-raises. `cli_common._emit_cli_json` is the shared success-path JSON emitter.
+
+## Module map by workflow
+
+Handler functions are private (`_search`, `_cmd_ingest`, ...); the tables list the user-facing subcommands each module implements.
+
+### Discovery and ingest
+
+- **`cli_search.py`** — finding papers before they enter the vault. Implements `search` (multi-backend academic search with year/citation/type filters and `--to-papers-input`), `websearch` (web-source search with optional `--ingest-into`), `enrich` (resolve bare titles/DOIs into full records), `references` / `cited-by` / `suggest` (citation-graph lookups around one identifier), and the staged `discover new | continue | status | clean | variants` flow (search → stashed fit-check prompt → apply scores → `papers_input.json`). Note: `cli.py` still resolves backends (`--region` / `--field` / `--backend` presets and `--peer-reviewed` adjustments) inline before calling `_search`.
+- **`cli_pipeline.py`** — running the ingest machinery. Implements `doctor`, `ingest`, `auto` (the one-shot topic → search → fit-check → Zotero → Obsidian → NotebookLM pipeline), `import-folder` (plus its dependency precheck), `fit-check emit | apply | audit | drift`, `sync status | reconcile` (cross-system drift), `pipeline repair` (orphan repair for a cluster), and `migrate-yaml`. The top-level `run` command is dispatched inline in `cli.py` directly to `pipeline.run_pipeline`.
+- **`cli_paper.py`** — per-paper CRUD and curation. Implements `add`, `remove`, `mark`, `move`, `find`, `label`, `label-bulk`, `verify`, `quarantine list | show | restore`, `autofill emit | apply`, `fit-check apply-labels`, and the whole `paper` subtree via `_paper_command`: `lookup-doi`, `find`, `add-to-cluster`, `gaps`, `prune`, `unarchive`, `bulk-relabel`, `bulk-move`, `bulk-delete`, `retype`, `enrich-existing`, `attach-pdfs`, `upgrade-pdfs`, `resummarize`, `summarize`.
+
+### Organization and AI-assisted content
+
+- **`cli_clusters.py`** — the `clusters` subtree: `list`, `show`, `set-group`, `prisma`, `new`, `bind`, `rename`, `archive`, `unarchive`, `merge`, `split`, `analyze`, `scaffold-missing`, `audit`, `restore-zotero-coll`, `sync-names`, `resolve-collision`. Three `clusters` branches stay inline in `cli.py`: `coverage` (calls `clusters.compute_coverage`), `delete` (preview/apply cascade delete via `clusters.cascade_delete_cluster` — a `_clusters_delete` helper exists in the module but the dispatch branch does not use it), and `rebind` (via `cluster_rebind`).
+- **`cli_summarize.py`** — AI-generated derived content: `crystal emit | apply | list | read | check` (pre-computed canonical crystals), `summarize`, `memory emit | apply | list | read` (structured cluster memory registries), and `vault summarize-status-migrate`.
+- **`cli_citations.py`** — writing support: `cite` (formatted citations for one identifier or a cluster), `quote` (add/list/remove saved paper quotes — `cli.py` untangles the positional `quote_target` grammar before calling the handlers), and `compose-draft` (outline + quotes → draft with optional bibliography).
+
+### Maintenance
+
+- **`cli_maintenance.py`** — install/ops surface: `install` (agent-platform integration), `where`, `serve` (REST API), `config encrypt-secrets | set`, `package-dxt`, `index` (rebuild `dedup_index.json`), `dedup invalidate | rebuild | compact`, `status` (per-cluster reading progress), `dashboard`, and the GC half of `cleanup` (`--bundles/--debug-logs/--artifacts`). Also owns the Claude Desktop MCP-config path/install helpers.
+- **`cli_vault.py`** — Obsidian-side maintenance: the `vault` subtree (`graph-colors`, `polish-markdown`, `rebuild-overviews`, `tag-migrate`, `prune-footers`, `gc`, `hub-backlink-migrate`, `cleanup-frontmatter`, `install-theme`), `bases emit` (Obsidian Bases generator), `synthesize` (hub index rebuild), and the wikilink-dedup half of `cleanup` (`_cleanup_hub`, also the bare-`cleanup` backwards-compat default).
+- **`cli_zotero.py`** — Zotero-side maintenance: `zotero backfill` (tags and notes), `zotero gc` (empty/test/orphan collections), `zotero mark-kept`, `zotero reparent-clusters`.
+
+### Export
+
+- **`cli_notebooklm.py`** — NotebookLM operations: `notebooklm bundle`, `upload`, `shard`, `download`, `read-briefing`, `generate`, `ask`, plus the shared `_preflight_nlm_session` check. Two `notebooklm` branches stay inline in `cli.py`: `login` (interactive / `--import-from` / `--from-browser`, delegating to `notebooklm/auth.py`) and `keepalive` (loop and Windows-task install, delegating to `notebooklm/keepalive.py`).
+
+### Shared plumbing
+
+- **`cli_common.py`** — no subcommands; shared helpers used across modules: deprecated-alias warnings, `_emit_cli_json` / `_json_safe` (structured `--json` output), `_stdout_to_stderr`, `_load_zotero_if_configured`, and argv parsers (`_parse_year_range`, `_parse_csv_terms`, `_parse_negative_terms`, `_parse_seed_dois`).
+
+## What still lives in cli.py itself
+
+Beyond parser construction and routing, `_main_dispatch` retains real logic for commands that were never extracted. These call domain modules directly rather than a `cli_*` handler:
+
+- `run` (→ `pipeline.run_pipeline`, plus post-run fit-check auto-labeling), `init` (→ `init_wizard` / `onboarding` field wizard), `setup` (→ `setup_command`), `tidy` (→ `tidy`), `ask` (→ `workflows.ask_cluster`), `plan` (→ `planner`), `describe` (→ `describe`), `ezproxy login | status` (→ `ezproxy`), `examples list | show | copy` (→ `examples`), `context init | audit | compress` (→ `context_cli.dispatch`), and the entire `topic` subtree (`scaffold | digest | show | propose | assign emit/apply | build | list` → `topic`).
+- The inline `clusters delete | rebind | coverage` and `notebooklm login | keepalive` branches noted above, the `search` backend-preset resolution, `quote` argument untangling, and `cleanup` routing between the vault wikilink-dedup and the maintenance GC.
+
+So "where is command X?" has three answers: flags are always in `cli.py`'s `build_parser()`; the handler is usually in the matching `cli_*` module; and for the commands in this section the handler body is in `_main_dispatch` itself, delegating straight to a domain module.
+
+## Adding a new subcommand
+
+1. **Register the parser** in `build_parser()` in `src/research_hub/cli.py` (find the neighboring command's `add_parser` block and follow its `dest` naming convention, e.g. `clusters_command`).
+2. **Write the handler** in the `cli_*` module that owns the workflow (tables above) as a private function returning an `int` exit code. Use `cli_common._emit_cli_json` if the command supports `--json`, and raise `ResearchHubError` subclasses for structured failures.
+3. **Import and route**: add the handler to the corresponding `from research_hub.cli_<module> import (...)` block in `cli.py`, then add the dispatch branch in `_main_dispatch`.
+4. **Config access**: call the module-level `get_config()` / `ClusterRegistry` inside the handler (not at import time) so the `_sync_cli_dependencies()` test-patch propagation works; if you create a *new* `cli_*` module, add its sync lines both at module scope in `cli.py` and inside `_sync_cli_dependencies()`.
+5. **Config gating**: if the command must work without a `config.json` (setup/diagnostic class), add it to `exempt_commands` in `_main_dispatch`.
+6. **Docs and tests**: add the command to [docs/cli-reference.md](../../docs/cli-reference.md); CLI tests live in `tests/` (`test_cli_smoke_comprehensive.py` for smoke coverage, `test_arch2_cli_split.py` guards the cli-split architecture, plus per-area files like `test_cli_search.py`, `test_cli_notebooklm.py`).
+
+## Source map
+
+- `src/research_hub/cli.py`
+- `src/research_hub/cli_citations.py`
+- `src/research_hub/cli_clusters.py`
+- `src/research_hub/cli_common.py`
+- `src/research_hub/cli_maintenance.py`
+- `src/research_hub/cli_notebooklm.py`
+- `src/research_hub/cli_paper.py`
+- `src/research_hub/cli_pipeline.py`
+- `src/research_hub/cli_search.py`
+- `src/research_hub/cli_summarize.py`
+- `src/research_hub/cli_vault.py`
+- `src/research_hub/cli_zotero.py`
+- `docs/cli-reference.md`
+- `README.md`

--- a/openwiki/operations/release-and-testing.md
+++ b/openwiki/operations/release-and-testing.md
@@ -1,0 +1,43 @@
+# Release and testing
+
+How to run the test suite, what the test seams are, and where the release process lives. This page is deliberately a pointer layer — the release runbook is [docs/RELEASING.md](../../docs/RELEASING.md) and dev setup is [CONTRIBUTING.md](../../CONTRIBUTING.md); do not duplicate them here.
+
+## Running the tests
+
+Pytest configuration lives in `pytest.ini` (the `[tool.pytest.ini_options]` block was removed from `pyproject.toml` because pytest prefers `pytest.ini` and the duplicate silently drifted — edit `pytest.ini` only). Defaults: `testpaths = tests`, `--timeout=30` per test, and `-m "not slow and not stress"` plus `--ignore=tests/stress`, so the default run excludes slow and stress tests automatically.
+
+```bash
+pip install -e '.[dev]'
+pytest -q
+```
+
+If imports fail (running from a clone without an editable install), use the dev variant:
+
+```bash
+PYTHONPATH=src pytest -q
+```
+
+Coverage, per [CONTRIBUTING.md](../../CONTRIBUTING.md):
+
+```bash
+pytest --cov=research_hub --cov-report=term-missing
+```
+
+## Test seams
+
+The suite is ~350 flat `test_*.py` files under `tests/`, organized by seam rather than by directory — plus two opt-in subdirectories:
+
+- **Default suite** (`tests/test_*.py`) — unit and integration tests over the CLI split, pipeline, connectors, vault maintenance, and dashboard. Includes an e2e smoke (`tests/test_e2e_smoke.py`). Shared fixtures in `tests/conftest.py`.
+- **Network fence** — `tests/conftest.py` installs a structural fence via `pytest-socket`: every test is restricted to loopback/unix sockets unless marked `network`, `real_zotero`, or `real_authenticity` (opt-in live-API markers). Unmarked tests cannot silently hit the wire.
+- **`tests/evals/`** — accuracy evaluations (search accuracy, fit-check quality, DOI normalization) with a metrics collector that appends results to `tests/evals/_metrics.json`.
+- **`tests/stress/`** — stress/load tests, excluded by default; run explicitly with `pytest tests/stress/ -o "addopts=" -m stress`.
+- **Markers** (declared in `pytest.ini`): `stress`, `network`, `evals`, `slow` (tests >30 s or blocking at C level; excluded by default).
+
+## Release flow
+
+The release process is **mechanically gated**: `bash scripts/release-check.sh` verifies a clean tree, `__version__`/`pyproject.toml` version sync, and the full pytest suite *including e2e* on a fresh `--basetemp`, then writes a sha-bound marker that a `pre-push` hook (installed by `scripts/install_release_gate.sh`) requires before any `v*` tag push. After pushing, `gh run watch` on real CI is mandatory — local green is not shipped green. The full runbook (version-bump checklist including `server.json`, step ordering rationale, MCP Registry republish, emergency bypass) is [docs/RELEASING.md](../../docs/RELEASING.md).
+
+## CI workflows
+
+- `.github/workflows/ci.yml` — runs on every branch push and on PRs to `master`: full suite (`-m "not slow"`) on Windows/macOS for Python 3.10–3.13 (3.14 experimental, non-gating), a 4-shard `pytest-split` matrix on Ubuntu (RAM limits), a coverage job (`--cov-fail-under=62`, Windows py3.12), a PR-only stress-test job, and a PR-only `skill-version-guard` that blocks skill-content changes lacking a plugin version bump.
+- `.github/workflows/publish.yml` — triggered by pushing a `v*` tag: builds the package, validates the wheel installs in a fresh venv with `__version__` matching the tag, smoke-tests the installed wheel (`init --sample` + `describe --json`), then uploads to PyPI with `twine upload --skip-existing`.

--- a/openwiki/operations/vault-maintenance.md
+++ b/openwiki/operations/vault-maintenance.md
@@ -1,0 +1,100 @@
+# Vault layout and maintenance
+
+What a research-hub vault looks like on disk, and the maintenance commands that keep it healthy — `doctor`, `tidy`, `cleanup`, the dedup index, `vault gc`, and `clusters rebind`. The safety-critical fact of this page: **every maintenance command that mutates the vault defaults to a preview/dry-run and requires an explicit flag (usually `--apply`) to write**, and cluster deletion is a *soft* delete into `raw/_deleted_<slug>/` before anything is ever hard-removed. Command syntax details live in [docs/cli-reference.md](../../docs/cli-reference.md); the interactive cleanup walkthrough is [docs/clean_vault.md](../../docs/clean_vault.md).
+
+All invocations below use the canonical form `python -m research_hub ...` (equivalently the `research-hub` console script). `PYTHONPATH=src` prefixing is only the dev/pytest variant — see [Release and testing](./release-and-testing.md).
+
+## Vault layout
+
+Paths come from `src/research_hub/config.py` (`Config.__init__`). The vault root must live under `$HOME` unless `RESEARCH_HUB_ALLOW_EXTERNAL_ROOT=1` is set — a misconfigured `RESEARCH_HUB_ROOT` fails loudly instead of writing outside home. Defaults (each overridable in config):
+
+- `raw/` (`cfg.raw`) — one subfolder per cluster (`raw/<obsidian_subfolder>/`), holding the per-paper Markdown notes plus an optional `topics/` subfolder of sub-topic notes and cluster index files (`00_*`, `*-index`). Folders named `pdfs/`, `attachments/`, and anything starting with `_deleted_` are excluded from paper walks (`paper.py`, `doctor.py`).
+- `raw/_deleted_<slug>/` — **soft-delete residue**. `clusters delete --apply` moves `raw/<slug>/` here instead of removing it (`clusters.py: cascade_delete_cluster`). Everything under a `_deleted_*` dir is skipped by sync, graph coloring, footer pruning, and GC content passes; only `vault gc` ever hard-removes it, and only past an age threshold.
+- `hub/` (`cfg.hub`) — per-cluster knowledge pages: `hub/<slug>/` (overview `00_overview.md`, crystals, memory.json, `.base` file, briefs) and `hub/_moc/` Map-of-Content pages. `hub/_moc` and `hub/_archived` are reserved names, never treated as cluster hubs (`vault/gc.py`).
+- `.research_hub/` (`cfg.research_hub_dir`) — machine state: `clusters.yaml` (the cluster registry, default location of `cfg.clusters_file`), `dedup_index.json`, `manifest.jsonl`, `dashboard.html`, NotebookLM bundle exports under `bundles/<slug>-<timestamp>/`, ask/brief outputs under `artifacts/<slug>/`, `nlm-debug-*.jsonl` run logs, and timestamped `rebind-*.log` audit logs.
+- Also under the root: `projects/`, `logs/`, and `.obsidian/graph.json` (managed graph color groups).
+
+`python -m research_hub where` prints all of these locations plus per-cluster note counts without making any API calls (`cli_maintenance.py: _cmd_where`).
+
+## Destructive vs preview-only: the flag map
+
+Grounded in the argparse wiring in `cli.py` and the handler defaults:
+
+| Command | Default behavior | What makes it write |
+|---|---|---|
+| `doctor` | read-only checks, **two exceptions below** | `--autofix` backfills frontmatter |
+| `tidy` | doctor+autofix, dedup rebuild, bases refresh; cleanup step is preview | `--apply-cleanup` flushes the cleanup preview |
+| `cleanup` | dry-run listing (`--dry-run` is the default) | `--apply` deletes; scope flags `--bundles/--debug-logs/--artifacts/--wikilinks/--all` |
+| `dedup compact` | preview (`--dry-run` default) | `--apply` writes the compacted index |
+| `dedup rebuild` / `index` / `dedup invalidate` | **writes immediately** — but only to `.research_hub/dedup_index.json`, never to notes |
+| `vault gc` | dry-run report | `--apply` purges/rewrites |
+| `vault polish-markdown`, `tag-migrate`, `hub-backlink-migrate`, `summarize-status-migrate`, `cleanup-frontmatter` | dry-run (`--dry-run` default `True`) | `--apply` writes notes |
+| `vault prune-footers` | report only | `--apply` rewrites footers |
+| `vault rebuild-overviews` | regenerates hub overview/MOC pages (managed content; debounced, `--force` bypasses) | n/a — always writes hub pages |
+| `clusters rebind` | `--emit` prints a proposal; `--apply <report>` is still dry-run | add `--no-dry-run` to actually move files |
+| `clusters delete` | preview report, zero Zotero I/O | `--apply` (plus `--force` for non-empty clusters) |
+| `clusters delete --purge-zotero-items` | **DESTRUCTIVE** (Zotero items → trash) | only acts with `--apply`; dry-run lists items/PDF counts |
+| `zotero gc` | preview of empty/test/orphan Zotero collections | `--apply` (respects `zotero mark-kept` list by default) |
+
+## doctor — health checks
+
+`python -m research_hub doctor` (`doctor.py: run_doctor`) runs ~20 checks: config presence, vault root and `raw/`/`.research_hub/` existence, Zotero API key + reachability (HEAD probe cached 60 s to avoid 429s), frontmatter completeness, cluster drift/collision/name-drift against Zotero, orphan papers, empty clusters, test-pattern cluster names, PDF/crystal coverage, trashed Zotero collections, manifest orphans, defuddle CLI, NotebookLM auth paths, and EZproxy session state. `--strict` surfaces legacy WARNs (missing DOI on old imports, empty sections) that are otherwise collapsed into one INFO line; `--json` emits a machine-readable report.
+
+Two writes hide inside an otherwise read-only command:
+
+- `run_doctor` always calls `_encrypt_plaintext_secrets` first — if it finds a plaintext Zotero API key in `config.json` it encrypts it in place and reports a WARN.
+- `--autofix` (`vault_autofix.py: run_autofix`) backfills mechanical frontmatter before checks run: missing `topic_cluster` from the folder→cluster map, missing `ingested_at` from file mtime, and a DOI derived from an arXiv id in the filename. It edits note frontmatter with no dry-run mode of its own.
+
+`clusters audit [--cluster S] [--json]` runs the drift/collision/test-pattern subset of doctor scoped to clusters.
+
+## tidy — one-shot maintenance
+
+`python -m research_hub tidy` (`tidy.py: run_tidy`) chains four non-fatal steps: (1) `doctor --autofix`, (2) dedup index rebuild from Obsidian notes only, (3) `bases emit --force` per cluster (Obsidian `.base` refresh), (4) `cleanup --bundles --debug-logs --artifacts` **in preview mode**. Only `--apply-cleanup` makes step 4 delete; `--cluster <slug>` restricts the bases step.
+
+## cleanup — garbage collection of accumulated files
+
+`python -m research_hub cleanup` (`cleanup.py: collect_garbage`) targets three kinds of regenerable state under `.research_hub/`: bundle dirs (keeps the newest 2 per cluster, `--keep-bundles`), `nlm-debug-*.jsonl` older than 30 days (`--debug-older-than`), and `ask-*.md`/`brief-*.txt` artifacts beyond the newest 10 per cluster (`--keep-artifacts`). You must opt into scopes (`--all` = all three); the default run is a dry-run listing sizes, and only `--apply` deletes. `--wikilinks` is a separate, note-touching pass (`vault/cleanup.py: dedup_hub_pages`) that de-duplicates repeated wikilinks in hub pages. Nothing in `cleanup` touches paper notes or Zotero.
+
+## Dedup index maintenance
+
+The dedup index (`.research_hub/dedup_index.json`, `dedup.py`) maps DOIs and normalized titles to known Obsidian paths and Zotero keys so ingest can skip duplicates. Maintenance surface (`cli_maintenance.py`):
+
+- `index` — full rebuild from Obsidian + Zotero (same as `dedup rebuild`).
+- `dedup rebuild [--obsidian-only]` — rebuild; `--obsidian-only` skips Zotero (useful offline), and a failed Zotero pass degrades with a warning rather than corrupting the index.
+- `dedup invalidate --doi X | --path Y` — drop stale entries after manual note moves/deletes.
+- `dedup compact [--apply] [--json]` — drop stale Obsidian paths and Zotero 404 hits; preview by default.
+
+These commands rewrite only the index file — a bad run costs you duplicate detection, not notes.
+
+## Soft delete and `vault gc`
+
+The soft-delete convention (`clusters.py: cascade_delete_cluster`): `clusters delete <slug> --apply` moves `raw/<slug>/` → `raw/_deleted_<slug>/`, removes `hub/<slug>/`, the cluster's bundles and artifacts, its manifest lines and dedup entries, and the `clusters.yaml` entry. Zotero items are *unbound* from the collection by default; `--delete-zotero-collection` removes the empty container, and `--purge-zotero-items` (flagged DESTRUCTIVE in its own help text) trashes parent items — recoverable in Zotero until trash is emptied, strictly scoped to the cluster's own collection key, with a guard that refuses to operate on the configured parent collection. Dry-run performs zero Zotero I/O.
+
+`vault gc` (`vault/gc.py: run_gc`) is the second stage — the only thing that ever hard-deletes soft-deleted residue. Four passes, all dry-run unless `--apply`:
+
+1. Purge `raw/_deleted_<slug>/` dirs older than `--older-than-days` (default 30, by dir mtime).
+2. Remove `hub/<slug>/` dirs whose slug has no registry entry at all (merged-but-present clusters are never orphans; note-linked hubs are protected).
+3. Remove `hub/_moc/*.md` pages no live cluster derives *and* no live note links; `PARENT_MOCS` are always protected, and MOC names are derived from both slugs and cluster queries so query-derived sub-MOCs survive.
+4. Strip bare parent-MOC lines from paper-note `## Hub` blocks — the only pass that edits note content; skip it with `--no-strip-parents`.
+
+To triage residue interactively before purging, see [docs/clean_vault.md](../../docs/clean_vault.md); cluster-structure invariants are in [docs/cluster-integrity.md](../../docs/cluster-integrity.md).
+
+## clusters rebind — orphan papers back into clusters
+
+`clusters rebind` (`cluster_rebind.py`) is a three-step, report-mediated flow with an extra safety layer beyond dry-run:
+
+1. `clusters rebind --emit > report.md` — walks `raw/` folders not bound to any cluster and proposes moves via a heuristic chain (explicit `cluster:`/`topic_cluster:` frontmatter → Zotero collection key → collection-name/keyword match → tag Jaccard vs seed keywords → folder-name match), each tagged with a confidence level. Folders with ≥5 unmatched papers yield opt-in *new cluster* proposals.
+2. Review/edit the JSON blocks in the report — the report is the contract; `--apply` replays exactly what it says.
+3. `clusters rebind --apply report.md` — still a dry-run; add `--no-dry-run` to actually move files (`robust_move`, skipping missing sources and existing destinations), and `--auto-create-new` to also create the proposed clusters. Every decision is appended to a timestamped `.research_hub/rebind-*.log`.
+
+## Overview and note-convention rebuilds
+
+- `vault rebuild-overviews [--cluster S] [--force]` re-runs `populate_overview` + `ensure_moc` for every cluster (`vault/hub_overview.py`); a debounce marker prevents redundant rebuilds unless `--force`. This regenerates managed hub pages — distinct from the LLM-driven overview auto-fill (`cluster_overview.py`) that runs inside `auto` and refuses to overwrite hand-curated TL;DRs (it only replaces recognized scaffold/fallback text).
+- The migration family — `vault tag-migrate`, `vault hub-backlink-migrate`, `vault summarize-status-migrate`, `vault cleanup-frontmatter`, `vault polish-markdown`, `vault prune-footers` — all share the same UX: scan notes, print per-action counts, and require `--apply` to write. All of them skip `_deleted_*` residue.
+- `vault graph-colors --refresh` and `synthesize [--graph-colors]` regenerate managed graph color groups and cluster synthesis pages.
+
+## Agent guidance
+
+- Preview first, always: run the bare command, read the report, then re-run with `--apply` (or `--no-dry-run` for rebind). The tools themselves print the exact re-run hint.
+- Treat `raw/_deleted_*` as quarantine, not garbage — restoring is a `git mv`/file move until `vault gc --apply` crosses the age threshold.
+- The regenerable/irreplaceable line: dedup index, bundles, artifacts, debug logs, dashboards, hub overviews, `.base` files, and graph colors can all be rebuilt; paper notes under `raw/` and Zotero items cannot. Commands that touch the latter (`--purge-zotero-items`, `zotero gc`, `vault gc` pass 1) are the ones to double-check.

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,0 +1,58 @@
+# research-hub quickstart
+
+research-hub (PyPI: `research-hub-pipeline`, v1.1.1, Python >= 3.10) is a CLI pipeline that turns Zotero, Obsidian, and NotebookLM into one AI-operable literature workspace. A single run discovers papers across academic search backends (arXiv, Semantic Scholar, CrossRef, OpenAlex, PubMed, and more under `src/research_hub/search/`), saves them into Zotero with hub-namespace tags, generates Obsidian paper notes, rebuilds the hub index, and optionally bundles and uploads the cluster to NotebookLM for brief generation. The same functionality is exposed four ways: the `research-hub` CLI (`research_hub.cli:main`), an MCP server (`research-hub-mcp` -> `research_hub.mcp_server:main`), a REST API (`src/research_hub/api/`), and a local dashboard (`src/research_hub/dashboard/`). Everything operates on a local-first vault the user owns; no OpenAI/Anthropic API key is required.
+
+## Start here
+
+- [CLI module map](./cli/modules.md) — which subcommands live in which `cli_*` module, and how `cli.py` dispatches to the split modules.
+- [Ingest pipeline architecture](./architecture/ingest-pipeline.md) — discovery → Zotero save → Obsidian note generation → hub index rebuild → NotebookLM upload, and the package boundaries (`connectors/`, `api/`, `dashboard/`) along the way.
+- [Vault maintenance](./operations/vault-maintenance.md) — vault layout plus doctor / cleanup / dedup / cluster-rebind flows, and which operations are destructive vs preview-only.
+- [Release and testing](./operations/release-and-testing.md) — how to run the test suite, the main test seams, and a pointer to [docs/RELEASING.md](../docs/RELEASING.md) for the release flow.
+
+## Repository layout
+
+- `src/research_hub/` — the package (hatchling build, `packages = ["src/research_hub"]` in `pyproject.toml`). Key areas:
+  - `cli.py` + `cli_*.py` — argparse entry point split into eleven modules (`cli_citations`, `cli_clusters`, `cli_common`, `cli_maintenance`, `cli_notebooklm`, `cli_paper`, `cli_pipeline`, `cli_search`, `cli_summarize`, `cli_vault`, `cli_zotero`); `cli.py` builds the parser tree (~170 subparser registrations) and imports the handlers.
+  - `pipeline.py`, `auto.py`, `discover.py`, `dedup.py`, `verify.py` — the ingest pipeline core: candidate discovery, dedup against Zotero/Obsidian, DOI/arXiv verification, Zotero item creation, manifest logging.
+  - `search/` — pluggable search backends plus fallback/ranking logic (`fallback.py`, `_rank.py`, `query_expansion.py`).
+  - `zotero/` — Zotero client boundary (`client.py`, `fetch.py`): pyzotero-based reads/writes, duplicate checks, child notes.
+  - `notebooklm/` — NotebookLM implementation: `auth.py`, `bundle.py`, `upload.py`, `ask.py`, `download.py` over `notebooklm-py`.
+  - `connectors/` — the external-service seam: a `Connector` Protocol (bundle → upload → generate → download), `_notebooklm_adapter.py` providing the Protocol view over the existing NotebookLM code, and `null.py` for no-op runs.
+  - `vault/` — Obsidian vault operations: `builder.py` (hub index), `cleanup.py`, `gc.py`, `repair.py`, `sync.py`, graph coloring, migrations.
+  - `api/` — REST API helpers (`v1.py`, `jobs.py`) served alongside the dashboard.
+  - `dashboard/` — HTML dashboard: `http_server.py`, `render.py`, `sections.py`, `data.py`, `executor.py` (action buttons), plus `template.html` / `script.js` / `style.css`.
+  - `mcp_server.py`, `skill/` + `skills_data/`, `samples/` — MCP server, packaged AI-host skills, and sample-vault data (shipped in the wheel).
+- `tests/` — pytest suite (`pytest.ini`: `testpaths = tests`, default run excludes `slow`/`stress` markers, 30 s per-test timeout).
+- `docs/` — user-facing docs: [cli-reference.md](../docs/cli-reference.md), [setup.md](../docs/setup.md), [notebooklm.md](../docs/notebooklm.md), [mcp-tools.md](../docs/mcp-tools.md), [RELEASING.md](../docs/RELEASING.md), per-version audits.
+- `skills/` — AI-host skill packages (gap-to-topic, literature-triage-matrix, paper-summarize, research-hub, zotero-library-curator, ...) mirrored into `src/research_hub/skills_data/` for wheel distribution.
+- `config.json.example`, `constraints.txt`, `scripts/` — config template, reproducible-install constraints, dev scripts.
+
+## Canonical invocation and configuration
+
+The canonical CLI form is:
+
+```bash
+python -m research_hub <command> ...
+```
+
+`src/research_hub/__main__.py` delegates to `research_hub.cli:main`, so this is identical to the installed `research-hub` console script. Prefixing `PYTHONPATH=src` is the dev/pytest variant for running from a source checkout without installing.
+
+Configuration is a JSON file modeled on `config.json.example` at the repo root: vault paths under `knowledge_base` (root/raw/hub/projects/logs), `clusters_file`, and a `zotero` block (library id/type, default collection, collection map). `src/research_hub/config.py` resolves it in order: the `RESEARCH_HUB_CONFIG` environment variable, then the platformdirs user config dir (`research-hub/config.json`), then legacy skill locations, then a repo-root `config.json`. Never commit a real `config.json`; secrets (Zotero API key, NotebookLM auth) stay out of the repo entirely.
+
+Quick smoke test without any accounts:
+
+```bash
+pip install research-hub-pipeline
+python -m research_hub dashboard --sample
+```
+
+## Backlog
+
+Not yet covered by this wiki (read the source or `docs/` directly for now):
+
+- Dashboard internals — section renderers, the action-button `executor.py`, drift/briefing views.
+- The REST `api/` surface (`v1.py`, `jobs.py`) and how `serve` wires API + dashboard together.
+- MCP server tool inventory (`mcp_server.py`; see [docs/mcp-tools.md](../docs/mcp-tools.md)).
+- `skills/` packaging and the skill installer (`skill_installer.py`, `skills_data/`).
+- Search-backend details beyond the pipeline's use of them (ranking, query expansion, region/field presets in `search/fallback.py`).
+- Import/EZproxy paths for local PDFs and paywalled sources (`importer.py`, `ezproxy.py`).


### PR DESCRIPTION
First OpenWiki generation for the weekly pilot (run 29590747941, provider nvidia/nemotron-3-super-120b-a12b).

Creates openwiki/ pages plus AGENTS.md and CLAUDE.md with the OPENWIKI:START/END managed blocks. Governance files are under the review gate — reviewed manually before merge.

Note: opened manually because the first run predated the Actions-can-create-PRs repo setting (now enabled — future scheduled runs open PRs themselves). CI does not run on openwiki PRs; content is reviewed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)